### PR TITLE
Set up npm publishing (@kdrrr/overcast) + tag-driven CI release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "overcast",
   "owner": {
-    "name": "overcast",
+    "name": "kdr",
     "url": "https://github.com/kdr/overcast"
   },
   "metadata": {
@@ -15,7 +15,7 @@
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
       "version": "0.0.0",
       "author": {
-        "name": "overcast"
+        "name": "kdr"
       },
       "homepage": "https://github.com/kdr/overcast",
       "repository": "https://github.com/kdr/overcast",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,20 +6,28 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.1"
+    "version": "0.0.0"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.1",
-      "author": { "name": "overcast" },
+      "version": "0.0.0",
+      "author": {
+        "name": "overcast"
+      },
       "homepage": "https://github.com/kdr/overcast",
       "repository": "https://github.com/kdr/overcast",
       "license": "SEE LICENSE AT https://github.com/kdr/overcast",
       "category": "media",
-      "tags": ["video", "osint", "cloudglue", "video-analysis", "investigation"],
+      "tags": [
+        "video",
+        "osint",
+        "cloudglue",
+        "video-analysis",
+        "investigation"
+      ],
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,10 +2,19 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.1",
-  "author": { "name": "overcast" },
+  "version": "0.0.0",
+  "author": {
+    "name": "overcast"
+  },
   "homepage": "https://github.com/kdr/overcast",
   "repository": "https://github.com/kdr/overcast",
   "license": "SEE LICENSE AT https://github.com/kdr/overcast",
-  "keywords": ["video", "osint", "video-analysis", "cloudglue", "investigation", "senses"]
+  "keywords": [
+    "video",
+    "osint",
+    "video-analysis",
+    "cloudglue",
+    "investigation",
+    "senses"
+  ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
   "version": "0.0.0",
   "author": {
-    "name": "overcast"
+    "name": "kdr"
   },
   "homepage": "https://github.com/kdr/overcast",
   "repository": "https://github.com/kdr/overcast",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       # extraction); the unit suite exercises them.
       - run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - run: npm ci
+      # version is single-sourced from package.json; fail if any surface drifted.
+      - run: node scripts/sync-version.mjs --check
       - run: npm run typecheck
       - run: npm run build
       # Phase 0 acceptance check: the built entrypoint must actually run.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+          # npm-recommended trusted-publishing config. With no NODE_AUTH_TOKEN set,
+          # npm >= 11.5.1 ignores setup-node's .npmrc token placeholder and auths via
+          # OIDC. Ref: https://docs.npmjs.com/trusted-publishers/
           registry-url: "https://registry.npmjs.org"
       # Trusted publishing needs npm >= 11.5.1; pin to latest to be safe.
       - name: Ensure npm supports trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+# Release: publish @kdrrr/overcast to npm via OIDC trusted publishing (no token),
+# then cross-compile the standalone bun binary for macOS/Linux and attach the
+# tarballs to the GitHub Release. Triggered by pushing a v* tag.
+#
+# One-time setup (maintainer): see RELEASING.md — configure the npmjs Trusted
+# Publisher for @kdrrr/overcast (GitHub Actions → repo kdr/overcast → workflow
+# release.yml) AFTER the first manual publish.
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (must equal package.json version)"
+        required: true
+
+permissions:
+  contents: write # create the GitHub Release + upload binary assets
+  id-token: write # OIDC for npm trusted publishing (provenance is automatic)
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      # Trusted publishing needs npm >= 11.5.1; pin to latest to be safe.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+      - name: Verify tag matches package.json version
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::tag/input version ($VERSION) != package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        id: ver
+      # ffmpeg/ffprobe are a system prerequisite exercised by the unit suite.
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - run: npm ci
+      - run: node scripts/sync-version.mjs --check
+      - run: npm run typecheck
+      - run: npm run build
+      - run: node dist/bin/overcast.js --version --json
+      - run: npm test
+      - name: Publish to npm (OIDC trusted publishing — no token)
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          if npm view "@kdrrr/overcast@$VERSION" version >/dev/null 2>&1; then
+            echo "@kdrrr/overcast@$VERSION is already published — skipping publish."
+          else
+            npm publish
+          fi
+
+  binaries:
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      # Deps are needed: bun-sidecar.mjs copies pi's builtin themes out of
+      # node_modules, and `bun --compile` resolves imports from node_modules.
+      - run: npm ci
+      - name: Cross-compile binaries + sidecar trees
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          for target in bun-darwin-arm64 bun-darwin-x64 bun-linux-x64 bun-linux-arm64; do
+            osarch="${target#bun-}"
+            out="dist/release/$osarch"
+            mkdir -p "$out"
+            echo "→ building $osarch"
+            bun build --compile --target="$target" bin/overcast.ts --outfile "$out/overcast"
+            node scripts/bun-sidecar.mjs "$out"
+            tar -C "$out" -czf "dist/release/overcast-$osarch.tar.gz" .
+          done
+          ls -lh dist/release/*.tar.gz
+      - name: Attach binaries to the GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/release/*.tar.gz
+          fail_on_unmatched_files: true
+      - name: Upload binaries as workflow artifacts (manual run)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: overcast-binaries
+          path: dist/release/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -31,14 +31,48 @@ the CLI from any harness. The brain LLM is BYO; the default perception backend i
 `overcast doctor` verifies all of these.
 
 ```bash
-npm i -g @overcast/cli          # the CLI + pi package
+npm i -g @kdrrr/overcast          # the CLI + pi package  →  `overcast`
 overcast doctor                 # preflight: pi, ffmpeg/ffprobe, Cloudglue, providers
 ```
 
-Or grab the standalone binary (no Node required) from releases, or build it:
+Update to the newest release, or run a verb one-off without installing:
 
 ```bash
-npm run build:bun               # → dist/bin/overcast  (still uses the system ffmpeg)
+npm i -g @kdrrr/overcast@latest   # update an existing global install
+npx @kdrrr/overcast doctor        # run any verb without a global install
+```
+
+Or grab the **standalone binary** (no Node required) for your platform from the
+[latest release](https://github.com/kdr/overcast/releases/latest) —
+`overcast-<os>-<arch>.tar.gz` (ships its `theme/` + `examples/` sidecars) — or
+build it locally:
+
+```bash
+tar -xzf overcast-darwin-arm64.tar.gz   # → ./overcast (+ sidecars); put it on PATH
+npm run build:bun                       # …or build locally → dist/bin/overcast
+```
+
+---
+
+## Use it from your agent
+
+overcast drives any harness three ways — pick whichever fits:
+
+**Agent skills** (Claude Code, Cursor, Codex, …) — install the bundled skills with
+the CLI, or pull them straight from this repo with the harness-agnostic
+[`skills`](https://github.com/vercel-labs/skills) installer:
+
+```bash
+overcast skills install               # menu: pick a harness, writes the SKILL.md files
+overcast skills install --global      # → ~/.claude/skills/overcast
+npx skills add kdr/overcast           # vercel-labs/skills; pulls skills from this repo
+```
+
+**Claude Code plugin** (slash commands + skills as one package):
+
+```text
+/plugin marketplace add kdr/overcast
+/plugin install overcast@overcast
 ```
 
 ---
@@ -188,7 +222,7 @@ pickable brain in `/model` when its key is set — never forced.
 
 Three surfaces from one source of truth (`src/registry/verbs.ts`):
 
-- **pi package** (`@overcast/cli`) — `tsup` bundles `dist/{bin,index,extension}.js`; pi + ffmpeg/ffprobe stay external (pinned / runtime-resolved). A `postinstall` brands the pinned pi host as "overcast" without moving `~/.pi`.
+- **pi package** (`@kdrrr/overcast`) — `tsup` bundles `dist/{bin,index,extension}.js`; pi + ffmpeg/ffprobe stay external (pinned / runtime-resolved). A `postinstall` brands the pinned pi host as "overcast" without moving `~/.pi`.
 - **standalone binary** — `bun build --compile` → a single executable (+ a sidecar `package.json` for branding).
 - **agent skills + Claude Code plugin** — `skills generate` renders `skills/overcast/{SKILL.md, reference/verbs.md}` from the registry; `skills install` copies them into a harness.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,128 @@
+# Releasing overcast
+
+overcast ships from one source tree to three places on every release:
+
+- **npm** — `@kdrrr/overcast` (the CLI + pi package), published from CI via **npm
+  OIDC trusted publishing** (no tokens, provenance attached automatically).
+- **GitHub Releases** — the standalone **bun binary**, cross-compiled for macOS
+  (arm64/x64) and Linux (x64/arm64) and attached as
+  `overcast-<os>-<arch>.tar.gz`.
+- **Claude plugin + agent skills** — the `.claude-plugin/` manifests and
+  `skills/` are read straight from the repo (GitHub), so they go live when the
+  release commit lands on the default branch.
+
+The whole thing is driven by **pushing a `v*` tag**. The workflow is
+[`.github/workflows/release.yml`](.github/workflows/release.yml).
+
+---
+
+## Versioning is single-sourced
+
+`package.json` `version` is the source of truth. `scripts/sync-version.mjs`
+propagates it into the files that hard-code a version:
+
+- `src/version.ts` (`OVERCAST_VERSION`)
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json` (`metadata.version` + every `plugins[].version`)
+
+(`scripts/bun-sidecar.mjs` reads `package.json` directly, so it needs no sync.)
+
+This is wired to the npm `version` lifecycle, so **`npm version <patch|minor|x.y.z>`
+bumps everything at once** and stages it into the version commit. CI also runs
+`node scripts/sync-version.mjs --check` and fails on drift, so the surfaces can
+never silently diverge.
+
+---
+
+## One-time setup: npm Trusted Publisher (maintainer, in a browser)
+
+Trusted publishing can only be configured **after the package's first version
+exists on npm** (chicken-and-egg). So the very first publish is manual (below);
+after that, configure OIDC once and CI takes over.
+
+On <https://www.npmjs.com/package/@kdrrr/overcast/access> → **Trusted Publisher** →
+**GitHub Actions**, enter:
+
+| Field             | Value              |
+| ----------------- | ------------------ |
+| Organization/user | `kdr`              |
+| Repository        | `overcast`         |
+| Workflow filename | `release.yml`      |
+| Environment       | _(leave blank)_    |
+
+No `NPM_TOKEN` secret is needed in GitHub — OIDC mints a short-lived credential
+per run. The repo is public, so npm provenance is generated automatically.
+
+---
+
+## First publish (bootstrap 0.0.0) — manual, one time only
+
+OIDC isn't available yet, so publish the initial version from a machine logged in
+to npm (`npm whoami` → an account with write access to the `@kdr` scope):
+
+```bash
+npm run build                 # produce dist/ (prepublishOnly also runs this)
+npm pack --dry-run            # sanity-check the tarball contents + the @kdrrr/overcast name
+npm publish                   # publishConfig sets access:public (provenance is CI-only)
+```
+
+Then configure the Trusted Publisher (section above), and cut the matching tag so
+the binaries + GitHub Release get built by CI:
+
+```bash
+git tag v0.0.0 && git push origin v0.0.0
+```
+
+The `release.yml` run for `v0.0.0` will **skip the npm publish** (0.0.0 already
+exists — the publish step is idempotent) and just build + attach the binaries.
+
+---
+
+## Cutting a release (0.0.1 and onward)
+
+From a clean default branch:
+
+```bash
+npm version patch             # or: minor / major / 0.3.0  → bumps + syncs + commits + tags vX.Y.Z
+git push --follow-tags        # push the commit and the tag together
+```
+
+Pushing the `vX.Y.Z` tag triggers `release.yml`, which:
+
+1. Verifies the tag matches `package.json` and that versions are in sync.
+2. Installs ffmpeg, runs `typecheck` → `build` → `--version` smoke → unit tests.
+3. **Publishes to npm** over OIDC (skipped if that version is already on npm).
+4. Cross-compiles the bun binary for the four targets and attaches the tarballs
+   to the GitHub Release for the tag.
+
+You can also run it manually from the Actions tab (**workflow_dispatch**) with the
+version as input; in that mode the binaries are uploaded as workflow artifacts
+instead of release assets.
+
+---
+
+## Verify a release
+
+```bash
+npm view @kdrrr/overcast version                 # the published version
+npm i -g @kdrrr/overcast@latest && overcast --version --json
+```
+
+- Binaries: download a tarball from the release, `tar -xzf …`, run `./overcast --version`.
+- Provenance: the npm package page shows a "Provenance" panel linking back to the run.
+- Plugin/skills: `/plugin marketplace add kdr/overcast` then `/plugin install overcast@overcast`,
+  or `npx skills add kdr/overcast`.
+
+---
+
+## Troubleshooting
+
+- **`npm publish` 403 / "you must be logged in"** on a normal release → the
+  Trusted Publisher isn't configured (or the workflow filename/repo doesn't match
+  what's registered on npm). Re-check the table above.
+- **`E404` configuring the Trusted Publisher** → the package doesn't exist yet; do
+  the manual bootstrap publish first.
+- **Version-drift CI failure** → run `npm run sync-version` and commit.
+- **2FA on the bootstrap publish** → `npm publish --otp=<code>`.
+- **Re-running a release tag** → safe; the publish step no-ops when the version is
+  already on npm, and binary assets are overwritten.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,7 +58,8 @@ per run. The repo is public, so npm provenance is generated automatically.
 ## First publish (bootstrap 0.0.0) — manual, one time only
 
 OIDC isn't available yet, so publish the initial version from a machine logged in
-to npm (`npm whoami` → an account with write access to the `@kdr` scope):
+to npm (`npm whoami` → an account that owns the `@kdrrr` scope, i.e. a member of
+the `kdrrr` org with publish rights):
 
 ```bash
 npm run build                 # produce dist/ (prepublishOnly also runs this)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@overcast/cli",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@overcast/cli",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "@overcast/cli",
-  "version": "0.0.1",
+  "name": "@kdrrr/overcast",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@overcast/cli",
-      "version": "0.0.1",
+      "name": "@kdrrr/overcast",
+      "version": "0.0.0",
       "hasInstallScript": true,
+      "license": "SEE LICENSE AT https://github.com/kdr/overcast",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.1",
         "@earendil-works/pi-ai": "0.80.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,31 @@
 {
-  "name": "@overcast/cli",
-  "version": "0.0.1",
+  "name": "@kdrrr/overcast",
+  "version": "0.0.0",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
+  "license": "SEE LICENSE AT https://github.com/kdr/overcast",
+  "author": "kdr",
+  "homepage": "https://github.com/kdr/overcast#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kdr/overcast.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kdr/overcast/issues"
+  },
+  "keywords": [
+    "video",
+    "osint",
+    "video-analysis",
+    "cloudglue",
+    "investigation",
+    "senses",
+    "pi",
+    "agent",
+    "cli"
+  ],
   "type": "module",
   "bin": {
-    "overcast": "./dist/bin/overcast.js"
+    "overcast": "dist/bin/overcast.js"
   },
   "exports": {
     ".": "./dist/index.js",
@@ -13,13 +34,17 @@
   "files": [
     "dist",
     "themes",
-    "assets",
+    "assets/banner.txt",
+    "assets/branding/logo.png",
     "skills",
     "prompts",
     "examples"
   ],
   "engines": {
     "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsup",
@@ -29,6 +54,9 @@
     "test:e2e:live": "bash test/e2e/live/run.sh",
     "build:bun": "bun build --compile bin/overcast.ts --outfile dist/bin/overcast && node scripts/bun-sidecar.mjs",
     "dev": "tsx bin/overcast.ts",
+    "sync-version": "node scripts/sync-version.mjs",
+    "version": "node scripts/sync-version.mjs && git add -A src/version.ts .claude-plugin/plugin.json .claude-plugin/marketplace.json",
+    "prepublishOnly": "npm run build",
     "postinstall": "node scripts/brand-pi.mjs",
     "brand": "node scripts/brand-pi.mjs"
   },

--- a/scripts/bun-sidecar.mjs
+++ b/scripts/bun-sidecar.mjs
@@ -7,17 +7,23 @@
 //      reads them on every TUI/headless launch and HARD-CRASHES if missing
 //      (ENOENT … /theme/dark.json), which broke the binary's agent mode.
 // We copy both here so the compiled binary is self-sufficient.
-import { writeFileSync, mkdirSync, copyFileSync, existsSync, cpSync } from "node:fs";
+import { writeFileSync, mkdirSync, copyFileSync, existsSync, cpSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const OUT = "dist/bin";
+// Output dir defaults to dist/bin (the `build:bun` path); the release workflow
+// passes a per-platform dir (e.g. dist/release/darwin-arm64) so each compiled
+// binary gets its own sidecar tree to tar up.
+const OUT = process.argv[2] || "dist/bin";
 mkdirSync(OUT, { recursive: true });
+
+// version tracks package.json (the source of truth; see scripts/sync-version.mjs)
+const VERSION = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8")).version;
 
 // 1) branding sidecar
 writeFileSync(
   join(OUT, "package.json"),
   JSON.stringify(
-    { name: "overcast", version: "0.0.1", type: "module", private: true, piConfig: { name: "overcast" } },
+    { name: "overcast", version: VERSION, type: "module", private: true, piConfig: { name: "overcast" } },
     null,
     2,
   ) + "\n",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -61,7 +61,7 @@ const mkt = JSON.parse(readFileSync(join(ROOT, mktPath), "utf8"));
 let mktDirty = false;
 if (mkt.metadata?.version !== VERSION) {
   drift.push(`${mktPath} (.metadata.version=${mkt.metadata?.version})`);
-  mkt.metadata.version = VERSION;
+  (mkt.metadata ??= {}).version = VERSION;
   mktDirty = true;
 }
 for (const p of mkt.plugins ?? []) {

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Single-source the overcast version. package.json is the source of truth; this
+// propagates its version into the places that hard-code it:
+//   - src/version.ts                  (OVERCAST_VERSION)
+//   - .claude-plugin/plugin.json      (.version)
+//   - .claude-plugin/marketplace.json (.metadata.version + every .plugins[].version)
+// scripts/bun-sidecar.mjs reads package.json directly, so it needs no syncing.
+//
+// Usage:
+//   node scripts/sync-version.mjs           # rewrite the files to match package.json
+//   node scripts/sync-version.mjs --check   # exit 1 if anything is out of sync (CI guard)
+//
+// Wired to the `version` npm lifecycle, so `npm version <x>` keeps every surface
+// in lockstep and stages the result into the version commit.
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CHECK = process.argv.includes("--check");
+
+const VERSION = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")).version;
+if (!VERSION) {
+  console.error("[sync-version] package.json has no version");
+  process.exit(1);
+}
+
+const drift = [];
+
+// 1) src/version.ts — the OVERCAST_VERSION literal.
+const versionTsPath = join(ROOT, "src", "version.ts");
+const versionTs = readFileSync(versionTsPath, "utf8");
+const VERSION_RE = /(export const OVERCAST_VERSION = ")([^"]*)(";)/;
+const m = versionTs.match(VERSION_RE);
+if (!m) {
+  console.error("[sync-version] could not find OVERCAST_VERSION in src/version.ts");
+  process.exit(1);
+}
+if (m[2] !== VERSION) {
+  drift.push(`src/version.ts (OVERCAST_VERSION=${m[2]})`);
+  if (!CHECK) writeFileSync(versionTsPath, versionTs.replace(VERSION_RE, `$1${VERSION}$3`));
+}
+
+// 2) + 3) the .claude-plugin manifests — JSON we rewrite while preserving 2-space
+// indent + trailing newline (matches the committed files).
+const writeJson = (relPath, obj) =>
+  writeFileSync(join(ROOT, relPath), JSON.stringify(obj, null, 2) + "\n");
+
+// plugin.json — top-level .version
+const pluginPath = ".claude-plugin/plugin.json";
+const plugin = JSON.parse(readFileSync(join(ROOT, pluginPath), "utf8"));
+if (plugin.version !== VERSION) {
+  drift.push(`${pluginPath} (.version=${plugin.version})`);
+  plugin.version = VERSION;
+  if (!CHECK) writeJson(pluginPath, plugin);
+}
+
+// marketplace.json — .metadata.version + every .plugins[].version
+const mktPath = ".claude-plugin/marketplace.json";
+const mkt = JSON.parse(readFileSync(join(ROOT, mktPath), "utf8"));
+let mktDirty = false;
+if (mkt.metadata?.version !== VERSION) {
+  drift.push(`${mktPath} (.metadata.version=${mkt.metadata?.version})`);
+  mkt.metadata.version = VERSION;
+  mktDirty = true;
+}
+for (const p of mkt.plugins ?? []) {
+  if (p.version !== VERSION) {
+    drift.push(`${mktPath} (.plugins[name=${p.name}].version=${p.version})`);
+    p.version = VERSION;
+    mktDirty = true;
+  }
+}
+if (mktDirty && !CHECK) writeJson(mktPath, mkt);
+
+if (CHECK) {
+  if (drift.length) {
+    console.error(`[sync-version] OUT OF SYNC with package.json (${VERSION}):`);
+    for (const d of drift) console.error(`  - ${d}`);
+    console.error("Run `npm run sync-version` (or `npm version <x>`) to fix.");
+    process.exit(1);
+  }
+  console.error(`[sync-version] all surfaces match package.json (${VERSION})`);
+} else if (drift.length) {
+  console.error(`[sync-version] synced ${drift.length} file(s) to ${VERSION}:`);
+  for (const d of drift) console.error(`  - ${d}`);
+} else {
+  console.error(`[sync-version] already at ${VERSION}; nothing to do`);
+}

--- a/skills/overcast-init/SKILL.md
+++ b/skills/overcast-init/SKILL.md
@@ -10,8 +10,8 @@ description: >-
 
 One-time setup for overcast.
 
-1. **Install the CLI** — `pi install npm:@overcast/cli` (inside pi) or
-   `npm i -g @overcast/cli` for the standalone binary.
+1. **Install the CLI** — `pi install npm:@kdrrr/overcast` (inside pi) or
+   `npm i -g @kdrrr/overcast` for the standalone binary.
 2. **Verify** — `overcast doctor --json` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI).
 3. **Cloudglue key** — the default `watch`/`listen` providers reach Cloudglue

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -128,8 +128,8 @@ description: >-
 
 One-time setup for overcast.
 
-1. **Install the CLI** — \`pi install npm:@overcast/cli\` (inside pi) or
-   \`npm i -g @overcast/cli\` for the standalone binary.
+1. **Install the CLI** — \`pi install npm:@kdrrr/overcast\` (inside pi) or
+   \`npm i -g @kdrrr/overcast\` for the standalone binary.
 2. **Verify** — \`overcast doctor --json\` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI).
 3. **Cloudglue key** — the default \`watch\`/\`listen\` providers reach Cloudglue

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.1.
 
-export const OVERCAST_VERSION = "0.0.1";
+export const OVERCAST_VERSION = "0.0.0";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.1";


### PR DESCRIPTION
## What

Sets up npm publishing and a tag-driven release pipeline for overcast.

- **Publish as `@kdrrr/overcast`** (scoped, public; renamed from `@overcast/cli`). The bootstrap version **`0.0.0` is already published manually** to seed the package — npm OIDC trusted publishing can't be configured until a version exists.
- **`publishConfig.access: public`** + `repository`/`homepage`/`bugs` metadata; `prepublishOnly` rebuilds `dist/` before pack. Tarball trimmed **7.9 MB → 1.5 MB** (dropped the unused 6.3 MB branding PNG; kept `banner.txt` (runtime) + `logo.png` (npm page)). Fixed the `bin` path (`./`-prefix warning).
- **Single-sourced version** — `scripts/sync-version.mjs` propagates `package.json` version into `src/version.ts` + both `.claude-plugin/*.json`; wired to the `npm version` lifecycle and gated in CI (`--check`).
- **`.github/workflows/release.yml`** — on `v*` tags: OIDC trusted publishing to npm (no token; **idempotent** — skips if the version is already live) + cross-compiled **bun binaries** (macOS arm64/x64, Linux x64/arm64) attached to the GitHub Release.
- **`bun-sidecar.mjs`** — takes an output dir + reads the version from `package.json`.
- **README** — `@kdrrr/overcast` install/update + the three agent-install routes (CLI `overcast skills install`, `npx skills add kdr/overcast`, `/plugin marketplace`).
- **`RELEASING.md`** — release runbook incl. the one-time npmjs Trusted-Publisher setup.

## Follow-ups after merge

- [ ] Configure the npmjs Trusted Publisher for `@kdrrr/overcast` (GitHub Actions → repo `kdr/overcast` → workflow `release.yml`, env blank) — see `RELEASING.md`.
- [ ] Tag `v0.0.0` to build + attach the binaries (the publish step no-ops since `0.0.0` is already live).

## Verification

- `npm run typecheck`, `npm run build`, `npm test` (146 pass) — all green.
- Tarball verified: `@kdrrr/overcast@0.0.0`, 31 files, no secrets/fixtures.
- Binary pipeline validated locally: cross-compiled → sidecar'd → tar'd → ran (`--version` → `0.0.0`).
- `0.0.0` already published to npm (manual bootstrap).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation and npm publishing (OIDC); runtime behavior is mostly docs/metadata/version strings, but a misconfigured release workflow could publish wrong artifacts or fail releases.
> 
> **Overview**
> Renames the npm package from `@overcast/cli` to **`@kdrrr/overcast`** (public scope, bootstrap **`0.0.0`**) and aligns install/docs/skills/plugin manifests with the new name and **`kdr`** authorship.
> 
> Adds **`scripts/sync-version.mjs`** so `package.json` is the sole version source for `src/version.ts` and `.claude-plugin` JSON; **`npm version`** runs the sync, and **CI** fails on drift via `--check`. **`package.json`** gains publish metadata, **`prepublishOnly`** build, a slimmer **`files`** list (drops a large unused PNG), and a corrected **`bin`** path.
> 
> Introduces **`.github/workflows/release.yml`**: on **`v*`** tags (or manual dispatch), verify tag vs version, run tests, **publish to npm via OIDC** (idempotent skip if already published), then **cross-compile bun binaries** for four platforms and attach **`overcast-<os>-<arch>.tar.gz`** to the GitHub Release. **`bun-sidecar.mjs`** accepts a per-platform output dir and reads version from **`package.json`**.
> 
> **`RELEASING.md`** documents bootstrap publish, Trusted Publisher setup, and release flow. **README** expands install/update/`npx` usage, release binaries, and agent install paths (skills + Claude plugin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595ed043f2b2165a4fefc65741342c812345aa87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->