### PR TITLE
Release v0.0.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.2"
+    "version": "0.0.3"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "kdr"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "hasInstallScript": true,
       "license": "SEE LICENSE AT https://github.com/kdr/overcast",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "SEE LICENSE AT https://github.com/kdr/overcast",
   "author": "kdr",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.1.
 
-export const OVERCAST_VERSION = "0.0.2";
+export const OVERCAST_VERSION = "0.0.3";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.1";


### PR DESCRIPTION
Patch release **v0.0.3**, cut from current `main` per [RELEASING.md](RELEASING.md).

## What ships since v0.0.2
- #15 — Add `face` verb + collection lifecycle, backed by tinycloud ≥ 0.3.4

## This PR
Version-only bump. `npm version 0.0.3 --no-git-tag-version` + `scripts/sync-version.mjs` propagated `0.0.3` to all four surfaces:
- `package.json` / `package-lock.json`
- `src/version.ts` (`OVERCAST_VERSION`)
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (`metadata.version` + `plugins[].version`)

`node scripts/sync-version.mjs --check` ✅ all surfaces match.

## After merge
Tag `main` to trigger `release.yml` (npm OIDC publish + bun binaries):
```
git checkout main && git pull
git tag v0.0.3 && git push origin v0.0.3
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version string updates only; no logic, API, or dependency changes in the diff.
> 
> **Overview**
> **Release v0.0.3** — version-only bump from **0.0.2** to **0.0.3** across every published version surface, with no application or dependency changes in this diff.
> 
> `package.json` and `package-lock.json` are updated for npm; **`OVERCAST_VERSION`** in `src/version.ts` drives CLI `--version` and TUI branding; **`.claude-plugin/plugin.json`** and **`.claude-plugin/marketplace.json`** (metadata + plugin entry) stay aligned for the Claude plugin marketplace. Functional work for this release (e.g. the `face` verb from #15) is already on `main`; this PR only cuts the release label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b8808520a71b240a36d89498088bb3dc63d12f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->