### PR TITLE
Add case clear confirmation flow

### DIFF
--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -33,7 +33,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `prebrief` — Stand up a case: name + target + source in one shot (non-interactive via flags).
 - `ask` — Natural-language query over the case memory; answers with record.id + media.at citations.
 - `brief` — Synthesize the case records into a report (timeline + findings); --export to md/html.
-- `case` — Inspect/manage the current case: init | info | records | memory.
+- `case` — Inspect/manage the current case: init | info | records | memory | clear.
 - `setup` — Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|show).
 - `provider` — Run a provider's init hook, or list/describe bound providers (provider init|list|describe).
 - `doctor` — Preflight: check pi version, ffmpeg/ffprobe, Cloudglue creds, tinycloud, provider bindings.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -368,17 +368,17 @@ Emits `source` records.
 
 ### `overcast case`
 
-A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search> [q]` routes to the bound memory providers. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
+A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
 
 ```
 overcast case <action> [sub] [arg] [options]
 
-  Inspect/manage the current case: init | info | records | memory.
+  Inspect/manage the current case: init | info | records | memory | clear.
 
-  A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search> [q]` routes to the bound memory providers. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
+  A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
 
 Arguments:
-  action           init | info | records | memory
+  action           init | info | records | memory | clear
   sub              memory subcommand (list|get|search), or dir for init
   arg              record id (memory get) or query (memory search)
 
@@ -389,6 +389,7 @@ Options:
   --field <string>       Payload field to read in full (memory get)
   --offset <number>      Start char offset when paging a field (memory get)
   --limit <number>       Max records/passages, or max chars when paging a field
+  --yes                  Confirm destructive case clear
   --json                 JSON output
   --format <string>      json | md | txt
 ```

--- a/src/case.ts
+++ b/src/case.ts
@@ -4,10 +4,12 @@
 
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   writeFileSync,
   readdirSync,
