### PR TITLE
Document and test source search modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,9 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   index a target's videos into a tinycloud collection: media-descriptions →
   `ask --collection`, entities → `collection entities`, face-analysis → `face`);
   `target` / `source` manage scope; `prebrief` stands up a case in one shot.
+  Built-in source refs: `youtube:@handle`, `youtube:search:<query>`,
+  `youtube:playlist:<id>` or a YouTube URL; `tiktok:@user`, `tiktok:#tag`;
+  `web:<query>`.
 - **Read** — `ask` (cited retrieval over case memory; `--collection <id>` answers
   over a tinycloud media-descriptions collection, `--probe` for moment search),
   `brief` (timeline/findings report), `case` (inspect/manage the case + its records;

--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ authoring guide in [`docs/providers.md`](docs/providers.md).
 | **source** | scan / capture / monitor | youtube (yt-dlp), tiktok (Apify), web (Tavily/Brave) |
 | **memory** | ask / brief | local (always on); a tinycloud `collection` (media-descriptions) via `ask --collection` |
 
+Built-in source refs:
+
+- `youtube:@handle` — enumerate a channel's videos.
+- `youtube:search:<query>` or `youtube:<keyword>` — YouTube keyword search.
+- `youtube:playlist:<id>` or `youtube:<full YouTube URL>` — enumerate a playlist/video URL.
+- `tiktok:@user` — enumerate a TikTok profile.
+- `tiktok:#tag` — enumerate a TikTok hashtag.
+- `web:<query>` — web search through Tavily, falling back to Brave when Tavily is unset.
+
 ### Profiles
 
 A **profile** is a named set of bindings — per-verb providers plus the brain LLM —

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -108,9 +108,9 @@ overcast see ./clip.mp4  --detect "weapon, hard hat" --json      # video → fra
 ## Source providers (built-in types)
 
 `scan`/`monitor` enumerate sources; `capture` fetches. Built-in types resolve to shipped scripts:
-- **`youtube`** — yt-dlp (no key). `source add youtube:@handle` · `youtube:search:"…"` · `youtube:playlist:<id>`.
-- **`tiktok`** — Apify (`APIFY_TOKEN`). `source add tiktok:@user` · `tiktok:#tag`.
-- **`web`** — Tavily (`TAVILY_API_KEY`, preferred) or Brave (`BRAVE_API_KEY`). `source add web:"<query>"` → web search hits.
+- **`youtube`** — yt-dlp (no key). Supported refs: `youtube:@handle` for a channel's videos; `youtube:search:<query>` or `youtube:<keyword>` for keyword search; `youtube:playlist:<id>` or `youtube:<full YouTube URL>` for playlists/video URLs.
+- **`tiktok`** — Apify (`APIFY_TOKEN`). Supported refs: `tiktok:@user` for profile videos and `tiktok:#tag` for hashtag videos. TikTok keyword search is not a built-in mode.
+- **`web`** — Tavily (`TAVILY_API_KEY`, preferred) or Brave (`BRAVE_API_KEY`). Supported ref: `web:<query>` for web search hits.
 - Any type via `OVERCAST_SOURCE_<TYPE>_CMD="<base cmd>"` (the fixture/e2e mechanism).
 
 Each responds to `describe` offline:

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -52,6 +52,15 @@ overcast ask "every white van, with timestamps" --json
 overcast brief --export ./brief.html
 ```
 
+Built-in source refs for `source add <type>:<ref>`:
+
+- `youtube:@handle` — enumerate a channel's videos.
+- `youtube:search:<query>` or `youtube:<keyword>` — YouTube keyword search.
+- `youtube:playlist:<id>` or `youtube:<full YouTube URL>` — enumerate a playlist/video URL.
+- `tiktok:@user` — enumerate a TikTok profile.
+- `tiktok:#tag` — enumerate a TikTok hashtag.
+- `web:<query>` — web search through Tavily, falling back to Brave when Tavily is unset.
+
 `overcast commands --json` dumps the authoritative verb registry. Full man
 pages are in [reference/verbs.md](reference/verbs.md) (progressive disclosure —
 read it when you need a verb's exact flags).

--- a/src/providers/sources/index.ts
+++ b/src/providers/sources/index.ts
@@ -3,8 +3,8 @@
 // `fetch(item) -> capture media`. Same exec wire contract as sense providers;
 // output is mapped to the loose record at THIS boundary.
 //
-// Built-in descriptors: youtube (yt-dlp), tiktok (Apify). Any type can be
-// overridden/added via env `OVERCAST_SOURCE_<TYPE>_CMD=<base command>` — the
+// Built-in descriptors: youtube (yt-dlp), tiktok (Apify), web (Tavily/Brave).
+// Any type can be overridden/added via env `OVERCAST_SOURCE_<TYPE>_CMD=<base command>` — the
 // base command is invoked as `<base> enumerate ...` / `<base> fetch ...`. This
 // is how the e2e binds a committed fixture source provider offline.
 
@@ -28,7 +28,7 @@ export interface SourceDescriptor {
   needs?: string;
 }
 
-/** Built-in source descriptors. yt-dlp / apify are gated by deps/creds. */
+/** Built-in source descriptors. yt-dlp / Apify / web search are gated by deps/creds. */
 /**
  * Tokenize a command string respecting single/double quotes, so a base command
  * whose path contains spaces can be bound (e.g. `"/My Tools/bridge" enumerate`).

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -91,6 +91,15 @@ overcast ask "every white van, with timestamps" --json
 overcast brief --export ./brief.html
 \`\`\`
 
+Built-in source refs for \`source add <type>:<ref>\`:
+
+- \`youtube:@handle\` — enumerate a channel's videos.
+- \`youtube:search:<query>\` or \`youtube:<keyword>\` — YouTube keyword search.
+- \`youtube:playlist:<id>\` or \`youtube:<full YouTube URL>\` — enumerate a playlist/video URL.
+- \`tiktok:@user\` — enumerate a TikTok profile.
+- \`tiktok:#tag\` — enumerate a TikTok hashtag.
+- \`web:<query>\` — web search through Tavily, falling back to Brave when Tavily is unset.
+
 \`overcast commands --json\` dumps the authoritative verb registry. Full man
 pages are in [reference/verbs.md](reference/verbs.md) (progressive disclosure —
 read it when you need a verb's exact flags).

--- a/test/e2e/live/cases/20_sources.sh
+++ b/test/e2e/live/cases/20_sources.sh
@@ -6,48 +6,73 @@ LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; source "$LIVE/lib.sh"
 C=source
 SRCDIR="$PWD/examples/providers/sources"
 
+assert_scan_hits() {
+  local id="$1" out="$2" label="$3"
+  local hits url title err
+  hits="$(echo "$out" | jq -s '[.[]|select(.state=="ready" and .verb=="scan" and (.payload.url // "") != "")]|length' 2>/dev/null)"
+  url="$(echo "$out" | jq -s -r '[.[]|select(.state=="ready" and .verb=="scan" and (.payload.url // "") != "")][0].payload.url // empty' 2>/dev/null)"
+  title="$(echo "$out" | jq -s -r '[.[]|select(.state=="ready" and .verb=="scan" and (.payload.title // "") != "")][0].payload.title // empty' 2>/dev/null)"
+  if [ "${hits:-0}" -ge 1 ]; then
+    ok "$id" "$label returned $hits hit(s): ${title:-$url}"
+    assert_nonempty "$id.url" "$url" "$label first hit has a url"
+  else
+    err="$(echo "$out" | jq -s -r '[.[]|select(.state=="error" or .state=="needs_credentials")][0].error // "no hits"' 2>/dev/null)"
+    fail "$id" "$label returned no usable hits ($err)"
+  fi
+}
+
 # --- web (Tavily) ---
 if require_cred "$C.web" TAVILY_API_KEY "skipping web search"; then
   CASE=$(case_dir src_web)
   export OVERCAST_SOURCE_WEB_CMD="bash $SRCDIR/web.sh"
-  ocrun "$CASE" source add 'web:overcast pi agent' --json >/dev/null 2>&1
-  out="$(OC_TIMEOUT=120 oc "$CASE" scan --source web --query "open source AI agent" --limit 3 --json)"
+  ocrun "$CASE" source add 'web:overcast weather app' --json >/dev/null 2>&1
+  out="$(OC_TIMEOUT=120 oc "$CASE" scan --source web --limit 3 --json)"
   save_json "20_scan_web" "$out" >/dev/null
-  hits="$(echo "$out" | jq -s '[.[]|select(.state!="error" and .verb=="scan")]|length' 2>/dev/null)"
-  if [ "${hits:-0}" -ge 1 ]; then
-    ok "$C.web.hits" "web search returned $hits hits"
-    assert_nonempty "$C.web.url" "$(echo "$out"|jq -s -r '[.[]|select(.payload.url!="")][0].payload.url // empty')" "first hit has a url"
-  else
-    err="$(echo "$out" | jq -s -r '[.[]|select(.state=="error")][0].error // "no hits"' 2>/dev/null)"
-    fail "$C.web.hits" "no web hits ($err)"
-  fi
+  assert_scan_hits "$C.web.query" "$out" "web query"
   unset OVERCAST_SOURCE_WEB_CMD
 fi
 
-# --- tiktok (Apify) — enumerate; small limit to keep cost low ---
+# --- tiktok (Apify) — profile + hashtag; small limits to keep cost low ---
 if require_cred "$C.tiktok" APIFY_TOKEN "skipping tiktok"; then
-  CASE=$(case_dir src_tiktok)
   export OVERCAST_SOURCE_TIKTOK_CMD="bash $SRCDIR/tiktok.sh"
-  ocrun "$CASE" source add 'tiktok:@nasa' --json >/dev/null 2>&1
+
+  CASE=$(case_dir src_tiktok_user)
+  ocrun "$CASE" source add 'tiktok:@chefreactions' --json >/dev/null 2>&1
   out="$(OC_TIMEOUT=180 oc "$CASE" scan --source tiktok --limit 2 --json)"
-  save_json "20_scan_tiktok" "$out" >/dev/null
-  recs="$(echo "$out" | jq -s 'length' 2>/dev/null)"
-  st="$(echo "$out" | jq -s -r '[.[]|select(.verb=="scan")][0].state // "none"' 2>/dev/null)"
-  # Apify can be slow/empty; assert the scan ran and produced a record (hit or a
-  # clean error), not that it found content — keep it tolerant but real.
-  if [ "${recs:-0}" -ge 1 ]; then ok "$C.tiktok.ran" "tiktok scan ran ($recs record(s), first state=$st)"; else fail "$C.tiktok.ran" "no records"; fi
+  save_json "20_scan_tiktok_user" "$out" >/dev/null
+  assert_scan_hits "$C.tiktok.user" "$out" "tiktok profile"
+
+  CASE=$(case_dir src_tiktok_tag)
+  ocrun "$CASE" source add 'tiktok:#space' --json >/dev/null 2>&1
+  out="$(OC_TIMEOUT=180 oc "$CASE" scan --source tiktok --limit 2 --json)"
+  save_json "20_scan_tiktok_tag" "$out" >/dev/null
+  assert_scan_hits "$C.tiktok.tag" "$out" "tiktok hashtag"
+
   unset OVERCAST_SOURCE_TIKTOK_CMD
 fi
 
-# --- youtube (yt-dlp) — gated on yt-dlp ---
+# --- youtube (yt-dlp) — channel + playlist URL + keyword search ---
 if have_cmd yt-dlp; then
-  CASE=$(case_dir src_youtube)
   export OVERCAST_SOURCE_YOUTUBE_CMD="bash $SRCDIR/youtube.sh"
-  ocrun "$CASE" source add 'youtube:search:nasa' --json >/dev/null 2>&1
+
+  CASE=$(case_dir src_youtube_handle)
+  ocrun "$CASE" source add 'youtube:@aiDotEngineer' --json >/dev/null 2>&1
   out="$(OC_TIMEOUT=120 oc "$CASE" scan --source youtube --limit 2 --json)"
-  save_json "20_scan_youtube" "$out" >/dev/null
-  hits="$(echo "$out" | jq -s '[.[]|select(.state!="error" and .verb=="scan")]|length' 2>/dev/null)"
-  [ "${hits:-0}" -ge 1 ] && ok "$C.youtube.hits" "youtube returned $hits hits" || fail "$C.youtube.hits" "no hits"
+  save_json "20_scan_youtube_handle" "$out" >/dev/null
+  assert_scan_hits "$C.youtube.handle" "$out" "youtube handle"
+
+  CASE=$(case_dir src_youtube_playlist)
+  ocrun "$CASE" source add 'youtube:https://www.youtube.com/watch?v=jWy39wavbjY&list=PLfaIDFEXuae2uJrYpdMZz_HbFfCfYIlVR' --json >/dev/null 2>&1
+  out="$(OC_TIMEOUT=120 oc "$CASE" scan --source youtube --limit 2 --json)"
+  save_json "20_scan_youtube_playlist" "$out" >/dev/null
+  assert_scan_hits "$C.youtube.playlist" "$out" "youtube playlist URL"
+
+  CASE=$(case_dir src_youtube_search)
+  ocrun "$CASE" source add 'youtube:search:baseball' --json >/dev/null 2>&1
+  out="$(OC_TIMEOUT=120 oc "$CASE" scan --source youtube --limit 2 --json)"
+  save_json "20_scan_youtube_search" "$out" >/dev/null
+  assert_scan_hits "$C.youtube.search" "$out" "youtube keyword search"
+
   unset OVERCAST_SOURCE_YOUTUBE_CMD
 else
   skip "$C.youtube" "yt-dlp not installed"

--- a/test/unit/osint-state.test.ts
+++ b/test/unit/osint-state.test.ts
@@ -105,10 +105,16 @@ test("tokenizeCommand respects quotes (spaced command paths)", () => {
 
 import { builtinDescriptor } from "../../src/providers/sources/index.ts";
 
-test("builtinDescriptor resolves youtube/tiktok to shipped scripts; env override wins", () => {
+test("builtinDescriptor resolves built-in source scripts; env override wins", () => {
   const yt = builtinDescriptor("youtube");
+  const tt = builtinDescriptor("tiktok");
+  const web = builtinDescriptor("web");
   assert.ok(yt, "youtube descriptor present in dev");
+  assert.ok(tt, "tiktok descriptor present in dev");
+  assert.ok(web, "web descriptor present in dev");
   assert.match(yt!.base.join(" "), /youtube\.sh$/);
+  assert.match(tt!.base.join(" "), /tiktok\.sh$/);
+  assert.match(web!.base.join(" "), /web\.sh$/);
   assert.equal(builtinDescriptor("nope"), undefined);
   // env override takes precedence and is quote-aware
   process.env.OVERCAST_SOURCE_YOUTUBE_CMD = 'bash "/x y/z.sh"';


### PR DESCRIPTION
## Summary
- Document the built-in source search refs for YouTube, TikTok, and web.
- Clarify that TikTok supports profile and hashtag refs, not keyword search.
- Expand live source e2e coverage across web query, TikTok profile/hashtag, and YouTube handle/playlist/search modes.
- Assert all built-in source descriptors resolve to shipped scripts.

## Validation
- `bash -n test/e2e/live/cases/20_sources.sh`
- `node --test --import tsx test/unit/osint-state.test.ts`
- Live source case with `.env` loaded: all 12 source-mode assertions passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, test assertions, and comments only; no scan/source runtime logic was modified.
> 
> **Overview**
> This PR **documents** the supported `source add <type>:<ref>` patterns for **youtube**, **tiktok**, and **web** in `CLAUDE.md`, `README.md`, `docs/providers.md`, `skills/overcast/SKILL.md`, and the `generateFlagshipSkill()` template in `src/skill-gen.ts`. The provider guide now spells out each ref shape (e.g. `youtube:@handle`, `youtube:search:<query>`, playlist/URL forms) and notes that **TikTok keyword search is not a built-in mode**—only `@user` and `#tag`.
> 
> **Live e2e** (`test/e2e/live/cases/20_sources.sh`) gains a shared **`assert_scan_hits`** helper that requires at least one **`ready`** scan record with a non-empty **`payload.url`**, replacing looser checks (including the old tolerant TikTok “scan ran” assertion). Coverage expands to web query-from-ref, TikTok profile + hashtag, and YouTube channel handle, playlist URL, and keyword search—each in its own case dir.
> 
> **Unit tests** now assert `builtinDescriptor` resolves **youtube**, **tiktok**, and **web** to the shipped `*.sh` scripts (env override behavior unchanged). Source provider comments in `index.ts` were updated to mention web alongside youtube/tiktok; no functional code changes there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47d0d6e579a91df48646a368db63ad9aa2bd525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->