### PR TITLE
Release v0.0.1: land version bump on main + fix the release runbook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.0"
+    "version": "0.0.1"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": {
     "name": "kdr"
   },

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -99,14 +99,14 @@ node scripts/sync-version.mjs --check     # all surfaces match (should already)
 `package-lock.json`, `src/version.ts`, both `.claude-plugin/*.json`) **without**
 committing or tagging.
 
-**2. Open + merge the PR** (prefer a **merge commit**, not squash, so the commit
-you'll tag stays reachable from `main`):
+**2. Open + merge the PR** (squash or merge — either is fine; step 3 tags `main`
+*after* it lands, so the tagged commit is always whatever ends up on `main`):
 
 ```bash
 git commit -am "Release vX.Y.Z"
 git push -u origin release-vX.Y.Z
 gh pr create --base main --fill
-# …review, then merge it (merge commit).
+# …review, then merge it.
 ```
 
 **3. Tag the merged commit on `main` and push the tag:**

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,9 +28,10 @@ propagates it into the files that hard-code a version:
 (`scripts/bun-sidecar.mjs` reads `package.json` directly, so it needs no sync.)
 
 This is wired to the npm `version` lifecycle, so **`npm version <patch|minor|x.y.z>`
-bumps everything at once** and stages it into the version commit. CI also runs
-`node scripts/sync-version.mjs --check` and fails on drift, so the surfaces can
-never silently diverge.
+bumps + syncs every surface at once** (pass `--no-git-tag-version` in the PR-based
+release flow below to skip the auto commit/tag). CI also runs `node
+scripts/sync-version.mjs --check` and fails on drift, so the surfaces can never
+silently diverge.
 
 ---
 
@@ -81,11 +82,38 @@ exists — the publish step is idempotent) and just build + attach the binaries.
 
 ## Cutting a release (0.0.1 and onward)
 
-From a clean default branch:
+`main` is protected (changes must go through a PR), so the version-bump **commit**
+lands via a PR and the **tag** is pushed afterward — the tag push is what triggers
+the release, and tags aren't covered by the branch rule.
+
+**1. Bump + sync on a release branch** (no commit/tag yet):
 
 ```bash
-npm version patch             # or: minor / major / 0.3.0  → bumps + syncs + commits + tags vX.Y.Z
-git push --follow-tags        # push the commit and the tag together
+git checkout main && git pull
+git checkout -b release-vX.Y.Z
+npm version X.Y.Z --no-git-tag-version   # patch / minor / major / x.y.z
+node scripts/sync-version.mjs --check     # all surfaces match (should already)
+```
+
+`--no-git-tag-version` edits + syncs every surface (`package.json`,
+`package-lock.json`, `src/version.ts`, both `.claude-plugin/*.json`) **without**
+committing or tagging.
+
+**2. Open + merge the PR** (prefer a **merge commit**, not squash, so the commit
+you'll tag stays reachable from `main`):
+
+```bash
+git commit -am "Release vX.Y.Z"
+git push -u origin release-vX.Y.Z
+gh pr create --base main --fill
+# …review, then merge it (merge commit).
+```
+
+**3. Tag the merged commit on `main` and push the tag:**
+
+```bash
+git checkout main && git pull
+git tag vX.Y.Z && git push origin vX.Y.Z
 ```
 
 Pushing the `vX.Y.Z` tag triggers `release.yml`, which:
@@ -99,6 +127,13 @@ Pushing the `vX.Y.Z` tag triggers `release.yml`, which:
 You can also run it manually from the Actions tab (**workflow_dispatch**) with the
 version as input; in that mode the binaries are uploaded as workflow artifacts
 instead of release assets.
+
+> **Why not `npm version patch && git push --follow-tags`?** That pushes the bump
+> commit straight to `main`, which the PR rule rejects (`GH013: Changes must be
+> made through a pull request`) — though the tag (and thus the publish) still goes
+> through, leaving `main` behind the tag. If you'd rather keep the one-liner, add
+> an admin **bypass** for the `main` ruleset (Settings → Rules) instead of the PR
+> flow above.
 
 ---
 
@@ -124,6 +159,9 @@ npm i -g @kdrrr/overcast@latest && overcast --version --json
 - **`E404` configuring the Trusted Publisher** → the package doesn't exist yet; do
   the manual bootstrap publish first.
 - **Version-drift CI failure** → run `npm run sync-version` and commit.
+- **`GH013` / "Changes must be made through a pull request"** when pushing the
+  version commit → `main` requires a PR. Use the PR-based flow above (the tag
+  pushes fine on its own), or add an admin bypass to the `main` ruleset.
 - **2FA on the bootstrap publish** → `npm publish --otp=<code>`.
 - **Re-running a release tag** → safe; the publish step no-ops when the version is
   already on npm, and binary assets are overwritten.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE AT https://github.com/kdr/overcast",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "SEE LICENSE AT https://github.com/kdr/overcast",
   "author": "kdr",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.1.
 
-export const OVERCAST_VERSION = "0.0.0";
+export const OVERCAST_VERSION = "0.0.1";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.1";


### PR DESCRIPTION
Two things, both consequences of cutting `v0.0.1`:

**1. Land the version bump on `main` (commit `06bc5a8`).**
`npm version patch` made this bump **and** the `v0.0.1` tag. The tag pushed → `release.yml` ran → **`@kdrrr/overcast@0.0.1` is live on npm** (first real OIDC publish) + 4 binaries on the GitHub Release. But the direct push of the commit to `main` was rejected by the `pull_request` rule, so `main` is still `0.0.0`. This is exactly that bump (the 5 single-sourced version surfaces).

**2. Fix `RELEASING.md` so this can't recur.**
The old runbook said `npm version patch && git push --follow-tags`, which pushes the bump commit straight to protected `main` (`GH013`). Rewrote *Cutting a release* to the PR-based flow: bump on a branch with `--no-git-tag-version`, merge the PR, then tag the merged commit on `main`. Added a `GH013` troubleshooting note + the admin-bypass alternative.

**Squash-merge is fine.** The release already shipped from the `v0.0.1` tag (`06bc5a8`); squashing just means that exact commit won't be in `main`'s history — purely cosmetic, `main` ends up with identical `0.0.1` content either way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string and documentation-only changes; no application logic, auth, or data paths.
> 
> **Overview**
> Aligns **default-branch** version surfaces with **0.0.1** by propagating `package.json` through `package-lock.json`, `OVERCAST_VERSION` in `src/version.ts`, and both `.claude-plugin` manifests (metadata + plugin entry).
> 
> **`RELEASING.md`** is rewritten so future cuts work on **protected `main`**: bump on a release branch with `npm version X.Y.Z --no-git-tag-version`, merge a PR, then tag and push `vX.Y.Z` (tag still drives `release.yml`). Documents why `npm version patch && git push --follow-tags` fails with **GH013**, and adds matching troubleshooting plus a note on `--no-git-tag-version` in the versioning section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19eddc0da52151d9dd100b43ea6a206e0d53d543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->