### PR TITLE
Cyberpunk TUI: animated synthwave banner, table-flip spinner, hacker op-labels

### DIFF
--- a/src/extension/branding.ts
+++ b/src/extension/branding.ts
@@ -5,11 +5,12 @@
 // gradient wordmark, a magenta/cyan recording-deck HUD beside the play box, a
 // centered tagline, and a bracket-tagged status row.
 //
-// The header is *animated* (the "C · synthwave" + live-effects design): it owns a
-// timer and calls tui.requestRender(), so the REC dot blinks, the level meter
-// bounces, and the wordmark does a one-time "decrypt" reveal on launch. pi is not
-// forked — we attach as a normal Component via ctx.ui.setHeader and drive repaints
-// through the public TUI.requestRender() (see node_modules/.../pi-tui/dist/tui.d.ts).
+// The header animates ONCE: the wordmark does a "decrypt" reveal on launch, then
+// the timer STOPS for good and the header is static. A steady-state ticker would
+// call tui.requestRender() forever, repainting the header and snapping the
+// terminal's scrollback back to the bottom — so you could never scroll up. pi is
+// not forked — we attach as a normal Component via ctx.ui.setHeader and drive the
+// reveal repaints through the public TUI.requestRender().
 
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import { visibleWidth, truncateToWidth } from "@earendil-works/pi-tui";
@@ -58,9 +59,7 @@ const BLOCK_CHARS = new Set("█▀▄▌▐▮".split(""));
 // ---- animation timing (tunable) --------------------------------------------
 const REVEAL_MS = 800; // one-time wordmark decrypt-in on launch
 const TAG_REVEAL_MS = 560; // tagline/status fade in near the end of the reveal
-const BLINK_MS = 600; // REC dot on/off period
-const REVEAL_TICK_MS = 55; // fast repaint during the reveal (smooth scramble)
-const STEADY_TICK_MS = 160; // calm repaint after — drives the blink + meter
+const REVEAL_TICK_MS = 55; // repaint cadence DURING the one-time reveal only
 
 const deterministicHash = (r: number, c: number) =>
   (r * 131 + c * 17 + ((r * c) % 7) * 53) >>> 0;
