### PR TITLE
Align overcast with tinycloud 0.3.6 behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
 - `@cloudglue/cloudglue-js` — the default sense backend (via the tinycloud CLI,
   `exec`). Cloudglue is **also** a pickable *brain* LLM provider (anthropic-messages
   API) so it appears in `/model` — never forced. The tinycloud CLI is a runtime
-  prerequisite (like ffmpeg), not an npm dep; `face` + `collection` need **≥ 0.3.4**.
+  prerequisite (like ffmpeg), not an npm dep; `face` + `collection` need **≥ 0.3.4**,
+  and current docs recommend tinycloud **0.3.6**.
 - `ffmpeg` + `ffprobe` — a **system prerequisite** (on `PATH`, or via
   `OVERCAST_FFMPEG` / `OVERCAST_FFPROBE`); the internal media toolkit, NOT bundled.
 - TypeScript / ESM / Node ≥22; `tsup` (dev build) + `bun build --compile` (binary).
@@ -72,7 +73,7 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `transcript` / `detailed`), `listen` (speech transcript; `--describe` for the
   full audio-scene), `see` (caption / OCR / open-vocab detect — turnkey Hugging
   Face, bindable fal, local OWLv2 via `examples/providers/detect`), `face` (tinycloud
-  ≥ 0.3.4: detect faces, `--match <img>` to find a person in a clip, or search a
+  ≥ 0.3.4: detect faces, `--match <img>` (JPEG/PNG) to find a person in a clip, or search a
   face-analysis collection), `enhance` (system ffmpeg or a bound model), `view`
   (HTML media player).
 - **OSINT** — `scan`, `capture`, `monitor` (sources: youtube / tiktok / web;

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ the CLI from any harness. The brain LLM is BYO; the default perception backend i
 - **[tinycloud CLI](https://www.npmjs.com/package/@cloudglue/tinycloud)** — the
   default `watch` / `listen` / `face` / `collection` backend (Cloudglue); set
   `CLOUDGLUE_API_KEY`. The `face` + `collection` verbs need **tinycloud ≥ 0.3.4**
-  (`tinycloud update`); override the invocation with `OVERCAST_TINYCLOUD_CMD`.
+  and overcast currently recommends **0.3.6** (`npm i -g @cloudglue/tinycloud@0.3.6`
+  or `tinycloud update`); override the invocation with `OVERCAST_TINYCLOUD_CMD`.
 - **yt-dlp** on `PATH` — only for the `youtube` / `tiktok` capture sources.
 
 `overcast doctor` verifies all of these.
@@ -95,7 +96,7 @@ overcast brief --export ./brief.html
 
 # 4) faces: detect, or find a specific person in a clip
 overcast face ./clip.mp4 --json                       # who is in this video
-overcast face ./clip.mp4 --match ./suspect.jpg --json # find this person, ranked by similarity
+overcast face ./clip.mp4 --match ./suspect.jpg --json # find this person (JPEG/PNG query image), ranked by similarity
 
 # 5) index the target's videos into a collection, then search across ALL of them
 overcast collection create faces --type face --json
@@ -209,6 +210,7 @@ bash examples/profiles/install-profiles.sh   # then: overcast <verb> … --profi
 **Default perception (tinycloud / Cloudglue)**
 - `CLOUDGLUE_API_KEY` — key for the default `watch`/`listen` + the turnkey brain (else `~/.tinycloud/config.json`)
 - `CLOUDGLUE_BASE_URL` — endpoint (default `https://api.cloudglue.dev`)
+- `TINYCLOUD_HTTP_RETRIES`, `TINYCLOUD_UPLOAD_IDLE_TIMEOUT_MS`, `TINYCLOUD_JOB_WAIT_TIMEOUT_MS` — tinycloud 0.3.6 Cloudglue retry/upload/job-wait knobs inherited by overcast's default providers
 
 **Opt-in sense providers** (bind via `setup provider <verb> <spec>`)
 - `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` — turnkey `see` + `enhance`; `HF_SEE_MODEL` (default `google/gemma-3-27b-it`), `HF_ENHANCE_IMAGE_MODEL` / `HF_ENHANCE_AUDIO_MODEL` / `HF_ENHANCE_ENDPOINT`

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -136,7 +136,8 @@ collections** surfaces (invariant #9: public verbs only; mapped to the loose
 record by the shared `runTinycloud` boundary in
 [`src/providers/tinycloud/envelope.ts`](../src/providers/tinycloud/envelope.ts)).
 Point `OVERCAST_TINYCLOUD_CMD` at a specific binary/wrapper if `tinycloud` isn't
-on `PATH`; `overcast doctor` reports the installed version and warns below 0.3.4.
+on `PATH`; `overcast doctor` reports the installed version, warns below 0.3.4,
+and recommends the latest tested tinycloud, currently 0.3.6.
 
 ### `face` — detect / match / search
 
@@ -144,14 +145,16 @@ One verb resolves to one of four tinycloud face ops from the inputs given:
 
 ```bash
 overcast face ./clip.mp4 --json                          # detect: who is in this video (boxes + timestamps)
-overcast face ./clip.mp4 --match ./suspect.jpg --json    # match: find this person in the clip, ranked by similarity
+overcast face ./clip.mp4 --match ./suspect.jpg --json    # match: find this person in the clip (JPEG/PNG query image), ranked by similarity
 overcast face --match ./suspect.jpg --collection <id> --json   # search a face-analysis collection (case-wide)
 overcast face ./clip.mp4 --collection <id> --json        # list a video's stored detections in a collection
 ```
 
 Emits a `face.analysis` record: `faces[]` is normalized (`at`, `box`,
 `similarity`, `thumbnail?`) and the full provider data survives in `detailed`.
-The video/reference may be a path, URL, or a case record id. Bind your own
+The video/reference may be a path, URL, or a case record id. The `--match`
+query image must be JPEG/PNG; tinycloud 0.3.6 rejects webp/heic/gif/bmp/tiff/avif
+at preflight. Bind your own
 detector with `setup provider face <spec>` like any sense (it receives the media
 plus `--match`/`--collection`/… as flags).
 
@@ -193,4 +196,5 @@ accept a path, URL, or a case record id (a `capture`/`watch` record → its medi
 
 `overcast doctor` checks pi, the system ffmpeg/ffprobe, Cloudglue creds, the
 tinycloud CLI **and its version** (`face`/`collection` need ≥ 0.3.4), the
-home/profiles, and the active provider bindings.
+home/profiles, and the active provider bindings. Version 0.3.6 is the current
+recommended tinycloud build.

--- a/skills/overcast-init/SKILL.md
+++ b/skills/overcast-init/SKILL.md
@@ -13,8 +13,9 @@ One-time setup for overcast.
 1. **Install the CLI** — `pi install npm:@kdrrr/overcast` (inside pi) or
    `npm i -g @kdrrr/overcast` for the standalone binary.
 2. **Install/update tinycloud** — the default perception backend. Get the latest
-   (`npm i -g @cloudglue/tinycloud` then `tinycloud install --latest`, or
-   `tinycloud update`). The `face` + `collection` verbs need **tinycloud ≥ 0.3.4**;
+   (`npm i -g @cloudglue/tinycloud@0.3.6` then `tinycloud install --latest`, or
+   `tinycloud update`). The `face` + `collection` verbs need **tinycloud ≥ 0.3.4**,
+   and overcast currently recommends **0.3.6**;
    override the invocation with `OVERCAST_TINYCLOUD_CMD` if it isn't on `PATH`.
 3. **Verify** — `overcast doctor --json` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI + version).

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -47,7 +47,7 @@ Run any verb from bash and parse the JSON record:
 overcast watch ./clip.mp4 --json          # video.analysis record
 overcast scan --pull --json               # enumerate sources, capture + sense
 overcast face ./clip.mp4 --json           # detect faces (boxes + timestamps)
-overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video
+overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video (JPEG/PNG query image)
 overcast ask "every white van, with timestamps" --json
 overcast brief --export ./brief.html
 ```
@@ -81,7 +81,9 @@ overcast collection create people --type entities --prompt "people, orgs, locati
 overcast collection entities <ent-col-id> ./clip.mp4 --json
 ```
 
-`face` needs tinycloud ≥ 0.3.4 (`overcast doctor` flags an older install).
+`face` needs tinycloud ≥ 0.3.4 (`overcast doctor` flags an older install);
+overcast currently recommends tinycloud 0.3.6 for the latest face validation and
+CLI reliability behavior.
 
 ### Reading large records
 

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -79,20 +79,20 @@ Emits `image.analysis` records.
 
 ### `overcast face`
 
-Default provider: tinycloud. `face <video>` detects faces — one box per sampled frame, so the count is detections, NOT unique people (detect doesn't cluster). To find or count a PERSON, use `face <video> --match ref.jpg` (locates that person in the clip, ranked by similarity), or `face --match ref.jpg --collection <id>` to search a registered face-analysis collection (case-wide); `face <video> --collection <id>` lists that video's stored detections. The video/reference may be a path, URL, or a case record id. Emits a face.analysis record whose `summary` is the headline, plus faces[] (at, box, similarity, thumbnail?) and the full provider data in `detailed`.
+Default provider: tinycloud. `face <video>` detects faces — one box per sampled frame, so the count is detections, NOT unique people (detect doesn't cluster). To find or count a PERSON, use `face <video> --match ref.jpg` (locates that person in the clip, ranked by similarity), or `face --match ref.jpg --collection <id>` to search a registered face-analysis collection (case-wide); `face <video> --collection <id>` lists that video's stored detections. The video/reference may be a path, URL, or a case record id; the reference image for --match must be JPEG/PNG. Emits a face.analysis record whose `summary` is the headline, plus faces[] (at, box, similarity, thumbnail?) and the full provider data in `detailed`.
 
 ```
 overcast face [input] [options]
 
   Detect, match, or search faces in video (and across face-analysis collections).
 
-  Default provider: tinycloud. `face <video>` detects faces — one box per sampled frame, so the count is detections, NOT unique people (detect doesn't cluster). To find or count a PERSON, use `face <video> --match ref.jpg` (locates that person in the clip, ranked by similarity), or `face --match ref.jpg --collection <id>` to search a registered face-analysis collection (case-wide); `face <video> --collection <id>` lists that video's stored detections. The video/reference may be a path, URL, or a case record id. Emits a face.analysis record whose `summary` is the headline, plus faces[] (at, box, similarity, thumbnail?) and the full provider data in `detailed`.
+  Default provider: tinycloud. `face <video>` detects faces — one box per sampled frame, so the count is detections, NOT unique people (detect doesn't cluster). To find or count a PERSON, use `face <video> --match ref.jpg` (locates that person in the clip, ranked by similarity), or `face --match ref.jpg --collection <id>` to search a registered face-analysis collection (case-wide); `face <video> --collection <id>` lists that video's stored detections. The video/reference may be a path, URL, or a case record id; the reference image for --match must be JPEG/PNG. Emits a face.analysis record whose `summary` is the headline, plus faces[] (at, box, similarity, thumbnail?) and the full provider data in `detailed`.
 
 Arguments:
   input            Video to analyze (path/URL/record-id); omit with --match + --collection to search the index
 
 Options:
-  --match <string>       Reference face image to find (path/URL/record-id)
+  --match <string>       Reference face image to find (JPEG/PNG path/URL/record-id)
   --collection <string>  Face-analysis collection id/name to search or list within (comma-list ok; default: the case's face collection)
   --max-faces <number>   match: cap returned matches (1–4000)
   --min-similarity <number> match/search: similarity floor (0–100)
@@ -295,7 +295,7 @@ Options:
   --memory <string>      Restrict to specific memory provider ids
   --since <string>       Time filter (e.g. 24h, 2026-06-01)
   --verb <string>        Restrict to record kinds (comma list)
-  --limit <number>       Max passages
+  --limit <number>       Max local passages; with --collection --probe, max probe results
   --format <string>      json | md | txt
   --json                 Shorthand for --format json
 ```
@@ -371,7 +371,7 @@ Emits `source` records.
 A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search> [q]` routes to the bound memory providers. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
 
 ```
-overcast case <action> [arg] [options]
+overcast case <action> [sub] [arg] [options]
 
   Inspect/manage the current case: init | info | records | memory.
 
@@ -379,7 +379,8 @@ overcast case <action> [arg] [options]
 
 Arguments:
   action           init | info | records | memory
-  arg              dir (init), record id (memory get), or query (memory search)
+  sub              memory subcommand (list|get|search), or dir for init
+  arg              record id (memory get) or query (memory search)
 
 Options:
   --name <string>        Case name (init)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,7 @@ const ENV_GROUPS: Array<{ title: string; vars: Array<[string, string]> }> = [
       ["CLOUDGLUE_API_KEY", "Cloudglue key for the default watch/listen/face/collection backend + turnkey brain (else ~/.tinycloud/config.json)"],
       ["CLOUDGLUE_BASE_URL", "Cloudglue endpoint (default https://api.cloudglue.dev)"],
       ["OVERCAST_TINYCLOUD_CMD", "Override the tinycloud invocation for face/collection/ask-collection (a path or wrapper, e.g. a pinned binary)"],
+      ["TINYCLOUD_HTTP_RETRIES / TINYCLOUD_UPLOAD_IDLE_TIMEOUT_MS / TINYCLOUD_JOB_WAIT_TIMEOUT_MS", "tinycloud 0.3.6 Cloudglue reliability knobs inherited by default providers"],
     ],
   },
   {

--- a/src/providers/tinycloud/collection.ts
+++ b/src/providers/tinycloud/collection.ts
@@ -217,7 +217,7 @@ export async function tcAsk(
   const verb = o.probe ? "probe" : "ask";
   const args = [verb, question, "--in", `collection:${collectionId}`];
   if (o.probe && o.scope) args.push("--scope", o.scope);
-  if (o.limit != null) args.push("--limit", String(o.limit));
+  if (o.probe && o.limit != null) args.push("--limit", String(o.limit));
   args.push("--json");
   const out = await runTinycloud(args, o);
 

--- a/src/providers/tinycloud/listen.ts
+++ b/src/providers/tinycloud/listen.ts
@@ -16,6 +16,16 @@ function envelopeData(parsed: unknown): Record<string, unknown> {
   return {};
 }
 
+function providerErrorMessage(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return "";
+  const o = value as Record<string, unknown>;
+  const code = typeof o.code === "string" ? o.code : "";
+  const message = typeof o.message === "string" ? o.message : "";
+  if (code && message) return `${code}: ${message}`;
+  return message || code;
+}
+
 /** Coerce a timestamp to seconds, tolerating numeric strings ("12.5"). */
 function toSeconds(v: unknown): number | undefined {
   if (typeof v === "number" && Number.isFinite(v)) return v;
@@ -167,10 +177,7 @@ export async function runListen(
   // An error envelope is a failure even when JSON parsed and exit was 0 — the
   // record's state/error is authoritative, so surface it instead of storing a
   // silent "ready" listen record (mirrors runWatch).
-  const envError =
-    (typeof envObj.error === "string" && envObj.error) ||
-    (typeof (data.error as string) === "string" && (data.error as string)) ||
-    "";
+  const envError = providerErrorMessage(envObj.error) || providerErrorMessage(data.error);
   // A non-zero exit OR an error envelope is a failure even when JSON parsed —
   // apply them together (like runWatch), and treat exit 13 as a cred gap.
   if (
@@ -180,6 +187,30 @@ export async function runListen(
     data.status === "error" ||
     Boolean(envError)
   ) {
+    const visualDescribeUnavailable =
+      opts.describe &&
+      !(opts.run && opts.run.trim()) &&
+      /(?:enable_visual_scene_description|visual scene description) is not available for audio files/i.test(envError);
+    if (visualDescribeUnavailable) {
+      const fallback = await runListen(input, {
+        ...opts,
+        describe: false,
+        run: undefined,
+      });
+      if (fallback.state !== "ready") return fallback;
+      fallback.payload = {
+        ...(fallback.payload as Record<string, unknown>),
+        description: "",
+        warning:
+          "tinycloud full describe is not available for audio-only files; used speech-only transcript instead.",
+      };
+      fallback.meta = {
+        ...fallback.meta,
+        mode: "speech_fallback",
+        warning: envError,
+      };
+      return fallback;
+    }
     return makeRecord({
       verb: "listen",
       format: "json",

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -44,6 +44,53 @@ function transcriptFromSegments(data: Record<string, unknown>): string {
   return lines.join("\n");
 }
 
+function textFromVttCue(raw: string): { speaker?: string; text: string } | undefined {
+  const cleaned = raw.replace(/\s+/g, " ").trim();
+  if (!cleaned) return undefined;
+  const voice = cleaned.match(/^<v\s+([^>]+)>(.*)<\/v>$/i);
+  if (voice) return { speaker: voice[1].trim(), text: voice[2].trim() };
+  return { text: cleaned.replace(/<\/?[^>]+>/g, "").trim() };
+}
+
+/** Tinycloud full describe writes speech to a WebVTT sidecar. Convert it to a
+ * readable speaker transcript so watch records expose spoken words inline. */
+function transcriptFromVttPath(path: string): string {
+  if (!existsSync(path)) return "";
+  let vtt = "";
+  try {
+    vtt = readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+  const out: Array<{ speaker?: string; text: string }> = [];
+  for (const block of vtt.split(/\n\s*\n/)) {
+    const lines = block.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+    if (!lines.length || lines[0] === "WEBVTT") continue;
+    const cue = lines.findIndex((l) => /-->/u.test(l));
+    if (cue < 0) continue;
+    const parsed = textFromVttCue(lines.slice(cue + 1).join(" "));
+    if (!parsed?.text) continue;
+    const last = out[out.length - 1];
+    if (last && last.speaker === parsed.speaker) last.text += ` ${parsed.text}`;
+    else out.push(parsed);
+  }
+  return out.map((x) => (x.speaker ? `${x.speaker}: ${x.text}` : x.text)).join("\n");
+}
+
+function transcriptFromSidecar(data: Record<string, unknown>): string {
+  const candidates: unknown[] = [data.vtt_path, data.speech_vtt_path];
+  if (data.describe && typeof data.describe === "object") {
+    const d = data.describe as Record<string, unknown>;
+    candidates.push(d.vtt_path, d.speech_vtt_path);
+  }
+  for (const c of candidates) {
+    if (typeof c !== "string") continue;
+    const t = transcriptFromVttPath(c);
+    if (t) return t;
+  }
+  return "";
+}
+
 /** A per-segment markdown breakdown (start–end · description — summary). */
 function segmentBreakdown(data: Record<string, unknown>): string {
   const segs = data.segments;
@@ -192,9 +239,9 @@ export async function runWatch(
 
   const content = contentMarkdown(data);
   const transcript =
-    typeof data.transcript === "string"
+    typeof data.transcript === "string" && data.transcript.trim()
       ? (data.transcript as string)
-      : transcriptFromSegments(data);
+      : transcriptFromSegments(data) || transcriptFromSidecar(data);
 
   // tinycloud may return a pending job envelope (async). Check BOTH the
   // top-level envelope and the unwrapped data object (the pending marker can

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -8,6 +8,7 @@ import { isCustomBinding, runBoundProvider } from "../providers/run.js";
 import { providerEnv } from "../providers/provider-env.js";
 import { listenVerb, seeVerb, enhanceVerb, viewVerb } from "../verbs/senses.js";
 import { faceVerb } from "../verbs/face.js";
+import { resolveVideoArg } from "../verbs/media-ref.js";
 import {
   scanVerb,
   captureVerb,
@@ -50,13 +51,27 @@ export const watchVerb: VerbSpec = {
         }),
       ];
     }
+    const resolved = resolveVideoArg(ctx.case, ctx.input, "watch input", { requireReady: false });
+    if (resolved.error) {
+      return [
+        makeRecord({
+          verb: "watch",
+          format: "json",
+          payload: { content: "", transcript: "", detailed: null },
+          media: { ref: ctx.input },
+          error: resolved.error,
+          state: "error",
+        }),
+      ];
+    }
+    const input = resolved.ref ?? ctx.input;
     // resolve the run template from the active profile binding (else default).
     const binding = ctx.profile.providers?.watch;
     // A custom provider already emits a record → dispatch by transport. Only the
     // tinycloud default needs envelope→record mapping.
     const rec = isCustomBinding(binding)
-      ? await runBoundProvider("watch", binding!, ctx.input, { env: providerEnv(ctx.case.mediaDir), timeoutMs: 15 * 60_000, signal: ctx.signal })
-      : await runWatch(ctx.input, { run: binding?.run, signal: ctx.signal });
+      ? await runBoundProvider("watch", binding!, input, { env: providerEnv(ctx.case.mediaDir), timeoutMs: 15 * 60_000, signal: ctx.signal })
+      : await runWatch(input, { run: binding?.run, signal: ctx.signal });
     rec.meta = { ...rec.meta, case: ctx.case.dir };
     return [rec];
   },

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -86,7 +86,7 @@ Run any verb from bash and parse the JSON record:
 overcast watch ./clip.mp4 --json          # video.analysis record
 overcast scan --pull --json               # enumerate sources, capture + sense
 overcast face ./clip.mp4 --json           # detect faces (boxes + timestamps)
-overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video
+overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video (JPEG/PNG query image)
 overcast ask "every white van, with timestamps" --json
 overcast brief --export ./brief.html
 \`\`\`
@@ -120,7 +120,9 @@ overcast collection create people --type entities --prompt "people, orgs, locati
 overcast collection entities <ent-col-id> ./clip.mp4 --json
 \`\`\`
 
-\`face\` needs tinycloud ≥ 0.3.4 (\`overcast doctor\` flags an older install).
+\`face\` needs tinycloud ≥ 0.3.4 (\`overcast doctor\` flags an older install);
+overcast currently recommends tinycloud 0.3.6 for the latest face validation and
+CLI reliability behavior.
 
 ### Reading large records
 
@@ -160,8 +162,9 @@ One-time setup for overcast.
 1. **Install the CLI** — \`pi install npm:@kdrrr/overcast\` (inside pi) or
    \`npm i -g @kdrrr/overcast\` for the standalone binary.
 2. **Install/update tinycloud** — the default perception backend. Get the latest
-   (\`npm i -g @cloudglue/tinycloud\` then \`tinycloud install --latest\`, or
-   \`tinycloud update\`). The \`face\` + \`collection\` verbs need **tinycloud ≥ 0.3.4**;
+   (\`npm i -g @cloudglue/tinycloud@0.3.6\` then \`tinycloud install --latest\`, or
+   \`tinycloud update\`). The \`face\` + \`collection\` verbs need **tinycloud ≥ 0.3.4**,
+   and overcast currently recommends **0.3.6**;
    override the invocation with \`OVERCAST_TINYCLOUD_CMD\` if it isn't on \`PATH\`.
 3. **Verify** — \`overcast doctor --json\` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI + version).

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -25,7 +25,8 @@ export const caseVerb: VerbSpec = {
     "[--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.",
   args: [
     { name: "action", summary: "init | info | records | memory", required: true },
-    { name: "arg", summary: "dir (init), record id (memory get), or query (memory search)" },
+    { name: "sub", summary: "memory subcommand (list|get|search), or dir for init" },
+    { name: "arg", summary: "record id (memory get) or query (memory search)" },
   ],
   flags: [
     { name: "name", summary: "Case name (init)", type: "string" },

--- a/src/verbs/face.ts
+++ b/src/verbs/face.ts
@@ -25,7 +25,14 @@ function err(message: string): OvercastRecord {
   return makeRecord({ verb: "face", format: "json", payload: { error: message }, error: message, state: "error" });
 }
 
-const IMG_RE = /\.(jpe?g|png|webp|gif|bmp|tiff?|heic|avif)$/i;
+const FACE_QUERY_IMAGE_RE = /\.(jpe?g|png)$/i;
+
+function faceQueryImageError(ref: string): string | undefined {
+  const clean = ref.replace(/[?#].*$/, "");
+  return FACE_QUERY_IMAGE_RE.test(clean)
+    ? undefined
+    : `--match image must be a JPEG or PNG: ${ref} (tinycloud 0.3.6 rejects webp/heic/gif/bmp/tiff/avif at preflight)`;
+}
 
 /** Resolve a --match face-IMAGE ref. A path/URL is used as-is; a case record id
  *  resolves to its media ONLY when that media looks like an image — a watch/
@@ -37,11 +44,12 @@ function resolveImageRef(c: Case, ref: string): { ref?: string; error?: string }
   if (!rec) return { ref }; // a direct path / URL — trust the user's choice
   const m = rec.media?.ref;
   if (!m) return { error: `--match record ${ref} has no media` };
-  // require an image extension for a record-resolved ref — local AND http (strip
-  // any query/fragment) — so a watch/capture/scan record pointing at a video or
-  // page URL is rejected, not accepted as a face image.
-  if (!IMG_RE.test(m.replace(/[?#].*$/, ""))) {
-    return { error: `--match record ${ref} resolves to ${m}, which isn't a face image — pass a face image (jpg/png) or an image record (e.g. a see/capture of a photo)` };
+  // tinycloud 0.3.6 accepts only JPEG/PNG query images for match/search. Check a
+  // record-resolved ref here so a watch/capture/scan record pointing at a video,
+  // page URL, or unsupported image format is rejected before spawning tinycloud.
+  const imageErr = faceQueryImageError(m);
+  if (imageErr) {
+    return { error: `--match record ${ref} resolves to ${m}; ${imageErr}` };
   }
   return { ref: m };
 }
@@ -95,13 +103,13 @@ export const faceVerb: VerbSpec = {
     "`face <video> --match ref.jpg` (locates that person in the clip, ranked by similarity), or " +
     "`face --match ref.jpg --collection <id>` to search a registered face-analysis collection (case-wide); " +
     "`face <video> --collection <id>` lists that video's stored detections. The video/reference may be a " +
-    "path, URL, or a case record id. Emits a face.analysis record whose `summary` is the headline, plus " +
+    "path, URL, or a case record id; the reference image for --match must be JPEG/PNG. Emits a face.analysis record whose `summary` is the headline, plus " +
     "faces[] (at, box, similarity, thumbnail?) and the full provider data in `detailed`.",
   args: [
     { name: "input", summary: "Video to analyze (path/URL/record-id); omit with --match + --collection to search the index", required: false },
   ],
   flags: [
-    { name: "match", summary: "Reference face image to find (path/URL/record-id)", type: "string" },
+    { name: "match", summary: "Reference face image to find (JPEG/PNG path/URL/record-id)", type: "string" },
     { name: "collection", summary: "Face-analysis collection id/name to search or list within (comma-list ok; default: the case's face collection)", type: "string" },
     { name: "max-faces", summary: "match: cap returned matches (1–4000)", type: "number" },
     { name: "min-similarity", summary: "match/search: similarity floor (0–100)", type: "number" },
@@ -171,6 +179,10 @@ export const faceVerb: VerbSpec = {
     // type-checks a record-resolved ref; a direct path is trusted until here).
     if (image && !/^https?:\/\//i.test(image) && !existsSync(image)) {
       return [err(`--match image not found: ${image}`)];
+    }
+    if (image) {
+      const imageErr = faceQueryImageError(image);
+      if (imageErr) return [err(imageErr)];
     }
 
     // Resolve which face op the given inputs select. This runs BEFORE the custom

--- a/src/verbs/media-ref.ts
+++ b/src/verbs/media-ref.ts
@@ -35,10 +35,16 @@ export function isRegisterableMediaRecord(r: OvercastRecord): boolean {
 }
 
 /** A case record id → its media.ref (+ the record id); otherwise the ref as-is
- *  (path / URL). Mirrors view/capture id resolution. */
+ *  (path / URL). Also resolves capture payload ids (`cap_...`) because those are
+ *  the human-facing handles capture emits. Mirrors view/capture id resolution. */
 export function resolveMediaRef(c: Case, ref: string): { ref: string; recordId?: string } {
   const rec = c.recordById(ref);
   if (rec?.media?.ref) return { ref: rec.media.ref, recordId: rec.id };
+  const byCapture = c.records().find((r) => {
+    if (r.verb !== "capture" || !r.media?.ref || !r.payload || typeof r.payload !== "object") return false;
+    return (r.payload as Record<string, unknown>).capture_id === ref;
+  });
+  if (byCapture?.media?.ref) return { ref: byCapture.media.ref, recordId: byCapture.id };
   return { ref };
 }
 

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -51,7 +51,7 @@ export const askVerb: VerbSpec = {
     { name: "memory", summary: "Restrict to specific memory provider ids", type: "string" },
     { name: "since", summary: "Time filter (e.g. 24h, 2026-06-01)", type: "string" },
     { name: "verb", summary: "Restrict to record kinds (comma list)", type: "string" },
-    { name: "limit", summary: "Max passages", type: "number" },
+    { name: "limit", summary: "Max local passages; with --collection --probe, max probe results", type: "number" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],
@@ -85,7 +85,13 @@ export const askVerb: VerbSpec = {
     // `!= null` so a PROVIDED-but-empty `--collection=` is rejected here, not
     // silently treated as omitted (→ a local-memory ask).
     if (ctx.opts.collection != null) {
-      // a tinycloud collection ask/probe supports only --probe/--scope/--limit;
+      // tinycloud collection Q&A supports --probe; --scope/--limit apply only
+      // to probe. Reject unsupported flags instead of silently dropping them.
+      if (ctx.opts.limit != null && ctx.opts.probe !== true) {
+        return [askError("--limit with --collection only applies with --probe (tinycloud ask does not support a limit flag)")];
+      }
+      // a tinycloud collection ask/probe supports only --probe/--scope/--limit
+      // (with --scope/--limit probe-only, above);
       // the local-memory flags (--deep/--memory/--verb) and the --since time
       // filter don't apply — reject them rather than silently ignoring them.
       const unsupported = (["deep", "memory", "verb", "since"] as const).filter(

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -10,6 +10,7 @@ import { runListen } from "../providers/tinycloud/listen.js";
 import { isCustomBinding, runBoundProvider, runExecProvider } from "../providers/run.js";
 import { execCapture, parseFirstJson } from "../providers/exec.js";
 import { tokenizeCommand } from "../providers/sources/index.js";
+import { resolveVideoArg } from "./media-ref.js";
 import {
   probe,
   enhance as ffEnhance,
@@ -54,6 +55,9 @@ export const listenVerb: VerbSpec = {
     if (!ctx.input) {
       return [errorRecord("listen", "listen requires an audio/video input")];
     }
+    const resolved = resolveVideoArg(ctx.case, ctx.input, "listen input", { requireReady: false });
+    if (resolved.error) return [errorRecord("listen", resolved.error)];
+    const input = resolved.ref ?? ctx.input;
     const describe = ctx.opts.describe === true;
     const binding = ctx.profile.providers?.listen;
     // forward the declared listen flags to a custom provider, and give it the
@@ -63,13 +67,13 @@ export const listenVerb: VerbSpec = {
     if (ctx.opts.diarize === true) extraArgs.push("--diarize");
     if (ctx.opts.lang) extraArgs.push("--lang", String(ctx.opts.lang));
     const rec = isCustomBinding(binding)
-      ? await runBoundProvider("listen", binding!, ctx.input, {
+      ? await runBoundProvider("listen", binding!, input, {
           env: providerEnv(ctx.case.mediaDir),
           extraArgs,
           timeoutMs: 15 * 60_000,
           signal: ctx.signal,
         })
-      : await runListen(ctx.input, {
+      : await runListen(input, {
           run: binding?.run,
           describe,
           signal: ctx.signal,

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -27,6 +27,8 @@ function err(verb: string, message: string): OvercastRecord {
 /** Minimum tinycloud the face + collection verbs need (`face match` landed in
  *  0.3.4). Older installs run watch/listen fine but lack faces/collections. */
 export const MIN_TINYCLOUD = "0.3.4";
+/** Latest tinycloud version this overcast build documents and recommends. */
+export const RECOMMENDED_TINYCLOUD = "0.3.6";
 
 function parseSemver(s: string): [number, number, number] | undefined {
   const m = s.match(/(\d+)\.(\d+)\.(\d+)/);
@@ -238,19 +240,21 @@ export const doctorVerb: VerbSpec = {
 
     // tinycloud CLI (default sense backend). Honor OVERCAST_TINYCLOUD_CMD so a
     // custom path/wrapper is the one actually checked. Parse the version to flag
-    // installs older than the face/collection minimum.
+    // installs older than the face/collection minimum and recommend the latest
+    // documented tinycloud build when an older-but-compatible CLI is present.
     const [tcCmd, ...tcLead] = tinycloudBase();
     const tc = await execCapture(tcCmd, [...tcLead, "--version"], { timeoutMs: 15_000 }).catch(() => ({ code: 1, stdout: "", stderr: "" }));
     const tcVer = parseSemver(`${tc.stdout} ${tc.stderr}`);
     const tcOld = tcVer ? semverLt(tcVer, parseSemver(MIN_TINYCLOUD)!) : false;
+    const tcBehind = tcVer ? semverLt(tcVer, parseSemver(RECOMMENDED_TINYCLOUD)!) : false;
     checks.push({
       name: "tinycloud",
       ok: tc.code === 0,
       detail:
         tc.code !== 0
-          ? "tinycloud CLI not on PATH (install: `npm i -g @cloudglue/tinycloud` or `tinycloud install --latest`)"
+          ? `tinycloud CLI not on PATH (install latest: \`npm i -g @cloudglue/tinycloud@${RECOMMENDED_TINYCLOUD}\` or \`tinycloud install --latest\`)`
           : tcVer
-            ? `${tcVer.join(".")}${tcOld ? ` (face/collection verbs need ≥ ${MIN_TINYCLOUD} — run \`tinycloud update\`)` : ""}`
+            ? `${tcVer.join(".")}${tcOld ? ` (face/collection verbs need ≥ ${MIN_TINYCLOUD} — run \`tinycloud update\`)` : tcBehind ? ` (update recommended: latest tested ${RECOMMENDED_TINYCLOUD}; run \`tinycloud update\`)` : ""}`
             : "CLI available",
     });
 
@@ -288,6 +292,8 @@ export const doctorVerb: VerbSpec = {
     }
     if (tcOld) {
       warnings.push(`tinycloud is older than ${MIN_TINYCLOUD} — the face + collection verbs need ≥ ${MIN_TINYCLOUD} (run \`tinycloud update\`)`);
+    } else if (tcBehind) {
+      warnings.push(`tinycloud ${tcVer?.join(".")} is older than the recommended ${RECOMMENDED_TINYCLOUD} — run \`tinycloud update\` to pick up the latest face validation and reliability behavior`);
     }
     if (!checks.find((c) => c.name === "cloudglue")?.ok) {
       warnings.push("no Cloudglue key — the default sense backend and the Cloudglue brain are unavailable");

--- a/test/unit/face-collection.test.ts
+++ b/test/unit/face-collection.test.ts
@@ -4,7 +4,7 @@
 
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -354,6 +354,41 @@ test("ask --collection rejects an invalid --limit instead of dropping it (#6)", 
   assert.match(rec.error ?? "", /--limit/);
 });
 
+test("ask --collection rejects --limit unless probing; probe forwards it", async () => {
+  const cdir = mkdtempSync(join(tmpdir(), "oc-asklimit-"));
+  const log = join(cdir, "argv.txt");
+  const fake = join(cdir, "tc.sh");
+  writeFileSync(
+    fake,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(log)}\necho '{"tinycloud":"1","kind":"'$1'","status":"ready","data":{"answer":"ok","citations":[]}}'\n`,
+  );
+  chmodSync(fake, 0o755);
+  const saved = process.env.OVERCAST_TINYCLOUD_CMD;
+  process.env.OVERCAST_TINYCLOUD_CMD = `bash ${fake}`;
+  try {
+    const c = openCase(cdir);
+    c.ensure();
+    const mk = (opts: VerbContext["opts"]): VerbContext => ({
+      input: "q?",
+      rest: [],
+      opts,
+      case: c,
+      profile: defaultProfile(),
+    });
+    const [bad] = await askVerb.run(mk({ collection: "col_x", limit: 3 }));
+    assert.equal(bad.state, "error");
+    assert.match(bad.error ?? "", /--limit with --collection only applies with --probe/);
+    await askVerb.run(mk({ collection: "col_x", probe: true, limit: 3 }));
+    const lines = readFileSync(log, "utf8").trim().split(/\n/);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /^probe q\? --in collection:col_x --limit 3 --json$/);
+  } finally {
+    if (saved === undefined) delete process.env.OVERCAST_TINYCLOUD_CMD;
+    else process.env.OVERCAST_TINYCLOUD_CMD = saved;
+    rmSync(cdir, { recursive: true, force: true });
+  }
+});
+
 test("collection add to an UNMIRRORED id records a stub + tracks the member (#2)", async () => {
   const cdir = mkdtempSync(join(tmpdir(), "oc-colmir-"));
   const video = join(cdir, "v.mp4");
@@ -687,7 +722,25 @@ test("face --match rejects a record id whose media isn't an image (#R7-2)", asyn
     c.writeRecord(watch);
     const [rec] = await faceVerb.run({ input: undefined, rest: [], opts: { match: watch.id, collection: "col_x" }, case: openCase(cdir), profile: defaultProfile() });
     assert.equal(rec.state, "error");
-    assert.match(rec.error ?? "", /isn't a face image/);
+    assert.match(rec.error ?? "", /JPEG or PNG/);
+  } finally { rmSync(cdir, { recursive: true, force: true }); }
+});
+
+test("face --match rejects unsupported query-image formats locally (tinycloud 0.3.6 gate)", async () => {
+  const cdir = mkdtempSync(join(tmpdir(), "oc-matchfmt-"));
+  const v = join(cdir, "clip.mp4"); writeFileSync(v, "x");
+  const webp = join(cdir, "suspect.webp"); writeFileSync(webp, "x");
+  try {
+    const [direct] = await faceVerb.run({ input: v, rest: [], opts: { match: webp }, case: openCase(cdir), profile: defaultProfile() });
+    assert.equal(direct.state, "error");
+    assert.match(direct.error ?? "", /JPEG or PNG/);
+
+    const c = openCase(cdir); c.ensure();
+    const imageRec = makeRecord({ verb: "capture", payload: {}, media: { ref: webp }, state: "ready" });
+    c.writeRecord(imageRec);
+    const [byRecord] = await faceVerb.run({ input: v, rest: [], opts: { match: imageRec.id }, case: openCase(cdir), profile: defaultProfile() });
+    assert.equal(byRecord.state, "error");
+    assert.match(byRecord.error ?? "", /JPEG or PNG/);
   } finally { rmSync(cdir, { recursive: true, force: true }); }
 });
 
@@ -798,6 +851,19 @@ test("doctor warns about missing tinycloud even when watch/listen are custom-bou
   } finally {
     if (saved === undefined) delete process.env.OVERCAST_TINYCLOUD_CMD;
     else process.env.OVERCAST_TINYCLOUD_CMD = saved;
+    rmSync(cdir, { recursive: true, force: true });
+  }
+});
+
+test("doctor warns when tinycloud is below the recommended version", async () => {
+  const cdir = mkdtempSync(join(tmpdir(), "oc-doctor-tcver-"));
+  try {
+    const c = openCase(cdir); c.ensure();
+    const [rec] = await doctorVerb.run({ input: undefined, rest: [], opts: {}, case: c, profile: defaultProfile(), home: cdir });
+    const warnings = (rec.payload as Record<string, unknown>).warnings as string[];
+    assert.equal(rec.state, "error");
+    assert.ok(warnings.some((w) => /recommended 0\.3\.6/.test(w) && /tinycloud update/.test(w)), `expected a tinycloud update warning; got ${JSON.stringify(warnings)}`);
+  } finally {
     rmSync(cdir, { recursive: true, force: true });
   }
 });
@@ -1235,7 +1301,7 @@ test("face --match record rejects an http video/page media.ref (#R14-4)", async 
     c.writeRecord(w);
     const [rec] = await faceVerb.run({ input: undefined, rest: [], opts: { match: w.id, collection: "col_x" }, case: openCase(cdir), profile: defaultProfile() });
     assert.equal(rec.state, "error");
-    assert.match(rec.error ?? "", /isn't a face image/);
+    assert.match(rec.error ?? "", /JPEG or PNG/);
   } finally { rmSync(cdir, { recursive: true, force: true }); }
 });
 

--- a/test/unit/senses.test.ts
+++ b/test/unit/senses.test.ts
@@ -150,6 +150,45 @@ test("listen --describe surfaces an audio-scene description (full describe mode)
 });
 function __dirname_compat() { return dirname(fileURLToPath(import.meta.url)); }
 
+test("listen preserves object-shaped tinycloud error envelope messages", async () => {
+  const { writeFileSync, chmodSync } = await import("node:fs");
+  const prov = join(dir, "listen-error-object.sh");
+  writeFileSync(
+    prov,
+    '#!/usr/bin/env bash\nprintf \'{"status":"error","data":null,"error":{"code":"upstream","message":"enable_visual_scene_description is not available for audio files"}}\\n\'\n',
+  );
+  chmodSync(prov, 0o755);
+  const rec = await runListen("clip.m4a", { run: `bash ${prov} {{input}}`, describe: true });
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /upstream: enable_visual_scene_description is not available for audio files/);
+});
+
+test("listen audio-only describe fallback does not mask a failed speech retry", async () => {
+  const { writeFileSync, chmodSync, mkdirSync } = await import("node:fs");
+  const bin = join(dir, "fake-tinycloud-bin");
+  mkdirSync(bin, { recursive: true });
+  const tinycloud = join(bin, "tinycloud");
+  writeFileSync(
+    tinycloud,
+    `#!/usr/bin/env bash
+if printf '%s\\n' "$@" | grep -q -- --speech-only; then
+  printf '{"status":"needs_credentials","error":{"code":"no_key","message":"set CLOUDGLUE_API_KEY"}}\\n'
+  exit 13
+fi
+printf '{"status":"error","data":null,"error":{"code":"upstream","message":"enable_visual_scene_description is not available for audio files"}}\\n'
+`,
+  );
+  chmodSync(tinycloud, 0o755);
+  const rec = await runListen("clip.m4a", {
+    describe: true,
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
+  });
+  assert.equal(rec.state, "needs_credentials");
+  assert.match(rec.error ?? "", /set CLOUDGLUE_API_KEY/);
+  assert.notEqual(rec.meta?.mode, "speech_fallback");
+  assert.equal("warning" in (rec.payload as Record<string, unknown>), false);
+});
+
 test("see forwards --ocr/--prompt to the bound provider (extraArgs)", async () => {
   const { writeFileSync, chmodSync } = await import("node:fs");
   const prov = join(dir, "see-args.sh");

--- a/test/unit/to-agent-tool.test.ts
+++ b/test/unit/to-agent-tool.test.ts
@@ -8,6 +8,7 @@ import { defaultProfile } from "../../src/profile.ts";
 import { makeRecord, type OvercastRecord } from "../../src/record.ts";
 import { toAgentTool, verbCallLine } from "../../src/registry/to-agent-tool.ts";
 import type { VerbSpec } from "../../src/registry/types.ts";
+import { caseVerb } from "../../src/verbs/case.ts";
 
 test("verbCallLine: class-colored ⟦ TAG ⟧ ▸ arg (semantic split + primary arg)", () => {
   const watch = { name: "watch", args: [{ name: "url" }] } as unknown as VerbSpec;
@@ -149,4 +150,24 @@ test("greedy budget: small records inline, the big one previews (mixed batch)", 
   assert.match(text, /SMALL-ANSWER-MARKER/); // small one fully inlined
   assert.doesNotMatch(text, /B{500}/); // big one previewed (not dumped)
   assert.match(text, /emitted 2 record\(s\)/);
+});
+
+test("case memory get tool schema forwards subcommand and record id", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-agent-case-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    const rec = makeRecord({ verb: "watch", payload: { content: "full text", transcript: "" }, media: { ref: "v.mp4" } });
+    c.writeRecord(rec);
+    const tool = toAgentTool(caseVerb, {
+      getCase: () => c,
+      getProfile: () => defaultProfile(),
+    });
+    const res = (await tool.execute("call_1", { action: "memory", sub: "get", arg: rec.id }, undefined as never)) as {
+      content: Array<{ type: string; text: string }>;
+    };
+    assert.match(res.content[0].text, new RegExp(`record: ${rec.id}`));
+    assert.doesNotMatch(res.content[0].text, /usage: case memory/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -1,9 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { runWatch } from "../../src/providers/tinycloud/watch.ts";
+import { openCase } from "../../src/case.ts";
+import { makeRecord } from "../../src/record.ts";
+import { defaultProfile } from "../../src/profile.ts";
+import { watchVerb } from "../../src/registry/verbs.ts";
+import { tmpdir } from "node:os";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FAKE = join(HERE, "..", "fixtures", "fake-watch.sh");
@@ -37,6 +42,58 @@ test("runWatch maps a real tinycloud envelope to the loose record (via fixture p
   // meta carries provider + extracted title/duration
   assert.equal(rec.meta?.provider, "tinycloud");
   assert.equal(rec.meta?.title, detailed.title);
+});
+
+test("runWatch fills transcript from tinycloud's speech.vtt sidecar", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchvtt-"));
+  try {
+    const vtt = join(dir, "speech.vtt");
+    writeFileSync(vtt, `WEBVTT
+
+1
+00:00:00.000 --> 00:00:01.000
+<v Bobby Lee>That's cool.</v>
+
+2
+00:00:01.000 --> 00:00:02.000
+<v Bobby Lee>That's amazing.</v>
+
+3
+00:00:02.000 --> 00:00:03.000
+<v Theo Von>Are there birth fears?</v>
+`);
+    const json = JSON.stringify({ status: "ready", data: { title: "clip", summary: "summary", transcript: "", describe: { vtt_path: vtt }, segments: [] } });
+    const script = join(dir, "watch.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    const p = rec.payload as Record<string, unknown>;
+    assert.match(String(p.transcript), /Bobby Lee: That's cool\. That's amazing\./);
+    assert.match(String(p.transcript), /Theo Von: Are there birth fears\?/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("watch resolves capture_id handles before dispatching to a provider", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchcap-"));
+  const media = join(dir, "clip.mp4");
+  try {
+    writeFileSync(media, "x");
+    const c = openCase(dir); c.ensure();
+    c.writeRecord(makeRecord({ verb: "capture", payload: { capture_id: "cap_clip.mp4" }, media: { ref: media }, state: "ready" }));
+    const script = join(dir, "provider.sh");
+    writeFileSync(script, '#!/usr/bin/env bash\nprintf \'{"verb":"watch","payload":{"input":"%s"},"media":{"ref":"%s"},"state":"ready"}\\n\' "$1" "$1"\n');
+    chmodSync(script, 0o755);
+    const p = defaultProfile();
+    p.providers = { ...p.providers, watch: { type: "exec", run: `bash ${script} {{input}}` } };
+    const [rec] = await watchVerb.run({ input: "cap_clip.mp4", rest: [], opts: {}, case: c, profile: p });
+    assert.equal(rec.state, "ready");
+    assert.equal((rec.payload as Record<string, unknown>).input, media);
+    assert.equal(rec.media?.ref, media);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("runWatch returns an error record when the provider emits no JSON", async () => {


### PR DESCRIPTION
## Summary

This PR aligns overcast with the latest tested tinycloud 0.3.6 behavior while keeping the existing 0.3.4 compatibility floor.

- Updates user-facing tinycloud guidance in setup/doctor output, README, provider docs, CLI env help, CLAUDE.md, and generated skills to recommend 0.3.6.
- Makes `doctor` warn/error when the installed default tinycloud is older than the recommended version, so users are prompted to update instead of seeing the update as merely optional.
- Mirrors tinycloud 0.3.6 face-query validation by rejecting unsupported `face --match` image formats locally; JPEG/PNG are accepted before spawning tinycloud.
- Surfaces tinycloud/Cloudglue reliability environment knobs in docs/help.
- Improves real tinycloud payload mapping:
  - `watch` resolves `cap_...` capture handles and record refs before dispatch.
  - `watch` fills `payload.transcript` from tinycloud WebVTT sidecars when inline transcript is missing or empty.
  - `listen` resolves media refs consistently with `watch`.
  - `listen --describe` preserves object-shaped tinycloud errors and falls back to speech-only only when the speech retry succeeds.
- Fixes agent/tool rough edges:
  - `case memory get <record-id>` is now represented correctly in the tool schema via a `sub` positional arg.
  - `ask --collection --limit` now errors unless `--probe` is set, matching tinycloud 0.3.6 (`ask` has no limit flag; `probe` does).

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- `npm run test:e2e -- phase4 phase4`
- Live/manual audit against `~/Downloads/test-videos` using real tinycloud/Cloudglue-backed calls:
  - `doctor`
  - `capture` + `watch` by `cap_...` handle
  - `listen` and `listen --describe` on audio
  - `face --limit 5`
  - `collection create/add`
  - `ask --collection`
  - `ask --collection --probe --limit 3`

## Notes

The Bobby/Theo sample showed tinycloud already emits speech in `describe.vtt_path`; the missing spoken-word transcript was an overcast mapping gap, not a required tinycloud output change. A tinycloud enhancement could still inline transcript in the watch JSON envelope for easier consumers, but overcast no longer depends on that.