+  rmSync,
 } from "node:fs";
 import { join, basename, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -25,6 +27,22 @@ export interface CaseInfo {
   created: string;
   /** optional profile pin (profile name) */
   profile?: string;
+}
+
+export interface CaseStoreEntrySummary {
+  files: number;
+  bytes: number;
+}
+
+export interface CaseClearSummary {
+  dir: string;
+  initialized: boolean;
+  info: CaseInfo | null;
+  records: number;
+  counts: Record<string, number>;
+  media: CaseStoreEntrySummary;
+  index: CaseStoreEntrySummary;
+  stateFiles: string[];
 }
 
 /** A case is a directory; this wraps its `.overcast/` store paths + I/O. */
@@ -123,6 +141,43 @@ export class Case {
   recordById(id: string): OvercastRecord | undefined {
     return this.records().find((r) => r.id === id);
   }
+
+  /** Summarize resettable case contents without mutating the store. */
+  clearSummary(): CaseClearSummary {
+    const recs = this.records();
+    const counts: Record<string, number> = {};
+    for (const r of recs) counts[r.verb] = (counts[r.verb] ?? 0) + 1;
+    return {
+      dir: this.dir,
+      initialized: this.exists(),
+      info: this.exists() ? this.info() : null,
+      records: recs.length,
+      counts,
+      media: summarizeTree(this.mediaDir),
+      index: summarizeTree(this.indexDir),
+      stateFiles: [
+        this.targetFile,
+        this.sourcesFile,
+        this.collectionsFile,
+        this.seenFile,
+      ].filter(existsSync).map((f) => basename(f)),
+    };
+  }
+
+  /** Clear records/media/index/state while preserving case.json and the case id. */
+  clear(): CaseClearSummary {
+    const summary = this.clearSummary();
+    rmSync(this.recordsDir, { recursive: true, force: true });
+    rmSync(this.mediaDir, { recursive: true, force: true });
+    rmSync(this.indexDir, { recursive: true, force: true });
+    rmSync(this.targetFile, { force: true });
+    rmSync(this.sourcesFile, { force: true });
+    rmSync(this.collectionsFile, { force: true });
+    rmSync(this.seenFile, { force: true });
+    mkdirSync(this.recordsDir, { recursive: true });
+    mkdirSync(this.mediaDir, { recursive: true });
+    return summary;
+  }
 }
 
 /** Open the case rooted at `dir` (default cwd). Does not create the store. */
@@ -134,4 +189,23 @@ export function openCase(dir: string = process.cwd()): Case {
 export function recordFiles(c: Case): string[] {
   if (!existsSync(c.recordsDir)) return [];
   return readdirSync(c.recordsDir).filter((f) => f.endsWith(".jsonl"));
+}
+
+function summarizeTree(path: string): CaseStoreEntrySummary {
+  let files = 0;
+  let bytes = 0;
+  const visit = (p: string) => {
+    if (!existsSync(p)) return;
+    const st = lstatSync(p);
+    if (st.isDirectory()) {
+      for (const name of readdirSync(p)) visit(join(p, name));
+      return;
+    }
+    if (st.isFile()) {
+      files++;
+      bytes += st.size;
+    }
+  };
+  visit(path);
+  return { files, bytes };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -327,7 +327,9 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 
     // persist into the active case, but skip a record explicitly tagged for a
     // different case (e.g. `case init <other-dir>` already wrote it there).
+    // Transient records are user-facing control results, not case history.
     for (const rec of records) {
+      if (rec.meta?.transient === true) continue;
       if (rec.meta?.case && rec.meta.case !== c.dir) continue;
       c.writeRecord(rec);
     }

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -262,8 +262,10 @@ export function toAgentTool(spec: VerbSpec, deps: ToolDeps): ToolDefinition {
       }
 
       // skip a record explicitly tagged for a different case (already persisted
-      // there) — e.g. `case init <other-dir>`.
+      // there) — e.g. `case init <other-dir>`. Transient records are user-facing
+      // control results, not case history.
       for (const rec of records) {
+        if (rec.meta?.transient === true) continue;
         if (rec.meta?.case && rec.meta.case !== c.dir) continue;
         c.writeRecord(rec);
       }

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -1,9 +1,10 @@
 // `case` verb — inspect/manage the current case (the .overcast/ store). Case is
 // a folder (invariant #4); this is the read/seed surface over it + the bound
-// memory providers. Subcommands: init | info | records | memory.
+// memory providers. Subcommands: init | info | records | memory | clear.
 
 import { makeRecord, type OvercastRecord } from "../record.js";
 import { openCase } from "../case.js";
+import { humanSize } from "../render.js";
 import { resolveMemory } from "../providers/memory/index.js";
 import { parseSince } from "../providers/memory/local.js";
 import { payloadFields, fieldText, fieldNames, getField } from "../render.js";
@@ -16,15 +17,16 @@ function err(message: string): OvercastRecord {
 export const caseVerb: VerbSpec = {
   name: "case",
   group: "state",
-  summary: "Inspect/manage the current case: init | info | records | memory.",
+  summary: "Inspect/manage the current case: init | info | records | memory | clear.",
   description:
     "A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; " +
     "`case info` shows state; `case records [--verb] [--since]` lists records; " +
     "`case memory <list|get|search> [q]` routes to the bound memory providers. " +
+    "`case clear` previews what would be lost; add `--yes` to clear records/media/state while preserving the case id. " +
     "`case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] " +
     "[--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.",
   args: [
-    { name: "action", summary: "init | info | records | memory", required: true },
+    { name: "action", summary: "init | info | records | memory | clear", required: true },
     { name: "sub", summary: "memory subcommand (list|get|search), or dir for init" },
     { name: "arg", summary: "record id (memory get) or query (memory search)" },
   ],
@@ -35,6 +37,7 @@ export const caseVerb: VerbSpec = {
     { name: "field", summary: "Payload field to read in full (memory get)", type: "string" },
     { name: "offset", summary: "Start char offset when paging a field (memory get)", type: "number" },
     { name: "limit", summary: "Max records/passages, or max chars when paging a field", type: "number" },
+    { name: "yes", summary: "Confirm destructive case clear", type: "boolean" },
     { name: "json", summary: "JSON output", type: "boolean" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
   ],
@@ -81,6 +84,55 @@ export const caseVerb: VerbSpec = {
           verb: "case",
           format: "json",
           payload: { dir: c.dir, initialized: exists, info: exists ? c.info() : null, records: recs.length, counts },
+          state: "ready",
+        }),
+      ];
+    }
+
+    if (action === "clear") {
+      const confirmed = ctx.opts.yes === true;
+      const before = confirmed ? ctx.case.clear() : ctx.case.clearSummary();
+      const lost = {
+        records: before.records,
+        counts: before.counts,
+        media_files: before.media.files,
+        media_size: humanSize(before.media.bytes),
+        index_files: before.index.files,
+        index_size: humanSize(before.index.bytes),
+        state_files: before.stateFiles,
+      };
+      if (!confirmed) {
+        return [
+          makeRecord({
+            verb: "case",
+            format: "json",
+            payload: {
+              dir: before.dir,
+              initialized: before.initialized,
+              info: before.info,
+              will_lose: lost,
+              confirmation_required: true,
+              confirm_with: "overcast case clear --yes",
+              note: "case id/name are preserved; records, media, index, targets, sources, collections, and seen state are cleared",
+            },
+            meta: { transient: true },
+            state: "pending",
+          }),
+        ];
+      }
+      return [
+        makeRecord({
+          verb: "case",
+          format: "json",
+          payload: {
+            dir: before.dir,
+            initialized: before.initialized,
+            info: before.info,
+            cleared: true,
+            lost,
+            preserved: ["case.json"],
+          },
+          meta: { transient: true },
           state: "ready",
         }),
       ];
@@ -235,6 +287,6 @@ export const caseVerb: VerbSpec = {
       return [err("usage: case memory <list|get|search> [arg]")];
     }
 
-    return [err("usage: case <init|info|records|memory>")];
+    return [err("usage: case <init|info|records|memory|clear>")];
   },
 };

--- a/test/e2e/cases/phase4_caseclear.sh
+++ b/test/e2e/cases/phase4_caseclear.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Phase 4 e2e: clearing a case is a two-step reset. A dry run summarizes what
+# would be lost and does not mutate the store; --yes clears resettable state
+# without writing a new case-history record.
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="$(cd "$DIR/../.." && pwd)"
+# shellcheck source=../lib.sh
+source "$DIR/lib.sh"
+
+casedir="$SMOKE_DIR/case_clear"; mkdir -p "$casedir"
+RID="rec_clear0001"
+
+record_lines() {
+  find "$casedir/.overcast/records" -name '*.jsonl' -type f -exec cat {} + 2>/dev/null | wc -l | tr -d ' '
+}
+
+node --import tsx -e "
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { openCase } from '$REPO/src/case.ts';
+import { makeRecord } from '$REPO/src/record.ts';
+const c = openCase('$casedir'); c.ensure();
+c.writeRecord(makeRecord({ id: '$RID', verb: 'watch', payload: { content: 'clear me' }, media: { ref: 'clip.mp4' } }));
+writeFileSync(c.sourcesFile, JSON.stringify({ sources: [{ id: 'src_1', type: 'fixture' }] }));
+writeFileSync(c.targetFile, JSON.stringify({ targets: [{ id: 'target_1', name: 'pier' }] }));
+writeFileSync(join(c.mediaDir, 'clip.txt'), 'media');
+mkdirSync(c.indexDir, { recursive: true });
+writeFileSync(join(c.indexDir, 'idx.txt'), 'index');
+" 2>"$SMOKE_DIR/phase4_caseclear_seed.err"
+
+preview="$($OVERCAST case clear --json --case "$casedir" 2>/dev/null)"
+save_json "phase4_caseclear_preview" "$preview" >/dev/null
+assert_eq "clear.preview_state" "pending" "$(jq -r '.state' <<<"$preview")" "dry run requires confirmation"
+assert_eq "clear.preview_records" "1" "$(jq -r '.payload.will_lose.records' <<<"$preview")" "dry run reports one record"
+assert_eq "clear.preview_confirm" "true" "$(jq -r '.payload.confirmation_required' <<<"$preview")" "dry run reports confirmation requirement"
+
+assert_eq "clear.preview_preserves_records" "1" "$(record_lines)" "dry run leaves records intact"
+if [ -f "$casedir/.overcast/sources.json" ]; then
+  ok "clear.preview_preserves_state" "dry run leaves state files intact"
+else
+  fail "clear.preview_preserves_state" "sources.json was removed"
+fi
+
+confirmed="$($OVERCAST case clear --yes --json --case "$casedir" 2>/dev/null)"
+save_json "phase4_caseclear_confirmed" "$confirmed" >/dev/null
+assert_eq "clear.confirmed" "true" "$(jq -r '.payload.cleared' <<<"$confirmed")" "--yes clears the case"
+assert_eq "clear.confirmed_lost_records" "1" "$(jq -r '.payload.lost.records' <<<"$confirmed")" "--yes reports lost record count"
+
+assert_eq "clear.records_empty" "0" "$(record_lines)" "records are empty after clear"
+assert_eq "clear.case_preserved" "true" "$([ -f "$casedir/.overcast/case.json" ] && echo true || echo false)" "case remains initialized"
+
+if [ ! -f "$casedir/.overcast/sources.json" ]; then
+  ok "clear.state_removed" "state file removed"
+else
+  fail "clear.state_removed" "sources.json still exists"
+fi
+if [ ! -f "$casedir/.overcast/media/clip.txt" ]; then
+  ok "clear.media_removed" "media file removed"
+else
+  fail "clear.media_removed" "media file still exists"
+fi
+if [ ! -d "$casedir/.overcast/index" ]; then
+  ok "clear.index_removed" "index directory removed"
+else
+  fail "clear.index_removed" "index directory still exists"
+fi

--- a/test/unit/case-verb.test.ts
+++ b/test/unit/case-verb.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openCase } from "../../src/case.ts";
@@ -33,6 +33,40 @@ test("case records --verb filters", async () => {
     assert.equal(recs.length, 1);
   });
 });