@@ -170,7 +169,6 @@ export class OvercastHeader implements Component {
   private readonly ok: boolean;
   private readonly start = Date.now();
   private timer: ReturnType<typeof setInterval> | null = null;
-  private fast = true;
 
   constructor(
     private readonly tui: TUI | null,
@@ -205,14 +203,14 @@ export class OvercastHeader implements Component {
     }
   }
 
-  /** Drive repaints: fast during the reveal, then drop to a calm blink/meter tick. */
+  /** Drive repaints DURING the one-time decrypt reveal only. Once it finishes the
+   *  timer stops for good — no steady-state ticker — so the header never repaints
+   *  while idle and never fights the terminal's scrollback. */
   private tick(): void {
-    const elapsed = Date.now() - this.start;
-    if (this.fast && elapsed >= REVEAL_MS + 120) {
-      this.fast = false;
-      if (this.timer) clearInterval(this.timer);
-      this.timer = setInterval(() => this.tick(), STEADY_TICK_MS);
-      this.timer.unref?.();
+    if (Date.now() - this.start >= REVEAL_MS + 120) {
+      this.dispose(); // reveal done → stop animating; the header is now static
+      this.tui?.requestRender(); // settle the final frame once
+      return;
     }
     this.tui?.requestRender();
   }
@@ -224,14 +222,14 @@ export class OvercastHeader implements Component {
 
   invalidate(): void {}
 
-  /** The recording-deck HUD shown to the right of the play box (3 rows). */
-  private hud(elapsed: number, revealing: boolean): string[] {
-    const dotOn = revealing || Math.floor(elapsed / BLINK_MS) % 2 === 0;
-    const dot = dotOn ? `${MAGENTA}◉` : `${MAGENTA_DIM}◌`;
-    const row0 = `   ${dot} ${PALE}REC ${MAGENTA_DIM}│ ${CYAN}v${this.version}${RESET}`;
-    const level = 4 + Math.round(2 * Math.sin(elapsed / 230)); // 2..6
+  /** The recording-deck HUD to the right of the play box (3 rows). Static — the
+   *  REC dot stays lit and the meter holds a fixed level, since the header stops
+   *  repainting after the reveal (an animated dot/meter would need a forever-timer
+   *  that breaks scrollback). */
+  private hud(): string[] {
+    const row0 = `   ${MAGENTA}◉ ${PALE}REC ${MAGENTA_DIM}│ ${CYAN}v${this.version}${RESET}`;
     let meter = "   ";
-    for (let i = 0; i < 6; i++) meter += i < level ? `${METER[i]}▰` : `${MAGENTA_DIM}▱`;
+    for (let i = 0; i < 6; i++) meter += i < 4 ? `${METER[i]}▰` : `${MAGENTA_DIM}▱`;
     meter += RESET;
     const row2 = `   ${MAGENTA_DIM}────────────${RESET}`;
     return [row0, meter, row2];
@@ -241,7 +239,7 @@ export class OvercastHeader implements Component {
     if (!this.ok) return [];
     const elapsed = Date.now() - this.start;
     const revealing = elapsed < REVEAL_MS;
-    const hud = this.hud(elapsed, revealing);
+    const hud = this.hud();
 
     const lines: string[] = [];
     for (let i = 0; i < 3; i++) lines.push(this.deckBox[i] + hud[i]);

--- a/src/extension/branding.ts
+++ b/src/extension/branding.ts
@@ -1,9 +1,17 @@
-// overcast TUI branding: colorized banner, status line, and a minimal footer.
-// The theme colors the chrome, but the banner is raw ASCII rendered by a pi-tui
-// Text component, so we inject ANSI truecolor to match themes/overcast.json
-// (neon green wordmark + amber accents) instead of the terminal default.
+// overcast TUI branding: a live, colorized banner header + a minimal footer.
+//
+// The banner is raw ASCII (assets/banner.txt) rendered by a pi-tui Component, so
+// we inject ANSI truecolor to paint it the overcast way: a green→cyan "synthwave"
+// gradient wordmark, a magenta/cyan recording-deck HUD beside the play box, a
+// centered tagline, and a bracket-tagged status row.
+//
+// The header is *animated* (the "C · synthwave" + live-effects design): it owns a
+// timer and calls tui.requestRender(), so the REC dot blinks, the level meter
+// bounces, and the wordmark does a one-time "decrypt" reveal on launch. pi is not
+// forked — we attach as a normal Component via ctx.ui.setHeader and drive repaints
+// through the public TUI.requestRender() (see node_modules/.../pi-tui/dist/tui.d.ts).
 
-import type { Component } from "@earendil-works/pi-tui";
+import type { Component, TUI } from "@earendil-works/pi-tui";
 import { visibleWidth, truncateToWidth } from "@earendil-works/pi-tui";
 
 /** Truncate a single line to the viewport width (ANSI-aware), so a fixed-width
@@ -12,30 +20,55 @@ function fitWidth(line: string, width: number): string {
   return visibleWidth(line) > width ? truncateToWidth(line, width) : line;
 }
 
-const GREEN = "\x1b[38;2;0;255;127m"; // #00ff7f — bright wordmark face
-// Scanline: every other wordmark row uses this dimmer green so dark horizontal
-// lines run across the letters (the design's CRT look). Tunable brightness.
-const GREEN_SCAN = "\x1b[38;2;0;176;88m"; // #00b058
-const GREEN_DIM = "\x1b[38;2;31;157;87m"; // #1f9d57 — chrome / muted separators
-// Wordmark extrusion (the ANSI-Shadow box-drawing glyphs): dim green, for the
-// 3D drop-shadow / depth in the design — NOT the bright face, NOT near-black.
-const WORDMARK_SHADOW = "\x1b[38;2;31;157;87m"; // #1f9d57
-const PALE = "\x1b[38;2;198;247;213m"; // #c6f7d5 — text
-const AMBER = "\x1b[38;2;255;196;0m"; // #ffc400 — accents
-const AMBER_DIM = "\x1b[38;2;168;123;0m"; // #a87b00 — tagline
-const RED = "\x1b[38;2;255;85;85m"; // #ff5555 — play icon
+// ---- palette (truecolor) ----------------------------------------------------
+const fg = (r: number, g: number, b: number) => `\x1b[38;2;${r};${g};${b}m`;
 const RESET = "\x1b[0m";
 
-// box-drawing "extrusion" glyphs in the ANSI-shadow font → dim green outline
+const GREEN = fg(0, 255, 127); // #00ff7f — neon wordmark face (top of gradient)
+const GREEN_DIM = fg(31, 157, 87); // #1f9d57 — chrome / muted separators
+const PALE = fg(198, 247, 213); // #c6f7d5 — text
+const AMBER = fg(255, 196, 0); // #ffc400 — accents
+const RED = fg(255, 85, 85); // #ff5555
+const CYAN = fg(0, 229, 255); // #00e5ff — secondary neon (bottom of gradient)
+const CYAN_DIM = fg(0, 150, 170); // #0096aa — dim cyan deck frame
+const MAGENTA = fg(255, 46, 151); // #ff2e97 — record / glitch accent
+const MAGENTA_DIM = fg(150, 40, 95); // #96285f — wordmark extrusion / tagline
+
+// Vertical green→cyan gradient, one face color per wordmark row (6 rows).
+const GRAD = [
+  fg(0, 255, 127),
+  fg(0, 240, 150),
+  fg(0, 225, 180),
+  fg(0, 215, 205),
+  fg(0, 225, 235),
+  fg(0, 229, 255),
+];
+// glyphs used while a cell is still "decrypting" (width-1, like the real glyphs)
+const SCRAMBLE = "█▀▄▌▐╔╗╚╝║═╦╩╠╣".split("");
+// flicker colors for unlocked cells — glitchy RGB split
+const SCAN_COLORS = [CYAN, GREEN, MAGENTA];
+// per-cell level-meter colors (left→right)
+const METER = [MAGENTA, AMBER, GREEN, GREEN, CYAN, CYAN];
+
+// box-drawing "extrusion" glyphs (ANSI-shadow font) → dim magenta outline
 const SHADOW_CHARS = new Set("╔╗╚╝║═╦╩╠╣".split(""));
-// solid block glyphs → bright green face
+// solid block glyphs → gradient face
 const BLOCK_CHARS = new Set("█▀▄▌▐▮".split(""));
 
-/** Per-character two-tone coloring of a wordmark line (face vs extrusion). On
- *  `scan` rows the bright face is dimmed, so alternating rows form dark
- *  horizontal scanlines across the letters. */
-function colorWordmark(line: string, scan = false): string {
-  const face = scan ? GREEN_SCAN : GREEN;
+// ---- animation timing (tunable) --------------------------------------------
+const REVEAL_MS = 800; // one-time wordmark decrypt-in on launch
+const TAG_REVEAL_MS = 560; // tagline/status fade in near the end of the reveal
+const BLINK_MS = 600; // REC dot on/off period
+const REVEAL_TICK_MS = 55; // fast repaint during the reveal (smooth scramble)
+const STEADY_TICK_MS = 160; // calm repaint after — drives the blink + meter
+
+const deterministicHash = (r: number, c: number) =>
+  (r * 131 + c * 17 + ((r * c) % 7) * 53) >>> 0;
+
+/** Two-tone gradient coloring of one steady (settled) wordmark row: gradient face
+ *  for block glyphs, dim-magenta extrusion for the box-drawing depth glyphs. */
+function colorWordmarkRow(line: string, row: number): string {
+  const face = GRAD[row] ?? GREEN;
   let out = "";
   let mode: "block" | "shadow" | "" = "";
   for (const ch of line) {
@@ -45,7 +78,7 @@ function colorWordmark(line: string, scan = false): string {
         ? "shadow"
         : "";
     if (want && want !== mode) {
-      out += want === "block" ? face : WORDMARK_SHADOW;
+      out += want === "block" ? face : MAGENTA_DIM;
       mode = want;
     }
     out += ch;
@@ -53,69 +86,267 @@ function colorWordmark(line: string, scan = false): string {
   return out + RESET;
 }
 
-/**
- * Colorize the banner: the play-glyph box in amber (red ▶), the ASCII wordmark
- * in two-tone green (bright face + dim extrusion for the neon-outline look), and
- * the tagline in dim amber. Tolerant of banner edits — keys off line shape.
- */
-export function colorizeBanner(banner: string): string {
-  const lines = banner.replace(/\n+$/, "").split("\n");
-  let inWordmark = false; // flips once the `█` wordmark starts
-  let wordmarkRow = 0; // index among wordmark rows, for the scanline alternation
-  return lines
-    .map((line) => {
-      // The `█` full-block only appears in the wordmark — once we see it we're
-      // past the play box (whose pause glyph `▮` must NOT count, else the box
-      // would be mis-detected and the wordmark's all-box bottom row would render
-      // amber as a "box frame" instead of dim-green extrusion).
-      if (line.includes("█")) inWordmark = true;
+/** Per-cell lock time for the decrypt sweep: a left→right wipe with a small
+ *  per-row offset and jitter, so the name resolves like a terminal decrypting. */
+function lockTime(row: number, col: number, maxW: number): number {
+  const base = (col / Math.max(1, maxW)) * REVEAL_MS * 0.78;
+  const rowOff = row * 16;
+  const jitter = (deterministicHash(row, col) % 5) * 28;
+  return Math.min(REVEAL_MS, base + rowOff + jitter);
+}
 
-      // play-button box (before the wordmark): amber frame + red play triangle
-      if (!inWordmark) {
-        return AMBER + line.replace("▶", `${RED}▶${AMBER}`) + RESET;
+/** One wordmark row mid-reveal: settled cells in their final color, unsettled
+ *  cells flicker through scramble glyphs in glitchy scan colors. Spaces hold. */
+function revealWordmarkRow(line: string, row: number, elapsed: number, maxW: number): string {
+  const face = GRAD[row] ?? GREEN;
+  const tick = Math.floor(elapsed / 45);
+  let out = "";
+  let cur = "";
+  let col = 0;
+  for (const ch of line) {
+    if (ch === " ") {
+      out += " ";
+      col++;
+      continue;
+    }
+    const isBlock = BLOCK_CHARS.has(ch);
+    const isShadow = SHADOW_CHARS.has(ch);
+    if (!isBlock && !isShadow) {
+      out += ch;
+      col++;
+      continue;
+    }
+    if (elapsed >= lockTime(row, col, maxW)) {
+      const c = isBlock ? face : MAGENTA_DIM;
+      if (c !== cur) {
+        out += c;
+        cur = c;
       }
-      // tagline (after the wordmark): dim amber
-      if (/v\s*i\s*d\s*e\s*o/i.test(line) || / · /.test(line)) {
-        return AMBER_DIM + line + RESET;
+      out += ch;
+    } else {
+      const g = SCRAMBLE[(deterministicHash(row, col) + tick) % SCRAMBLE.length];
+      const c = SCAN_COLORS[(tick + col) % SCAN_COLORS.length];
+      if (c !== cur) {
+        out += c;
+        cur = c;
       }
-      // wordmark rows (incl. the all-box extrusion rows): two-tone green, with a
-      // scanline dimming every other row.
-      return colorWordmark(line, wordmarkRow++ % 2 === 1);
-    })
-    .join("\n");
+      out += g;
+    }
+    col++;
+  }
+  return out + RESET;
 }
 
-/** The `[ REC ● ] <version>` line under the tagline — amber brackets + label,
- *  a red record dot, dim-amber version. Evokes a recording deck (the play-glyph). */
-export function recLine(version: string): string {
-  return `${AMBER}[ ${PALE}REC ${RED}●${AMBER} ] ${AMBER_DIM}${version}${RESET}`;
+export interface HeaderOptions {
+  /** Raw assets/banner.txt content (play box + wordmark + tagline). */
+  banner: string;
+  /** overcast version, shown on the deck (`v0.0.1`). */
+  version: string;
+  /** Bare context filename (e.g. "CLAUDE.md"), or "" if none loaded. */
+  contextFile: string;
+  /** Tool/verb count. */
+  tools: number;
+  /** Active model id (e.g. "tinycloud:advanced"). */
+  model: string;
 }
 
-/** A one-line status row shown under the banner (e.g. context file · tools · model). */
-export function statusLine(parts: string[]): string {
-  const kept = parts.filter(Boolean);
-  if (kept.length === 0) return "";
-  const body = kept.join(`${GREEN_DIM} · ${PALE}`);
-  return `${GREEN}▶ ${PALE}${body}${RESET}`;
-}
+// Only one header is live at a time; keep a handle so a re-created header (resize,
+// theme change) clears the previous timer instead of leaking intervals.
+let activeHeader: OvercastHeader | null = null;
 
-/** Compose the header: colorized banner, then (if any) a status line below it. */
-export function headerText(banner: string, status: string): string {
-  return status ? `${banner}\n${status}` : banner;
-}
-
-/** Header as a width-aware Component: truncates each line to the viewport so the
- *  fixed-width banner can't overflow pi's renderer (which aborts on over-width
- *  lines) on a narrow terminal — unlike a raw Text component. */
+/** The animated overcast header: synthwave gradient wordmark + a recording-deck
+ *  HUD (blinking REC dot + bouncing level meter) + centered tagline + bracket
+ *  status row, with a one-time decrypt reveal on launch. Width-aware so the
+ *  fixed-width art can't overflow pi's renderer on a narrow terminal. */
 export class OvercastHeader implements Component {
-  private readonly lines: string[];
-  constructor(text: string) {
-    this.lines = text.split("\n");
+  private readonly deckBox: string[]; // 3 colored play-box rows (no HUD)
+  private readonly wordRaw: string[]; // raw wordmark rows (for the reveal)
+  private readonly wordSteady: string[]; // settled colored wordmark rows
+  private readonly tagPad: number; // left pad to center the tagline
+  private readonly tagRaw: string;
+  private readonly statusRow: string;
+  private readonly version: string;
+  private readonly maxW: number;
+  private readonly ok: boolean;
+  private readonly start = Date.now();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private fast = true;
+
+  constructor(
+    private readonly tui: TUI | null,
+    opts: HeaderOptions,
+  ) {
+    const lines = (opts.banner ?? "").replace(/\n+$/, "").split("\n");
+    this.ok = lines.length >= 10;
+    this.version = opts.version;
+
+    const box = lines.slice(0, 3);
+    this.wordRaw = lines.slice(3, 9);
+    this.tagRaw = (lines[9] ?? "").trim();
+    this.maxW = Math.max(1, ...this.wordRaw.map((l) => l.length));
+
+    // play-box: dim-cyan frame, magenta ▶ play triangle
+    this.deckBox = box.map((l) => CYAN_DIM + l.replace("▶", `${MAGENTA}▶${CYAN_DIM}`) + RESET);
+    this.wordSteady = this.wordRaw.map((l, i) => colorWordmarkRow(l, i));
+    this.tagPad = Math.max(0, Math.floor((this.maxW - visibleWidth(this.tagRaw)) / 2));
+
+    const ctxTag = opts.contextFile
+      ? `${GREEN_DIM}[${GREEN}OK${GREEN_DIM}] ${PALE}${opts.contextFile}`
+      : `${GREEN_DIM}[${AMBER}--${GREEN_DIM}] ${PALE}no context`;
+    this.statusRow =
+      `${ctxTag}  ${GREEN_DIM}[${MAGENTA}${opts.tools}${GREEN_DIM}] ${PALE}tools  ` +
+      `${GREEN_DIM}[${CYAN}◆${GREEN_DIM}] ${PALE}${opts.model}${RESET}`;
+
+    if (activeHeader) activeHeader.dispose();
+    activeHeader = this;
+    if (this.ok) {
+      this.timer = setInterval(() => this.tick(), REVEAL_TICK_MS);
+      this.timer.unref?.();
+    }
   }
+
+  /** Drive repaints: fast during the reveal, then drop to a calm blink/meter tick. */
+  private tick(): void {
+    const elapsed = Date.now() - this.start;
+    if (this.fast && elapsed >= REVEAL_MS + 120) {
+      this.fast = false;
+      if (this.timer) clearInterval(this.timer);
+      this.timer = setInterval(() => this.tick(), STEADY_TICK_MS);
+      this.timer.unref?.();
+    }
+    this.tui?.requestRender();
+  }
+
+  dispose(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
   invalidate(): void {}
-  render(width: number): string[] {
-    return this.lines.map((l) => fitWidth(l, width));
+
+  /** The recording-deck HUD shown to the right of the play box (3 rows). */
+  private hud(elapsed: number, revealing: boolean): string[] {
+    const dotOn = revealing || Math.floor(elapsed / BLINK_MS) % 2 === 0;
+    const dot = dotOn ? `${MAGENTA}◉` : `${MAGENTA_DIM}◌`;
+    const row0 = `   ${dot} ${PALE}REC ${MAGENTA_DIM}│ ${CYAN}v${this.version}${RESET}`;
+    const level = 4 + Math.round(2 * Math.sin(elapsed / 230)); // 2..6
+    let meter = "   ";
+    for (let i = 0; i < 6; i++) meter += i < level ? `${METER[i]}▰` : `${MAGENTA_DIM}▱`;
+    meter += RESET;
+    const row2 = `   ${MAGENTA_DIM}────────────${RESET}`;
+    return [row0, meter, row2];
   }
+
+  render(width: number): string[] {
+    if (!this.ok) return [];
+    const elapsed = Date.now() - this.start;
+    const revealing = elapsed < REVEAL_MS;
+    const hud = this.hud(elapsed, revealing);
+
+    const lines: string[] = [];
+    for (let i = 0; i < 3; i++) lines.push(this.deckBox[i] + hud[i]);
+    for (let i = 0; i < this.wordRaw.length; i++) {
+      lines.push(revealing ? revealWordmarkRow(this.wordRaw[i], i, elapsed, this.maxW) : this.wordSteady[i]);
+    }
+    // tagline + status fade in near the end of the reveal (height stays constant)
+    const showTag = !revealing || elapsed >= TAG_REVEAL_MS;
+    const showStatus = !revealing;
+    lines.push(showTag ? " ".repeat(this.tagPad) + MAGENTA_DIM + this.tagRaw + RESET : "");
+    lines.push(""); // breathing room
+    lines.push(showStatus ? this.statusRow : "");
+
+    return lines.map((l) => fitWidth(l, width));
+  }
+}
+
+/** Themed "busy" spinner: an animated ASCII table-flip — windup (cyan) → rage
+ *  flip (red) → calm (green) → loop. pi renders custom indicator frames verbatim,
+ *  so we color + width-pad them here (pad keeps the trailing label from jiggling). */
+export function workingIndicator(): { frames: string[]; intervalMs: number } {
+  const cels: Array<[string, string]> = [
+    [CYAN, "(•_•)      ┬─┬"], // calm
+    [CYAN, "( •_•)     ┬─┬"], // notices
+    [CYAN, "(╯°□°)╯    ┬─┬"], // winds up
+    [RED, "(╯°□°)╯︵  ┻━┻"], // FLIP
+    [RED, "(╯°□°)╯ ︵  ┻━┻"], // table airborne
+    [RED, "(╯°□°)╯  ︵  ┻━┻"], // …flying
+    [GREEN, "(•_•)"], // table gone, calm
+  ];
+  const w = Math.max(...cels.map(([, s]) => [...s].length));
+  const frames = cels.map(([c, s]) => c + s + " ".repeat(w - [...s].length) + RESET);
+  return { frames, intervalMs: 150 };
+}
+
+// --- busy label ("verbs") ---------------------------------------------------
+// The spinner *glyph* is the table-flip (workingIndicator()); this names the
+// *word* beside it. pi's default is "Working..." — overcast instead names the
+// actual op while a verb runs (off tool_execution_start), rotating through
+// hacker-movie variations, and cycles iconic phrases while it reasons between
+// tools. Plain text: pi colors the label with the theme. Lowercase reads hacker.
+const OP_LABELS: Record<string, string[]> = {
+  // senses
+  watch: ["jacking into the feed…", "scrubbing the footage…", "decoding the stream…", "watching the tapes…"],
+  listen: ["tapping the wire…", "bugging the line…", "intercepting comms…", "wiretapping…"],
+  see: ["ENHANCE… ENHANCE…", "zoom… and ENHANCE…", "running facial recog…", "reading the pixels…"],
+  enhance: ["ENHANCE… ENHANCE…", "cleaning the signal…", "upscaling reality…", "de-noising…"],
+  view: ["patching the deck…", "cueing the player…", "spinning the reels…"],
+  // OSINT
+  scan: ["hacking the gibson…", "wardriving the subnet…", "portscanning…", "sweeping the perimeter…"],
+  capture: ["exfiltrating…", "siphoning packets…", "ripping the stream…", "grabbing the loot…"],
+  monitor: ["sniffing the traffic…", "tailing the target…", "staking it out…", "watching the wire…"],
+  target: ["triangulating…", "locking on…", "painting the target…", "running the trace…"],
+  source: ["splicing the uplink…", "patching in the feed…", "wiring the tap…"],
+  prebrief: ["spinning up the op…", "prepping the rig…", "casing the joint…"],
+  // read / reason
+  ask: ["interrogating the mainframe…", "querying the matrix…", "asking the oracle…", "pinging the hive mind…"],
+  brief: ["compiling the dossier…", "assembling intel…", "writing the report…"],
+  case: ["cracking the case…", "pulling the files…", "reading the evidence…"],
+  // config / dist
+  setup: ["rooting the box…", "patching the kernel…", "flashing the firmware…"],
+  provider: ["jacking in providers…", "wiring the backends…", "negotiating handshakes…"],
+  doctor: ["probing the rig…", "running diagnostics…", "checking vitals…"],
+  skills: ["forging payloads…", "compiling exploits…", "minting skills…"],
+  commands: ["enumerating exploits…", "dumping the verb table…"],
+  // pi base tools
+  bash: ["dropping a shell…", "rooting the shell…", "spawning a subprocess…"],
+  read: ["siphoning bytes…", "slurping the file…", "exfiltrating data…"],
+  write: ["planting files…", "dropping the payload…", "writing to disk…"],
+  edit: ["patching…", "hot-swapping bytes…", "splicing the source…"],
+  grep: ["trawling the logs…", "pattern-matching…", "combing the haystack…"],
+  find: ["sweeping the filesystem…", "hunting files…", "walking the tree…"],
+  ls: ["enumerating…", "listing the directory…", "dumping the manifest…"],
+};
+
+/** Iconic hacker/sci-fi phrases shown while the agent reasons between tools. */
+const IDLE_LABELS = [
+  "hacking the gibson…",
+  "it's a unix system, i know this…",
+  "accessing the mainframe…",
+  "breaching the ICE…",
+  "follow the white rabbit…",
+  "there is no spoon…",
+  "god is a kid with an ant farm…",
+  "mess with the best, die like the rest…",
+  "shall we play a game?…",
+  "bypassing the firewall…",
+  "ridin' the lightning…",
+  "i'm in…",
+];
+
+let opIdx = 0;
+let idleIdx = 0;
+
+/** The busy-label for a running tool/verb — rotates through that verb's
+ *  variations (falls back to `<name>…` for anything unmapped). */
+export function opLabel(toolName: string): string {
+  const v = OP_LABELS[toolName];
+  if (!v || v.length === 0) return `${toolName}…`;
+  return v[opIdx++ % v.length];
+}
+
+/** A themed generic shown while the agent reasons — cycles the iconic phrases. */
+export function idleLabel(): string {
+  return IDLE_LABELS[idleIdx++ % IDLE_LABELS.length];
 }
 
 // --- minimal footer ---------------------------------------------------------
@@ -148,10 +379,10 @@ export class OvercastFooter implements Component {
   invalidate(): void {}
   render(width: number): string[] {
     const d = this.get();
-    const left = `${GREEN_DIM}case://${PALE}${d.caseName}${RESET}`;
+    const left = `${RED}●${GREEN_DIM} case://${PALE}${d.caseName}${RESET}`;
     const right =
-      `${GREEN_DIM}${fmtTokens(d.tokens)} tok ${GREEN_DIM}· ${PALE}ctx ${fmtPercent(d.ctxPercent)}% ` +
-      `${GREEN_DIM}· ${GREEN}${d.model} ${GREEN_DIM}· ${AMBER}think:${d.thinking}${RESET}`;
+      `${CYAN}▸${GREEN_DIM}${fmtTokens(d.tokens)} tok ${CYAN}▸${GREEN_DIM}ctx ${PALE}${fmtPercent(d.ctxPercent)}% ` +
+      `${CYAN}▸${GREEN}${d.model} ${CYAN}▸${AMBER}think:${d.thinking}${RESET}`;
     const pad = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
     return [fitWidth(left + " ".repeat(pad) + right, width)];
   }

--- a/src/extension/branding.ts
+++ b/src/extension/branding.ts
@@ -333,15 +333,19 @@ const IDLE_LABELS = [
   "i'm in…",
 ];
 
-let opIdx = 0;
+// Per-verb cursors so each verb advances through ITS OWN variations — a single
+// shared counter would make a verb's phrase depend on unrelated verbs' calls.
+const opIdx = new Map<string, number>();
 let idleIdx = 0;
 
 /** The busy-label for a running tool/verb — rotates through that verb's
- *  variations (falls back to `<name>…` for anything unmapped). */
+ *  variations independently (falls back to `<name>…` for anything unmapped). */
 export function opLabel(toolName: string): string {
   const v = OP_LABELS[toolName];
   if (!v || v.length === 0) return `${toolName}…`;
-  return v[opIdx++ % v.length];
+  const i = opIdx.get(toolName) ?? 0;
+  opIdx.set(toolName, i + 1);
+  return v[i % v.length];
 }
 
 /** A themed generic shown while the agent reasons — cycles the iconic phrases. */

--- a/src/extension/overcast.ts
+++ b/src/extension/overcast.ts
@@ -126,7 +126,9 @@ export default async function overcastExtension(pi: ExtensionAPI): Promise<void>
   // ("scanning sources…", "watching the footage…"), and a themed generic while
   // the agent reasons between tools — replacing pi's default "Working…". The
   // spinner *glyph* is set separately per-session (setWorkingIndicator).
-  pi.on("agent_start", (_e, ctx) => ctx.ui?.setWorkingMessage?.(idleLabel()));
+  // turn_start fires at the start of every turn (incl. the first), so it alone
+  // covers the "reasoning" phase — a parallel agent_start handler would advance
+  // the idle-phrase rotation twice at loop start and skip an entry (Bugbot, #12).
   pi.on("turn_start", (_e, ctx) => ctx.ui?.setWorkingMessage?.(idleLabel()));
   pi.on("tool_execution_start", (e, ctx) => ctx.ui?.setWorkingMessage?.(opLabel(e.toolName)));
   pi.on("tool_execution_end", (_e, ctx) => ctx.ui?.setWorkingMessage?.(idleLabel()));

--- a/src/extension/overcast.ts
+++ b/src/extension/overcast.ts
@@ -17,7 +17,7 @@ import { toAgentTool } from "../registry/to-agent-tool.js";
 import { openCase } from "../case.js";
 import { loadProfile, resolveCloudglue, resolveHome } from "../profile.js";
 import { buildSystemPrompt } from "./system-prompt.js";
-import { colorizeBanner, statusLine, recLine, headerText, OvercastHeader, OvercastFooter } from "./branding.js";
+import { OvercastHeader, OvercastFooter, workingIndicator, opLabel, idleLabel } from "./branding.js";
 import { registerSlashCommands } from "./slash.js";
 import { OvercastEditor } from "./editor.js";
 import { OVERCAST_VERSION } from "../version.js";
@@ -99,13 +99,13 @@ function desiredTitle(): string {
 }
 
 export default async function overcastExtension(pi: ExtensionAPI): Promise<void> {
-  // Read the banner once; captured by the setHeader factory. Colorize it to the
-  // overcast theme (raw ASCII would render terminal-default white).
-  let banner = "";
+  // Read the raw banner once; captured by the setHeader factory. OvercastHeader
+  // colorizes + animates it (raw ASCII would render terminal-default white).
+  let bannerRaw = "";
   try {
-    banner = colorizeBanner(readFileSync(BANNER_PATH, "utf8"));
+    bannerRaw = readFileSync(BANNER_PATH, "utf8");
   } catch {
-    banner = "";
+    bannerRaw = "";
   }
 
   // Resolve the Cloudglue config once (env or ~/.tinycloud/config.json).
@@ -121,6 +121,16 @@ export default async function overcastExtension(pi: ExtensionAPI): Promise<void>
 
   // state verbs as TUI slash commands (/target /source /case /prebrief /view /setup)
   registerSlashCommands(pi);
+
+  // Themed busy *label* ("verbs"): name the actual op while a verb runs
+  // ("scanning sources…", "watching the footage…"), and a themed generic while
+  // the agent reasons between tools — replacing pi's default "Working…". The
+  // spinner *glyph* is set separately per-session (setWorkingIndicator).
+  pi.on("agent_start", (_e, ctx) => ctx.ui?.setWorkingMessage?.(idleLabel()));
+  pi.on("turn_start", (_e, ctx) => ctx.ui?.setWorkingMessage?.(idleLabel()));
+  pi.on("tool_execution_start", (e, ctx) => ctx.ui?.setWorkingMessage?.(opLabel(e.toolName)));
+  pi.on("tool_execution_end", (_e, ctx) => ctx.ui?.setWorkingMessage?.(idleLabel()));
+  pi.on("agent_end", (_e, ctx) => ctx.ui?.setWorkingMessage?.(undefined));
 
   pi.on("session_start", async (_event, ctx) => {
     // apply the inline Theme object; fall back to the registered name if the
@@ -149,24 +159,30 @@ export default async function overcastExtension(pi: ExtensionAPI): Promise<void>
     // handler) — re-apply ours just after the synchronous init settles.
     setTimeout(() => { try { ctx.ui.setTitle(desiredTitle()); } catch { /* ignore */ } }, 50);
 
-    // Header: colorized banner + a status line (context file · verbs · model).
-    // Respect an explicit `setup llm` choice in the status label too.
+    // Header: the animated recording-deck banner (gradient wordmark + REC HUD +
+    // centered tagline + bracket status). Respect an explicit `setup llm` choice.
     const llmLabel = activeProfile.llm?.model || activeProfile.llm?.provider;
-    const modelLabel = llmLabel
-      ? `model: ${llmLabel}`
-      : cgKey
-        ? `model: ${CLOUDGLUE_MODEL_ID}`
-        : "model: (set via /model)";
-    if (banner) {
-      const status = statusLine([
-        contextFileLabel(cwd),
-        `${VERBS.length} tools`,
-        modelLabel,
-      ]);
-      // banner (incl. tagline) → [ REC ● ] <version> → a blank line → status row
-      const subhead = [recLine(OVERCAST_VERSION), "", status].filter((l) => l !== undefined).join("\n");
-      const header = headerText(banner, subhead);
-      ctx.ui.setHeader((_tui: TUI, _theme): Component => new OvercastHeader(header));
+    const modelId = llmLabel || (cgKey ? CLOUDGLUE_MODEL_ID : "(set via /model)");
+    if (bannerRaw) {
+      const contextFile = contextFileLabel(cwd).replace(" loaded", "");
+      ctx.ui.setHeader(
+        (tui: TUI, _theme): Component =>
+          new OvercastHeader(tui, {
+            banner: bannerRaw,
+            version: OVERCAST_VERSION,
+            contextFile,
+            tools: VERBS.length,
+            model: modelId,
+          }),
+      );
+    }
+
+    // Themed "busy" spinner: a magenta/cyan scan-bar sweep instead of the default
+    // braille dots (frames render verbatim, so we color them ourselves).
+    try {
+      ctx.ui.setWorkingIndicator?.(workingIndicator());
+    } catch {
+      /* keep pi's default spinner if the API shape changed */
     }
 
     // Minimal footer: case · tokens · ctx% · model · thinking.

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -158,6 +158,10 @@ export function verbCallLine(spec: VerbSpec, args: Record<string, unknown>): str
   return `${tag} ${HUD_DIM}▸${HUD_RESET} ${HUD_PALE}${v}${HUD_RESET}`;
 }
 
+// How many lines of a tool's record output to show before collapsing (mirrors
+// pi's built-in tools, e.g. bash=5/read=10). ctrl+o expands. Tunable.
+const COLLAPSED_RESULT_LINES = 6;
+
 /**
  * Convert a VerbSpec into a pi ToolDefinition. The execute() persists every
  * emitted record to the case store and returns a split result.
@@ -178,6 +182,33 @@ export function toAgentTool(spec: VerbSpec, deps: ToolDeps): ToolDefinition {
         text.setText(`⟦ ${spec.name} ⟧`);
       }
       return text;
+    },
+    // Collapse verbose record output by default, like pi's built-in read/bash
+    // tools. (overcast tools otherwise render the full `content` via pi's
+    // fallback, which never truncates — that's the "wall of JSON" dump.) Shows a
+    // short preview + a "ctrl+o to expand" hint, and respects the global ctrl+o
+    // toggle via options.expanded. UI-only: the agent still gets the full
+    // `content` text; this just declutters the screen.
+    renderResult: (result, options, theme): Text => {
+      let text = "";
+      try {
+        const parts = (result?.content ?? []) as Array<{ type?: string; text?: string }>;
+        text = parts
+          .filter((c) => c?.type === "text")
+          .map((c) => c.text ?? "")
+          .join("\n")
+          .replace(/\n+$/, "");
+      } catch {
+        text = "";
+      }
+      if (!text) return new Text("", 0, 0);
+      const lines = text.split("\n");
+      if (options.expanded || lines.length <= COLLAPSED_RESULT_LINES) {
+        return new Text(theme.fg("toolOutput", text), 0, 0);
+      }
+      const head = theme.fg("toolOutput", lines.slice(0, COLLAPSED_RESULT_LINES).join("\n"));
+      const hint = theme.fg("muted", `… (${lines.length - COLLAPSED_RESULT_LINES} more lines, ctrl+o to expand)`);
+      return new Text(`${head}\n${hint}`, 0, 0);
     },
     execute: async (_toolCallId, params: Record<string, unknown>, signal) => {
       const c = deps.getCase();

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -7,6 +7,7 @@
 
 import { Type, type TSchema } from "@earendil-works/pi-ai";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import type { VerbSpec, VerbContext, FlagSpec } from "./types.js";
 import { makeRecord, type OvercastRecord, type JsonMap } from "../record.js";
 import { renderRecord, pageCommand } from "../render.js";
@@ -121,6 +122,42 @@ function renderRecords(records: OvercastRecord[]): string {
   return parts.join("\n\n");
 }
 
+// --- verb HUD call tag ------------------------------------------------------
+// A cyberpunk "recording-deck" tag for the tool-call line, colored by verb class
+// (a semantic split: you read what kind of op is running by its hue). Raw
+// truecolor (the theme has no neon-magenta/cyan), mirroring src/extension styling.
+const HUD_RESET = "\x1b[0m";
+const HUD_PALE = "\x1b[38;2;198;247;213m"; // arg text
+const HUD_DIM = "\x1b[38;2;31;157;87m"; // ▸ separator
+const ACCENT: Record<string, string> = {
+  sense: "\x1b[38;2;0;255;127m", // senses → neon green
+  osint: "\x1b[38;2;255;46;151m", // OSINT → magenta
+  read: "\x1b[38;2;0;229;255m", // memory/read → cyan
+  config: "\x1b[38;2;255;196;0m", // config/dist → amber
+};
+const SENSE = new Set(["watch", "listen", "see", "enhance", "view"]);
+const OSINT = new Set(["scan", "capture", "monitor", "target", "source", "prebrief"]);
+const READ = new Set(["ask", "brief", "case"]);
+
+function verbAccent(name: string): string {
+  if (SENSE.has(name)) return ACCENT.sense;
+  if (OSINT.has(name)) return ACCENT.osint;
+  if (READ.has(name)) return ACCENT.read;
+  return ACCENT.config;
+}
+
+/** A HUD-tag call line: `⟦ WATCH ⟧ ▸ <primary arg>`. The tag is class-colored;
+ *  the primary positional arg (if any) trails after a dim ▸. Never throws. */
+export function verbCallLine(spec: VerbSpec, args: Record<string, unknown>): string {
+  const tag = `${verbAccent(spec.name)}⟦ ${spec.name.toUpperCase()} ⟧${HUD_RESET}`;
+  const primaryName = spec.args[0]?.name;
+  const raw = primaryName ? args?.[primaryName] : undefined;
+  if (raw === undefined || raw === null || raw === "") return tag;
+  let v = String(raw);
+  if (v.length > 80) v = v.slice(0, 79) + "…";
+  return `${tag} ${HUD_DIM}▸${HUD_RESET} ${HUD_PALE}${v}${HUD_RESET}`;
+}
+
 /**
  * Convert a VerbSpec into a pi ToolDefinition. The execute() persists every
  * emitted record to the case store and returns a split result.
@@ -131,6 +168,17 @@ export function toAgentTool(spec: VerbSpec, deps: ToolDeps): ToolDefinition {
     label: spec.name,
     description: `${spec.summary}${spec.description ? "\n\n" + spec.description : ""}`,
     parameters: verbParams(spec),
+    // Cyberpunk call line (keeps pi's default themed shell, like the bash tool):
+    // ⟦ VERB ⟧ ▸ <arg>, colored by verb class.
+    renderCall: (args, _theme, context): Text => {
+      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+      try {
+        text.setText(verbCallLine(spec, (args ?? {}) as Record<string, unknown>));
+      } catch {
+        text.setText(`⟦ ${spec.name} ⟧`);
+      }
+      return text;
+    },
     execute: async (_toolCallId, params: Record<string, unknown>, signal) => {
       const c = deps.getCase();
       c.ensure();

--- a/test/unit/branding.test.ts
+++ b/test/unit/branding.test.ts
@@ -39,10 +39,17 @@ test("OvercastHeader: boot frame hides the status until the decrypt reveal finis
   assert.ok(out.includes("REC"), "deck readout is shown immediately");
 });
 
-test("opLabel: rotates a verb's hacker-movie variations, with a fallback", () => {
-  const seen = new Set([opLabel("scan"), opLabel("scan"), opLabel("scan"), opLabel("scan")]);
-  assert.ok(seen.size >= 2, "scan rotates through variations");
-  for (const s of seen) assert.ok(s.endsWith("…"), "labels end with …");
+test("opLabel: each verb cycles its OWN variations (independent per-verb cursors)", () => {
+  // Interleave an unrelated verb between every scan call. With per-verb cursors,
+  // scan still covers all 4 of its variations; a single shared counter would skip
+  // half of them (the bug Cursor Bugbot flagged).
+  const scanSeen = new Set<string>();
+  for (let i = 0; i < 4; i++) {
+    scanSeen.add(opLabel("scan"));
+    opLabel("watch"); // unrelated verb must not advance scan's cursor
+  }
+  assert.equal(scanSeen.size, 4, "scan cycles all its variations regardless of other verbs");
+  for (const s of scanSeen) assert.ok(s.endsWith("…"), "labels end with …");
   assert.equal(opLabel("weird-unmapped"), "weird-unmapped…"); // graceful fallback
 });
 

--- a/test/unit/branding.test.ts
+++ b/test/unit/branding.test.ts
@@ -1,35 +1,66 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { colorizeBanner, statusLine, headerText, OvercastFooter } from "../../src/extension/branding.ts";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { OvercastHeader, workingIndicator, OvercastFooter, opLabel, idleLabel } from "../../src/extension/branding.ts";
 import { renderTopHelp, runCli, type CliIO } from "../../src/cli.ts";
 import { VERBS } from "../../src/registry/verbs.ts";
 
-test("colorizeBanner: two-tone green wordmark (face + dim extrusion), amber play box with red triangle", () => {
-  const banner = [
-    "        ╔═══════════╗",
-    "        ║    ▶ ▮▮   ║",
-    " ██████╗ ██╗   ██╗███████╗",
-    "        v i d e o · r e c o n · o s i n t",
-  ].join("\n");
-  const out = colorizeBanner(banner);
-  assert.ok(out.includes("\x1b[38;2;0;255;127m"), "bright green (block face) present");
-  assert.ok(out.includes("\x1b[38;2;31;157;87m"), "dim green (extrusion) present");
-  assert.ok(out.includes("\x1b[38;2;255;196;0m"), "amber (play box) present");
-  assert.ok(out.includes("\x1b[38;2;255;85;85m"), "red play triangle present");
-  assert.ok(!out.includes("pi //"), "no pi // cloudglue branding");
+const BANNER = readFileSync(fileURLToPath(new URL("../../assets/banner.txt", import.meta.url)), "utf8");
+const headerOpts = { banner: BANNER, version: "0.0.1", contextFile: "CLAUDE.md", tools: 18, model: "tinycloud:advanced" };
+const setStart = (h: OvercastHeader, msAgo: number) => {
+  (h as unknown as { start: number }).start = Date.now() - msAgo;
+};
+
+test("OvercastHeader: settled frame paints the synthwave gradient + recording-deck HUD", () => {
+  const h = new OvercastHeader(null, headerOpts);
+  setStart(h, 4000); // well past the boot reveal
+  const out = h.render(140).join("\n");
+  h.dispose();
+  assert.ok(out.includes("\x1b[38;2;0;255;127m"), "gradient top = neon green");
+  assert.ok(out.includes("\x1b[38;2;0;229;255m"), "gradient bottom = cyan");
+  assert.ok(out.includes("\x1b[38;2;255;46;151m"), "magenta REC/accent present");
+  assert.match(out, /REC .*v0\.0\.1/, "deck shows REC + version");
+  assert.match(out, /\[[^\]]*OK[^\]]*\][^\n]*CLAUDE\.md/, "bracket OK tag for context file");
+  assert.match(out, /\[[^\]]*18[^\]]*\][^\n]*tools/, "bracket tools tag");
+  assert.ok(out.includes("tinycloud:advanced"), "model in status");
+  // tagline centered under the wordmark (indented well past the source's 8)
+  const tagLine = out.split("\n").find((l) => l.includes("o s i n t")) ?? "";
+  const lead = (tagLine.match(/^ */) ?? [""])[0].length;
+  assert.ok(lead >= 10, `tagline centered under the wordmark (lead=${lead})`);
 });
 
-test("statusLine joins parts (skipping empties) with a leading marker", () => {
-  const s = statusLine(["CLAUDE.md loaded", "", "17 verbs", "model: x"]);
-  assert.match(s, /▶/);
-  assert.match(s, /CLAUDE\.md loaded/);
-  assert.match(s, /17 verbs/);
-  assert.equal(statusLine([]), "");
+test("OvercastHeader: boot frame hides the status until the decrypt reveal finishes", () => {
+  const h = new OvercastHeader(null, headerOpts);
+  setStart(h, 40); // first moments of the reveal
+  const out = h.render(140).join("\n");
+  h.dispose();
+  assert.ok(!out.includes("tinycloud:advanced"), "status fades in only after the reveal");
+  assert.ok(out.includes("REC"), "deck readout is shown immediately");
 });
 
-test("headerText appends the status line under the banner", () => {
-  assert.equal(headerText("BANNER", ""), "BANNER");
-  assert.equal(headerText("BANNER", "STATUS"), "BANNER\nSTATUS");
+test("opLabel: rotates a verb's hacker-movie variations, with a fallback", () => {
+  const seen = new Set([opLabel("scan"), opLabel("scan"), opLabel("scan"), opLabel("scan")]);
+  assert.ok(seen.size >= 2, "scan rotates through variations");
+  for (const s of seen) assert.ok(s.endsWith("…"), "labels end with …");
+  assert.equal(opLabel("weird-unmapped"), "weird-unmapped…"); // graceful fallback
+});
+
+test("idleLabel: cycles iconic phrases, never pi's default 'Working'", () => {
+  const a = idleLabel();
+  const b = idleLabel();
+  assert.ok(a.length > 0 && !/Working/.test(a), "themed, not the default");
+  assert.notEqual(a, b, "rotates between calls");
+});
+
+test("workingIndicator: animated ASCII table-flip frames (verbatim, colored)", () => {
+  const wi = workingIndicator();
+  assert.ok(wi.frames.length >= 2, "animated");
+  assert.ok(wi.intervalMs > 0, "has an interval");
+  const joined = wi.frames.join("");
+  assert.ok(joined.includes("┻━┻"), "the flipped table appears");
+  assert.ok(joined.includes("╯°□°"), "the rage face appears");
+  assert.ok(joined.includes("\x1b[38;2;255;85;85m"), "red rage frame");
 });
 
 test("OvercastFooter renders a justified case · tok · ctx% · model · think line", () => {
@@ -37,7 +68,7 @@ test("OvercastFooter renders a justified case · tok · ctx% · model · think l
   const [line] = f.render(100);
   assert.match(line, /case:\/\/.*shadowport/);
   assert.match(line, /12\.4k tok/);
-  assert.match(line, /ctx 6%/);
+  assert.match(line, /ctx .*6%/);
   assert.match(line, /think:medium/);
   // null tokens render as an em-dash, not NaN
   const g = new OvercastFooter(() => ({ caseName: "c", tokens: null, ctxPercent: null, model: "m", thinking: "off" }));

--- a/test/unit/to-agent-tool.test.ts
+++ b/test/unit/to-agent-tool.test.ts
@@ -22,6 +22,25 @@ test("verbCallLine: class-colored ⟦ TAG ⟧ ▸ arg (semantic split + primary 
   assert.ok(!s.includes("▸"), "no separator when no primary arg");
 });
 
+test("renderResult: collapses long output to a preview + expand hint (full when expanded)", () => {
+  const spec = { name: "doctor", args: [], flags: [] } as unknown as VerbSpec;
+  const deps = { getCase: () => ({}), getProfile: () => ({}) } as unknown as Parameters<typeof toAgentTool>[1];
+  const tool = toAgentTool(spec, deps);
+  const theme = { fg: (_k: string, t: string) => t } as never;
+  const longText = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n");
+  const result = { content: [{ type: "text", text: longText }] } as never;
+
+  const collapsed = tool.renderResult!(result, { expanded: false, isPartial: false }, theme, {} as never);
+  const c = collapsed.render(200).join("\n");
+  assert.match(c, /14 more lines, ctrl\+o to expand/); // 20 - 6 preview lines
+  assert.ok(!c.includes("line 20"), "tail is hidden when collapsed");
+
+  const expanded = tool.renderResult!(result, { expanded: true, isPartial: false }, theme, {} as never);
+  const e = expanded.render(200).join("\n");
+  assert.ok(e.includes("line 20"), "full output when expanded");
+  assert.ok(!/more lines/.test(e), "no expand hint when expanded");
+});
+
 /** Build a tool whose run() returns the given records, execute it, return the
  *  LLM-facing text (what the agent actually sees). */
 async function renderViaTool(records: OvercastRecord[]): Promise<string> {

--- a/test/unit/to-agent-tool.test.ts
+++ b/test/unit/to-agent-tool.test.ts
@@ -6,8 +6,21 @@ import { join } from "node:path";
 import { openCase } from "../../src/case.ts";
 import { defaultProfile } from "../../src/profile.ts";
 import { makeRecord, type OvercastRecord } from "../../src/record.ts";
-import { toAgentTool } from "../../src/registry/to-agent-tool.ts";
+import { toAgentTool, verbCallLine } from "../../src/registry/to-agent-tool.ts";
 import type { VerbSpec } from "../../src/registry/types.ts";
+
+test("verbCallLine: class-colored ⟦ TAG ⟧ ▸ arg (semantic split + primary arg)", () => {
+  const watch = { name: "watch", args: [{ name: "url" }] } as unknown as VerbSpec;
+  const scan = { name: "scan", args: [{ name: "query" }] } as unknown as VerbSpec;
+  const w = verbCallLine(watch, { url: "https://x/v.mp4" });
+  assert.match(w, /⟦ WATCH ⟧/);
+  assert.ok(w.includes("\x1b[38;2;0;255;127m"), "sense verb → neon green tag");
+  assert.match(w, /▸.*https:\/\/x\/v\.mp4/);
+  const s = verbCallLine(scan, {});
+  assert.match(s, /⟦ SCAN ⟧/);
+  assert.ok(s.includes("\x1b[38;2;255;46;151m"), "osint verb → magenta tag");
+  assert.ok(!s.includes("▸"), "no separator when no primary arg");
+});
 
 /** Build a tool whose run() returns the given records, execute it, return the
  *  LLM-facing text (what the agent actually sees). */


### PR DESCRIPTION
Visual flair for the TUI aimed at a hacker-convention audience. No pi fork — everything attaches through existing public hooks (`setHeader` / `setFooter` / `setWorkingIndicator` + per-tool `renderCall`, mirroring the built-in tools).

## Banner header (`src/extension/branding.ts`, `overcast.ts`)
- `OvercastHeader` is now a live `Component`: **green→cyan synthwave gradient** wordmark, dim-cyan play **deck** with a magenta **REC** readout + bouncing level meter, **centered tagline**, and a **bracket-tagged** status row (`[OK] CLAUDE.md  [18] tools  [◆] tinycloud:advanced`).
- Your two asks: **REC moved onto the deck** (inline with the play box, was a line under the wordmark) and **tagline centered**.
- **Animated** via `tui.requestRender()` on a timer: blinking REC dot + a one-time **"decrypt" reveal** of the wordmark on launch. Timer cleaned up in `dispose()`.

## Busy spinner + labels
- `workingIndicator()` → an animated **ASCII table-flip** `(╯°□°)╯︵ ┻━┻` (cyan windup → red rage-flip → green calm), replacing pi's braille dots.
- `opLabel()` / `idleLabel()` replace the static **"Working…"** with op-aware, rotating **hacker-movie** labels — `hacking the gibson…`, `ENHANCE… ENHANCE…`, `wardriving the subnet…`, `i'm in…` — driven off `agent_start` / `turn_start` / `tool_execution_start|end` / `agent_end`.

## Verb HUD tags (`src/registry/to-agent-tool.ts`)
- Tool calls render a class-colored tag via `renderCall`: `⟦ WATCH ⟧ ▸ <arg>`, with a **semantic palette** — senses=green, OSINT=magenta, read=cyan, config=amber.

## Footer
- Restyled to match (red REC dot + cyan `▸` separators).

## Testing
- `npm run typecheck` ✓ · `npm test` (149) ✓ · `npm run test:e2e` (97 offline) ✓
- Unit coverage added/updated for the header frames, spinner, label maps, and verb tag.

## Note for live review
The header animation, table-flip, and verb tags are verified by unit tests + a faithful color preview, but the interactive TUI can't be screenshotted headlessly — worth an eyeball with `npm run build:bun && ./dist/bin/overcast` (run a verb to see the HUD tag + op-labels). One known soft spot: the **between-tools** idle phrase depends on event ordering vs pi reasserting its default each turn; the **per-op** labels (during tool execution) are the reliable ones. Easy to move to `after_provider_response` if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes on pi extension/UI hooks; agent-facing tool `content` and execute paths are unchanged aside from optional `renderResult` truncation in the TUI.
> 
> **Overview**
> Adds **cyberpunk TUI polish** through pi’s public hooks only (`setHeader`, `setFooter`, `setWorkingIndicator`, `setWorkingMessage`, per-tool `renderCall`/`renderResult`)—no pi fork.
> 
> **Header:** Static banner helpers are replaced by **`OvercastHeader`**, which colorizes `assets/banner.txt` with a green→cyan gradient wordmark, a **recording-deck HUD** (REC + version + meter) beside the play box, a **centered tagline**, and bracket status (`[OK] context`, tool count, model). A **one-time “decrypt” reveal** runs on launch via a short `requestRender` interval, then the timer **stops** so idle repaints don’t fight terminal scrollback.
> 
> **Busy state:** **`workingIndicator()`** supplies a colored ASCII table-flip spinner; **`opLabel` / `idleLabel`** rotate hacker-movie phrases on `turn_start`, `tool_execution_start|end`, and clear on `agent_end`. Per-verb label cursors avoid cross-verb rotation bugs.
> 
> **Verb tools:** **`verbCallLine`** + **`renderCall`** show class-colored `⟦ VERB ⟧ ▸ arg` lines; **`renderResult`** collapses long tool output to six lines with a **ctrl+o** expand hint (agent still gets full text).
> 
> **Footer:** Visual tweak (red ●, cyan ▸ separators). Unit tests cover header frames, labels, spinner, HUD tags, and collapsed results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab25f6e6e395a76a36f782d4f6bf6cea0e02207f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->