### PR TITLE
Fix broken npm install + release v0.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.1"
+    "version": "0.0.2"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "kdr"
   },

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -135,6 +135,11 @@ instead of release assets.
 > an admin **bypass** for the `main` ruleset (Settings → Rules) instead of the PR
 > flow above.
 
+**Shipping one PR's change as a patch?** You can skip the dedicated
+`release-vX.Y.Z` branch and fold the bump into that PR: run `npm version X.Y.Z
+--no-git-tag-version` on the feature branch, commit it alongside the change, then
+tag `main` after the PR merges (step 3 above). One PR instead of two.
+
 ---
 
 ## Verify a release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "hasInstallScript": true,
       "license": "SEE LICENSE AT https://github.com/kdr/overcast",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "assets/branding/logo.png",
     "skills",
     "prompts",
-    "examples"
+    "examples",
+    "scripts/brand-pi.mjs"
   ],
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "SEE LICENSE AT https://github.com/kdr/overcast",
   "author": "kdr",

--- a/scripts/brand-pi.mjs
+++ b/scripts/brand-pi.mjs
@@ -10,41 +10,80 @@
 // must sit next to the executable (handled by the build:bun step).
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
 const BRAND = "overcast";
+const PI_PKG = "@earendil-works/pi-coding-agent";
+const PI_SEGMENTS = PI_PKG.split("/"); // ["@earendil-works", "pi-coding-agent"]
 
-function piPackageJsonPath() {
-  // resolve the installed pi-coding-agent package.json
-  const require = createRequire(import.meta.url);
-  try {
-    return require.resolve("@earendil-works/pi-coding-agent/package.json");
-  } catch {
-    // fall back to the conventional node_modules location
-    const p = new URL(
-      "../node_modules/@earendil-works/pi-coding-agent/package.json",
-      import.meta.url,
-    ).pathname;
-    return existsSync(p) ? p : undefined;
+// Walk up the directory tree from `startDir`; at each level probe
+// node_modules/<PI_PKG>/package.json as a RAW filesystem path. This deliberately
+// avoids require.resolve("<PI_PKG>/package.json"), which throws
+// ERR_PACKAGE_PATH_NOT_EXPORTED because pi's `exports` map only exposes ".".
+// Covers both layouts npm produces: pi nested under overcast (standalone global
+// install) and pi hoisted to a shared node_modules (installed alongside others).
+function findUpNodeModules(startDir) {
+  let dir = startDir;
+  for (;;) {
+    const candidate = join(dir, "node_modules", ...PI_SEGMENTS, "package.json");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined; // hit the filesystem root
+    dir = parent;
   }
 }
 
+// Belt-and-suspenders for symlinked layouts (e.g. pnpm): resolve pi's "." entry
+// — which follows symlinks into the real store — then climb to the owning
+// package root (the nearest package.json whose `name` is PI_PKG).
+function findViaResolve() {
+  try {
+    const require = createRequire(import.meta.url);
+    let dir = dirname(require.resolve(PI_PKG));
+    for (;;) {
+      const candidate = join(dir, "package.json");
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, "utf8"));
+        if (pkg.name === PI_PKG) return candidate;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) return undefined;
+      dir = parent;
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+function piPackageJsonPath() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return findUpNodeModules(here) ?? findViaResolve();
+}
+
 function main() {
-  const path = piPackageJsonPath();
-  if (!path || !existsSync(path)) {
+  const pkgPath = piPackageJsonPath();
+  if (!pkgPath || !existsSync(pkgPath)) {
     // pi not installed yet (e.g. running before deps) — nothing to brand.
     console.error("[brand-pi] pi-coding-agent not found; skipping rebrand");
     return;
   }
-  const pkg = JSON.parse(readFileSync(path, "utf8"));
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
   pkg.piConfig = pkg.piConfig ?? {};
   if (pkg.piConfig.name === BRAND) {
     return; // already branded
   }
   pkg.piConfig.name = BRAND;
   // keep configDir as-is (".pi") so the agent home / sessions don't move.
-  writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n", "utf8");
-  console.error(`[brand-pi] set piConfig.name="${BRAND}" in ${path}`);
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n", "utf8");
+  console.error(`[brand-pi] set piConfig.name="${BRAND}" in ${pkgPath}`);
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  // Branding is purely cosmetic — a failure here (e.g. a read-only global
+  // node_modules) must never abort `npm install`. Warn and exit 0.
+  console.error(`[brand-pi] skipped (non-fatal): ${err?.message ?? err}`);
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.1.
 
-export const OVERCAST_VERSION = "0.0.1";
+export const OVERCAST_VERSION = "0.0.2";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.1";


### PR DESCRIPTION
## Problem

`npm install -g @kdrrr/overcast@0.0.1` **fails for everyone**:

```
npm error Error: Cannot find module '.../@kdrrr/overcast/scripts/brand-pi.mjs'
npm error code: 'MODULE_NOT_FOUND'
```

The `postinstall` runs `node scripts/brand-pi.mjs`, but `scripts/` was never in
the `files` whitelist, so the script isn't in the published tarball → the
postinstall errors and npm rolls the whole install back. The dev `npm link`
masked this because the working tree has `scripts/` on disk.

## Fixes

**1. Ship the script** — add `scripts/brand-pi.mjs` to `files` (just that one
file; the dev-only `bun-sidecar.mjs` / `sync-version.mjs` stay unpublished).

**2. Make the rebrand actually work, and never block install** — the postinstall
was *also* silently no-op'ing on normal installs:

- The resolver called `require.resolve("@earendil-works/pi-coding-agent/package.json")`,
  which throws `ERR_PACKAGE_PATH_NOT_EXPORTED` (pi's `exports` map only exposes
  `"."`). It fell back to a single *nested* path, so it found nothing whenever pi
  is **hoisted**. Replaced with a raw-fs walk up the `node_modules` chain (immune
  to `exports`) covering nested + hoisted layouts, plus a resolve-based fallback
  for symlinked (pnpm) stores.
- Wrapped `main()` so a cosmetic branding failure (e.g. read-only global
  `node_modules`) warns and exits 0 instead of aborting the install.

## Release

This PR also **cuts `v0.0.2`** (the patch that ships the fix) by folding the
version bump into the same PR — `npm version 0.0.2 --no-git-tag-version`, which
syncs every surface (`package.json`, `package-lock.json`, `src/version.ts`, both
`.claude-plugin/*.json`). After merge, push the `v0.0.2` tag to trigger
`release.yml`. `RELEASING.md` documents this fold-into-PR pattern.

## Verification

Packed the tarball and ran a clean `npm install` (scripts **enabled**) into a
fresh dir:

- install exits `0` (previously aborted)
- `scripts/brand-pi.mjs` is present in the tarball
- the **hoisted** pi gets `piConfig.name="overcast"` (previously stayed unbranded)
- `npm run typecheck` clean; `npm test` → 150/150 pass; `sync-version --check` clean