+
+test("case clear previews what will be lost and requires --yes", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    writeFileSync(c.sourcesFile, JSON.stringify({ sources: [] }));
+
+    const [rec] = await caseVerb.run(ctx(dir, "clear"));
+    assert.equal(rec.state, "pending");
+    assert.equal(rec.meta?.transient, true);
+    const p = rec.payload as Record<string, unknown>;
+    assert.equal(p.confirmation_required, true);
+    assert.match(String(p.confirm_with), /case clear --yes/);
+    assert.equal(((p.will_lose as Record<string, unknown>).records), 2);
+    assert.equal(c.records().length, 2, "preview leaves records intact");
+    assert.equal(existsSync(c.sourcesFile), true, "preview leaves state intact");
+  });
+});
+
+test("case clear --yes clears records and state without persisting itself", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    writeFileSync(c.sourcesFile, JSON.stringify({ sources: [] }));
+
+    const [rec] = await caseVerb.run(ctx(dir, "clear", [], { yes: true }));
+    assert.equal(rec.state, "ready");
+    assert.equal(rec.meta?.transient, true);
+    const p = rec.payload as Record<string, unknown>;
+    assert.equal(p.cleared, true);
+    assert.equal(((p.lost as Record<string, unknown>).records), 2);
+    assert.equal(c.records().length, 0);
+    assert.equal(existsSync(c.sourcesFile), false);
+  });
+});
+
 test("case memory search returns passages", async () => {
   await withCase(async (dir) => {
     const [rec] = await caseVerb.run(ctx(dir, "memory", ["search", "white", "van"]));

--- a/test/unit/case.test.ts
+++ b/test/unit/case.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openCase, recordFiles } from "../../src/case.ts";
@@ -42,5 +42,47 @@ test("writeRecord persists per-verb JSONL and records() reads them back", () => 
     assert.equal(all.length, 1);
     assert.equal(all[0].id, r.id);
     assert.equal(c.recordById(r.id)?.payload && (c.recordById(r.id)!.payload as Record<string, unknown>).content, "hi");
+  });
+});
+
+test("clearSummary reports resettable records, media, index, and state files", () => {
+  withTmp((dir) => {
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "hi" }, media: { ref: "x.mp4" } }));
+    mkdirSync(c.indexDir, { recursive: true });
+    writeFileSync(join(c.mediaDir, "clip.txt"), "media");
+    writeFileSync(join(c.indexDir, "idx.txt"), "index");
+    writeFileSync(c.sourcesFile, JSON.stringify({ sources: [] }));
+
+    const summary = c.clearSummary();
+    assert.equal(summary.records, 1);
+    assert.deepEqual(summary.counts, { watch: 1 });
+    assert.equal(summary.media.files, 1);
+    assert.equal(summary.media.bytes, 5);
+    assert.equal(summary.index.files, 1);
+    assert.deepEqual(summary.stateFiles, ["sources.json"]);
+    assert.equal(c.records().length, 1, "summary does not mutate the case");
+  });
+});
+
+test("clear removes records/media/index/state while preserving case.json", () => {
+  withTmp((dir) => {
+    const c = openCase(dir);
+    const info = c.ensure();
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "hi" }, media: { ref: "x.mp4" } }));
+    mkdirSync(c.indexDir, { recursive: true });
+    writeFileSync(join(c.mediaDir, "clip.txt"), "media");
+    writeFileSync(join(c.indexDir, "idx.txt"), "index");
+    writeFileSync(c.targetFile, JSON.stringify({ targets: [] }));
+
+    const before = c.clear();
+    assert.equal(before.records, 1);
+    assert.ok(existsSync(c.caseFile));
+    assert.equal(openCase(dir).info().id, info.id);
+    assert.equal(c.records().length, 0);
+    assert.equal(existsSync(join(c.mediaDir, "clip.txt")), false);
+    assert.equal(existsSync(c.indexDir), false);
+    assert.equal(existsSync(c.targetFile), false);
   });
 });

--- a/test/unit/cli-parse.test.ts
+++ b/test/unit/cli-parse.test.ts
@@ -1,8 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { parseVerbArgs } from "../../src/registry/to-cli.ts";
 import { runCli, type CliIO } from "../../src/cli.ts";
 import { watchVerb } from "../../src/registry/verbs.ts";
+import { openCase } from "../../src/case.ts";
+import { makeRecord } from "../../src/record.ts";
 
 function capture(): { io: CliIO; out: () => string; err: () => string } {
   let o = "";
@@ -44,4 +49,20 @@ test("runCli: commands --json lists watch (offline, no cloud)", async () => {
   assert.equal(code, 0);
   const parsed = JSON.parse(c.out());
   assert.ok(parsed.verbs.some((v: { name: string }) => v.name === "watch"));
+});
+
+test("runCli: case clear --yes does not leave a new case record behind", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-cli-clear-"));
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "hi" } }));
+    const cap = capture();
+    const code = await runCli(["case", "clear", "--yes", "--case", dir, "--json"], cap.io);
+    assert.equal(code, 0);
+    assert.equal(openCase(dir).records().length, 0);
+    assert.equal(JSON.parse(cap.out()).payload.cleared, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- add `overcast case clear` dry-run output that summarizes records, media, index, and state that would be removed
- require `--yes` for destructive clearing while preserving `case.json`
- keep clear preview/results transient so reset operations do not add case-history records
- update generated skill reference and add focused tests

## Tests
- `npm test -- --test-name-pattern=clear`
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive filesystem deletes on the case store; mitigated by default dry-run and `--yes` confirmation, with identity preserved via `case.json`.
> 
> **Overview**
> Adds **`overcast case clear`**, a guarded reset for an investigation case without re-init.
> 
> Without **`--yes`**, the command is a **dry run**: it reports record counts (by verb), media/index size, and state files that would be removed, returns **`pending`**, and leaves the store unchanged. With **`--yes`**, it deletes records, media, index, and state files (`target`, `sources`, `collections`, `seen`) while **keeping `case.json` and the case id**.
> 
> Clear preview and completion responses are tagged **`meta.transient`**, so the CLI and agent tool still print them but **do not append them to case history**—a reset does not leave a `case` record in the timeline.
> 
> Skill docs and verb reference document the new subcommand and **`--yes`** flag. Unit, CLI, and e2e tests cover preview vs confirm behavior and transient persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e38748b96494ac2e6474a803ea61fb8755d409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->