### PR TITLE
Add human note verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,19 @@ overcast scan --pull --json            # enumerate sources → capture → sense
 overcast ask "every white van, with timestamps" --json
 overcast brief --export ./brief.html
 
-# 4) faces: detect, or find a specific person in a clip
+# 4) add a human observation anchored to evidence
+overcast note "rear plate is missing" --ref <watch-record-id> --at 12-18 --tag vehicle --json
+
+# 5) faces: detect, or find a specific person in a clip
 overcast face ./clip.mp4 --json                       # who is in this video
 overcast face ./clip.mp4 --match ./suspect.jpg --json # find this person (JPEG/PNG query image), ranked by similarity
 
-# 5) index the target's videos into a collection, then search across ALL of them
+# 6) index the target's videos into a collection, then search across ALL of them
 overcast collection create faces --type face --json
 overcast collection add --all --to <face-col-id> --json   # register every captured/sensed video
 overcast face --match ./suspect.jpg --collection <face-col-id> --json   # find them across the index
 
-# 6) launch the interactive agent (pi TUI) in the current case
+# 7) launch the interactive agent (pi TUI) in the current case
 overcast
 ```
 
@@ -135,7 +138,7 @@ surface + env vars.)
 | `capture` | fetch a URL / scan-hit / local path into the case |
 | `monitor` | scan on a loop, diff the seen-set, pipe new items into a sense (`--once` / `--every`) |
 | `collection` | index a target's videos into a tinycloud collection (media-descriptions / entities / face-analysis) → searchable corpus |
-| `target` / `source` | manage the standing scope + where to look |
+| `target` / `source` / `note` | manage the standing scope, where to look, and human-authored observations |
 | `prebrief` | stand up a case (name + target + source) in one shot |
 
 **Read** — synthesize the case

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -30,6 +30,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `collection` — Manage tinycloud collections that index a target's videos (create/add/list/show/delete/remove/entities).
 - `target` — Define/refine the standing scope (add|list|rm|show). Persisted to .overcast/target.json.
 - `source` — Register where to look (add <type>:<ref> | list | enable|disable <id> | rm <id>).
+- `note` — Add a human observation/finding to the case, optionally anchored to evidence.
 - `prebrief` — Stand up a case: name + target + source in one shot (non-interactive via flags).
 - `ask` — Natural-language query over the case memory; answers with record.id + media.at citations.
 - `brief` — Synthesize the case records into a report (timeline + findings); --export to md/html.
@@ -46,6 +47,7 @@ Run any verb from bash and parse the JSON record:
 ```bash
 overcast watch ./clip.mp4 --json          # video.analysis record
 overcast scan --pull --json               # enumerate sources, capture + sense
+overcast note "rear plate is missing" --ref <record-id> --at 12-18 --json
 overcast face ./clip.mp4 --json           # detect faces (boxes + timestamps)
 overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video (JPEG/PNG query image)
 overcast ask "every white van, with timestamps" --json

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -366,6 +366,32 @@ Options:
 
 Emits `source` records.
 
+### `overcast note`
+
+Creates a primary human-authored `note` record. Notes are searchable by `ask`, included in `brief`, visible in `case records`, and can cite media via `--ref <record-id|capture-id|path|url>` plus `--at <seconds|start-end|timecode>`. Use `--tag` for comma-separated labels and `--confidence` for the analyst's confidence marker.
+
+```
+overcast note <text> [options]
+
+  Add a human observation/finding to the case, optionally anchored to evidence.
+
+  Creates a primary human-authored `note` record. Notes are searchable by `ask`, included in `brief`, visible in `case records`, and can cite media via `--ref <record-id|capture-id|path|url>` plus `--at <seconds|start-end|timecode>`. Use `--tag` for comma-separated labels and `--confidence` for the analyst's confidence marker.
+
+Arguments:
+  text             Observation/finding text
+
+Options:
+  --ref <string>         Evidence record id, capture id, media path, or URL to anchor this note
+  --at <string>          Anchor time: seconds, hh:mm:ss, or start-end span
+  --tag <string>         Comma-separated labels (e.g. vehicle,contradiction)
+  --confidence <string>  Analyst confidence marker (e.g. low|medium|high)
+  --title <string>       Short note title
+  --format <string>      json | md | txt
+  --json                 Shorthand for --format json
+```
+
+Emits `note` records.
+
 ### `overcast case`
 
 A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -20,6 +20,7 @@ import {
 import { collectionVerb } from "../verbs/collection.js";
 import { askVerb, briefVerb } from "../verbs/read.js";
 import { caseVerb } from "../verbs/case.js";
+import { noteVerb } from "../verbs/note.js";
 import { setupVerb, providerVerb, doctorVerb } from "../verbs/setup.js";
 import { skillsVerb } from "../verbs/skills.js";
 import type { VerbSpec } from "./types.js";
@@ -91,6 +92,7 @@ export const VERBS: VerbSpec[] = [
   collectionVerb,
   targetVerb,
   sourceVerb,
+  noteVerb,
   prebriefVerb,
   askVerb,
   briefVerb,

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -85,6 +85,7 @@ Run any verb from bash and parse the JSON record:
 \`\`\`bash
 overcast watch ./clip.mp4 --json          # video.analysis record
 overcast scan --pull --json               # enumerate sources, capture + sense
+overcast note "rear plate is missing" --ref <record-id> --at 12-18 --json
 overcast face ./clip.mp4 --json           # detect faces (boxes + timestamps)
 overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video (JPEG/PNG query image)
 overcast ask "every white van, with timestamps" --json

--- a/src/verbs/note.ts
+++ b/src/verbs/note.ts
@@ -1,0 +1,145 @@
+// Human-authored case observations. Notes are primary records (not read/meta
+// outputs), so they flow through local memory, ask, brief, and case records like
+// sensed/captured evidence. They can optionally anchor to a media ref or record.
+
+import { existsSync } from "node:fs";
+import { makeRecord, type MediaRef, type OvercastRecord } from "../record.js";
+import { resolveMediaRef } from "./media-ref.js";
+import type { VerbSpec, VerbContext } from "../registry/types.js";
+
+function err(message: string): OvercastRecord {
+  return makeRecord({ verb: "note", format: "json", payload: { error: message }, error: message, state: "error" });
+}
+
+function parseStamp(s: string): number | undefined {
+  const raw = s.trim();
+  if (!raw) return undefined;
+  if (/^\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
+  const parts = raw.split(":");
+  if (parts.length < 2 || parts.length > 3) return undefined;
+  if (!parts.every((p) => /^\d+(?:\.\d+)?$/.test(p))) return undefined;
+  const nums = parts.map(Number);
+  if (nums.some((n) => !Number.isFinite(n))) return undefined;
+  return nums.length === 2
+    ? nums[0] * 60 + nums[1]
+    : nums[0] * 3600 + nums[1] * 60 + nums[2];
+}
+
+function parseAt(s: string): number | [number, number] | undefined {
+  const raw = s.trim();
+  if (!raw) return undefined;
+  const span = raw.match(/^(.+)-(.+)$/);
+  if (span) {
+    const start = parseStamp(span[1]);
+    const end = parseStamp(span[2]);
+    if (start == null || end == null || end < start) return undefined;
+    return [start, end];
+  }
+  return parseStamp(raw);
+}
+
+function splitTags(v: unknown): string[] | undefined {
+  if (v == null) return undefined;
+  const tags = String(v)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return tags.length ? tags : undefined;
+}
+
+function noteText(ctx: VerbContext): string {
+  return [ctx.input, ...ctx.rest].filter((x): x is string => typeof x === "string" && x.length > 0).join(" ").trim();
+}
+
+export const noteVerb: VerbSpec = {
+  name: "note",
+  group: "state",
+  summary: "Add a human observation/finding to the case, optionally anchored to evidence.",
+  description:
+    "Creates a primary human-authored `note` record. Notes are searchable by `ask`, included in " +
+    "`brief`, visible in `case records`, and can cite media via `--ref <record-id|capture-id|path|url>` " +
+    "plus `--at <seconds|start-end|timecode>`. Use `--tag` for comma-separated labels and " +
+    "`--confidence` for the analyst's confidence marker.",
+  args: [
+    { name: "text", summary: "Observation/finding text", required: true },
+  ],
+  flags: [
+    { name: "ref", summary: "Evidence record id, capture id, media path, or URL to anchor this note", type: "string" },
+    { name: "at", summary: "Anchor time: seconds, hh:mm:ss, or start-end span", type: "string" },
+    { name: "tag", summary: "Comma-separated labels (e.g. vehicle,contradiction)", type: "string" },
+    { name: "confidence", summary: "Analyst confidence marker (e.g. low|medium|high)", type: "string" },
+    { name: "title", summary: "Short note title", type: "string" },
+    { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
+    { name: "json", summary: "Shorthand for --format json", type: "boolean" },
+  ],
+  outputKind: "note",
+  providerKey: "note",
+  run: async (ctx) => {
+    const text = noteText(ctx);
+    if (!text) return [err("note requires observation text")];
+
+    for (const f of ["ref", "at", "tag", "confidence", "title"] as const) {
+      if (ctx.opts[f] != null && !String(ctx.opts[f]).trim()) {
+        return [err(`--${f} requires a value`)];
+      }
+    }
+
+    let media: MediaRef | undefined;
+    let relatedRecord: string | undefined;
+    let evidenceRef: string | undefined;
+
+    if (ctx.opts.ref != null) {
+      const rawRef = String(ctx.opts.ref).trim();
+      const rec = ctx.case.recordById(rawRef);
+      if (rec) {
+        relatedRecord = rec.id;
+        evidenceRef = rec.media?.ref ?? rawRef;
+        // Link to the same media, but do NOT inherit the source record's
+        // timestamp. A human note is only time-anchored when the analyst says so
+        // with --at.
+        if (rec.media?.ref) media = { ref: rec.media.ref };
+      } else {
+        const resolved = resolveMediaRef(ctx.case, rawRef);
+        if (resolved.recordId == null) {
+          const isUrl = /^https?:\/\//i.test(rawRef);
+          const isExistingPath = !isUrl && existsSync(rawRef);
+          if (!isUrl && !isExistingPath) {
+            if (/^rec_/i.test(rawRef)) return [err(`--ref record not found in this case: ${rawRef}`)];
+            if (/^cap_/i.test(rawRef)) return [err(`--ref capture id not found in this case: ${rawRef}`)];
+            return [err(`--ref does not resolve to a record, capture id, existing path, or URL: ${rawRef}`)];
+          }
+        }
+        relatedRecord = resolved.recordId;
+        evidenceRef = resolved.ref;
+        media = { ref: resolved.ref };
+      }
+    }
+
+    if (ctx.opts.at != null) {
+      if (!ctx.opts.ref) return [err("--at requires --ref so the timestamp has evidence to anchor")];
+      if (!media?.ref) return [err("--at requires --ref to resolve to media (the referenced record has no media.ref)")];
+      const at = parseAt(String(ctx.opts.at));
+      if (at == null) return [err(`invalid --at '${ctx.opts.at}' (expected seconds, hh:mm:ss, or start-end)`)];
+      media = { ref: media.ref, at };
+    }
+
+    const tags = splitTags(ctx.opts.tag);
+    const payload: Record<string, unknown> = { text };
+    if (ctx.opts.title) payload.title = String(ctx.opts.title);
+    if (tags) payload.tags = tags;
+    if (ctx.opts.confidence) payload.confidence = String(ctx.opts.confidence);
+    if (evidenceRef) payload.ref = evidenceRef;
+    if (relatedRecord) payload.related_record = relatedRecord;
+
+    return [
+      makeRecord({
+        verb: "note",
+        format: "md",
+        payload,
+        media,
+        meta: { provider: "human", case: ctx.case.dir },
+        state: "ready",
+      }),
+    ];
+  },
+};

--- a/test/e2e/cases/phase4_read.sh
+++ b/test/e2e/cases/phase4_read.sh
@@ -18,6 +18,16 @@ c.writeRecord(makeRecord({verb:'watch',payload:{content:'Daytime footage of an e
 c.writeRecord(makeRecord({verb:'scan',payload:{title:'dock cam feed',url:'http://x/feed'}}));
 " 2>"$SMOKE_DIR/phase4_seed.err"
 
+# human-authored notes are first-class case records: searchable, citable, and
+# included in briefs. Anchor this one to the first watch record's media span.
+watch_id="$(node --import tsx -e "import {openCase} from '$REPO/src/case.ts'; const c=openCase('$casedir'); console.log(c.records().find(r=>r.verb==='watch').id)")"
+note="$($OVERCAST note 'Human observation: the white van has a missing rear plate' --ref "$watch_id" --at 13-16 --tag vehicle,plate --confidence high --json --case "$casedir" 2>/dev/null)"
+save_json "phase4_note" "$note" >/dev/null
+assert_eq "note.verb" "note" "$(jq -r '.verb' <<<"$note")" "note verb"
+assert_eq "note.state" "ready" "$(jq -r '.state' <<<"$note")" "note ready"
+assert_eq "note.media_at" "[13,16]" "$(jq -r '.media.at|tostring' <<<"$note")" "note carries media.at"
+assert_eq "note.provider" "human" "$(jq -r '.meta.provider' <<<"$note")" "note marked human"
+
 # ask cites the matching record by id + media.at
 ask="$($OVERCAST ask 'white van at the docks' --json --case "$casedir" 2>/dev/null)"
 save_json "phase4_ask" "$ask" >/dev/null
@@ -29,6 +39,10 @@ top_at="$(jq -r '.payload.citations[0].at|tostring' <<<"$ask")"
 assert_eq "ask.cites_media_at" "[12,18]" "$top_at" "top citation carries media.at"
 if jq -e '.payload.text|test("white van";"i")' >/dev/null <<<"$ask"; then ok "ask.grounded" "answer text references the matched finding"; else fail "ask.grounded" "answer missed the finding"; fi
 
+note_ask="$($OVERCAST ask 'missing rear plate' --json --case "$casedir" 2>/dev/null)"
+save_json "phase4_note_ask" "$note_ask" >/dev/null
+if jq -e '.payload.citations[]|select(.verb=="note")' >/dev/null <<<"$note_ask"; then ok "ask.cites_note" "ask cites the human note"; else fail "ask.cites_note" "ask did not cite note"; fi
+
 # brief --export writes an html report containing the timeline
 brief_html="$casedir/brief.html"
 brief="$($OVERCAST brief --export "$brief_html" --json --case "$casedir" 2>/dev/null)"
@@ -36,12 +50,12 @@ save_json "phase4_brief" "$brief" >/dev/null
 # >= 3 seeded records (the prior `ask` also persists its own answer record)
 btotal="$(jq -r '.payload.total' <<<"$brief")"
 [ "${btotal:-0}" -ge 3 ] && ok "brief.total" "brief covers the case records ($btotal)" || fail "brief.total" "expected >=3 got $btotal"
-if [ -f "$brief_html" ] && grep -q "white van" "$brief_html" && grep -q "<h1>" "$brief_html"; then
+if [ -f "$brief_html" ] && grep -q "white van" "$brief_html" && grep -q "missing rear plate" "$brief_html" && grep -q "<h1>" "$brief_html"; then
   ok "brief.export_html" "exported html report with timeline"
 else
   fail "brief.export_html" "export missing or incomplete"
 fi
 
-# verb surface now lists ask + brief
+# verb surface now lists ask + brief + note
 v="$($OVERCAST commands --json 2>/dev/null | jq -r '.verbs[].name')"
-echo "$v" | grep -qx ask && echo "$v" | grep -qx brief && ok "read.verb_surface" "ask + brief listed" || fail "read.verb_surface" "ask/brief missing"
+echo "$v" | grep -qx ask && echo "$v" | grep -qx brief && echo "$v" | grep -qx note && ok "read.verb_surface" "ask + brief + note listed" || fail "read.verb_surface" "ask/brief/note missing"

--- a/test/e2e/live/cases/00_cli.sh
+++ b/test/e2e/live/cases/00_cli.sh
@@ -9,9 +9,13 @@ ver="$(ocg version --json)"
 assert_eq "$C.version" "0.80.1" "$(echo "$ver" | jq -r '.pi')" "pi pinned at 0.80.1"
 assert_nonempty "$C.binary_runs" "$(echo "$ver" | jq -r '.overcast')" "binary reports overcast version"
 
-cond "the verb registry exposes all 18 verbs"
-n="$(ocg commands --json | jq '.verbs|length')"
-assert_eq "$C.commands" "18" "$n" "18 verbs in the registry"
+cond "the verb registry exposes the public verbs"
+cmds="$(ocg commands --json)"
+n="$(echo "$cmds" | jq '.verbs|length')"
+if [ "${n:-0}" -ge 21 ]; then ok "$C.commands_count" "$n verbs in the registry"; else fail "$C.commands_count" "expected at least 21 verbs, got $n"; fi
+for verb in watch listen see face enhance view scan capture monitor collection target source note prebrief ask brief case setup provider doctor skills; do
+  if echo "$cmds" | jq -e --arg v "$verb" '.verbs[]|select(.name==$v)' >/dev/null; then ok "$C.commands_$verb" "$verb listed"; else fail "$C.commands_$verb" "$verb missing from registry"; fi
+done
 
 cond "overcast --help documents every provider env var"
 help="$(ocg --help)"

--- a/test/unit/note.test.ts
+++ b/test/unit/note.test.ts
@@ -1,0 +1,135 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openCase } from "../../src/case.ts";
+import { defaultProfile } from "../../src/profile.ts";
+import { makeRecord } from "../../src/record.ts";
+import { noteVerb } from "../../src/verbs/note.ts";
+import { askVerb, briefVerb } from "../../src/verbs/read.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+function ctx(dir: string, input: string, rest: string[] = [], opts: VerbContext["opts"] = {}): VerbContext {
+  return { input, rest, opts, case: openCase(dir), profile: defaultProfile() };
+}
+
+async function withCase(fn: (dir: string) => Promise<void>) {
+  const dir = mkdtempSync(join(tmpdir(), "oc-note-"));
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({
+      verb: "watch",
+      payload: { content: "A delivery van enters the east gate." },
+      media: { ref: "gate.mp4", at: [30, 35] },
+    }));
+    await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("note creates a human-authored primary record with tags and evidence anchor", async () => {
+  await withCase(async (dir) => {
+    const source = openCase(dir).records().find((r) => r.verb === "watch")!;
+    const [note] = await noteVerb.run(ctx(
+      dir,
+      "Analyst confirms the van has no rear plate",
+      [],
+      { ref: source.id, at: "00:00:31-00:00:34", tag: "vehicle,plate", confidence: "high", title: "rear plate" },
+    ));
+
+    assert.equal(note.verb, "note");
+    assert.equal(note.state, "ready");
+    assert.equal(note.meta?.provider, "human");
+    assert.deepEqual(note.media, { ref: "gate.mp4", at: [31, 34] });
+
+    const payload = note.payload as Record<string, unknown>;
+    assert.equal(payload.text, "Analyst confirms the van has no rear plate");
+    assert.equal(payload.related_record, source.id);
+    assert.deepEqual(payload.tags, ["vehicle", "plate"]);
+    assert.equal(payload.confidence, "high");
+    assert.equal(payload.title, "rear plate");
+  });
+});
+
+test("note --ref links media without inheriting source media.at unless --at is explicit", async () => {
+  await withCase(async (dir) => {
+    const source = openCase(dir).records().find((r) => r.verb === "watch")!;
+    const [note] = await noteVerb.run(ctx(dir, "Analyst flags the same clip but not a specific moment", [], { ref: source.id }));
+
+    assert.deepEqual(note.media, { ref: "gate.mp4" });
+    assert.equal((note.payload as Record<string, unknown>).related_record, source.id);
+  });
+});
+
+test("note joins unquoted positional text and rejects invalid anchors", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    const [joined] = await noteVerb.run(ctx(dir, "white", ["van", "turns", "left"]));
+    assert.equal((joined.payload as Record<string, unknown>).text, "white van turns left");
+
+    const [missingRef] = await noteVerb.run(ctx(dir, "bad anchor", [], { at: "12" }));
+    assert.equal(missingRef.state, "error");
+    assert.match(String(missingRef.error), /--at requires --ref/);
+
+    const mediaPath = join(dir, "x.mp4");
+    writeFileSync(mediaPath, "fake media");
+    const [badAt] = await noteVerb.run(ctx(dir, "bad anchor", [], { ref: mediaPath, at: "20-10" }));
+    assert.equal(badAt.state, "error");
+    assert.match(String(badAt.error), /invalid --at/);
+
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      writeFileSync("cap_clip.mp4", "fake media");
+      const [capPath] = await noteVerb.run(ctx(dir, "local cap-prefixed path", [], { ref: "cap_clip.mp4" }));
+      assert.equal(capPath.state, "ready");
+      assert.deepEqual(capPath.media, { ref: "cap_clip.mp4" });
+
+      writeFileSync("rec_clip.mp4", "fake media");
+      const [recPath] = await noteVerb.run(ctx(dir, "local rec-prefixed path", [], { ref: "rec_clip.mp4" }));
+      assert.equal(recPath.state, "ready");
+      assert.deepEqual(recPath.media, { ref: "rec_clip.mp4" });
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const scan = makeRecord({ verb: "scan", payload: { title: "page result" } });
+    c.writeRecord(scan);
+    const [noMedia] = await noteVerb.run(ctx(dir, "bad anchor", [], { ref: scan.id, at: "12" }));
+    assert.equal(noMedia.state, "error");
+    assert.match(String(noMedia.error), /has no media\.ref/);
+
+    const [missingRecord] = await noteVerb.run(ctx(dir, "bad ref", [], { ref: "rec_doesnotexist" }));
+    assert.equal(missingRecord.state, "error");
+    assert.match(String(missingRecord.error), /record not found/);
+
+    const [missingCapture] = await noteVerb.run(ctx(dir, "bad ref", [], { ref: "cap_doesnotexist" }));
+    assert.equal(missingCapture.state, "error");
+    assert.match(String(missingCapture.error), /capture id not found/);
+
+    const [missingPath] = await noteVerb.run(ctx(dir, "bad ref", [], { ref: join(dir, "missing.mp4") }));
+    assert.equal(missingPath.state, "error");
+    assert.match(String(missingPath.error), /does not resolve/);
+  });
+});
+
+test("note records are searchable and included in briefs", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    const [note] = await noteVerb.run(ctx(dir, "Human observation: driver switches jackets near the loading dock", [], { tag: "driver" }));
+    c.writeRecord(note);
+
+    const [ask] = await askVerb.run(ctx(dir, "Who switches jackets?"));
+    const answer = (ask.payload as Record<string, unknown>).text as string;
+    assert.match(answer, /switches jackets/i);
+    assert.ok(((ask.payload as Record<string, unknown>).citations as Array<Record<string, unknown>>).some((c) => c.verb === "note"));
+
+    const [brief] = await briefVerb.run(ctx(dir, ""));
+    const report = (brief.payload as Record<string, unknown>).report as string;
+    assert.match(report, /Human observation: driver switches jackets/);
+    assert.match(report, /`note`/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `overcast note` for human-authored case observations and findings.
- Support optional evidence anchors with `--ref` and `--at`, plus tags, title, and confidence fields.
- Include notes in generated skills/docs and offline/live e2e coverage so notes are searchable and show up in briefs.

## Validation

- `npm run typecheck`
- `npm test`
- `bash test/e2e/run.sh phase4`
- `bash test/e2e/live/run.sh` — 141/141 passed (including skips), 0 failed
- `git diff --check`

Live e2e report: `/Users/kdr/dev/github/overcast/.dev/smoke/live-20260627T225906Z/report.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI verb and docs/tests only; no changes to auth, providers, or existing record pipelines beyond indexing another record kind.
> 
> **Overview**
> Adds **`overcast note`** so analysts can persist human observations as first-class **`note`** records in the case store (group **state**), with **`meta.provider: human`**.
> 
> The verb accepts observation text plus optional **`--ref`** (record id, capture id, path, or URL), **`--at`** (seconds, timecode, or span), **`--tag`**, **`--title`**, and **`--confidence`**. **`--ref`** on an existing record links **`media.ref`** but does **not** copy that record’s **`media.at`** unless **`--at`** is set explicitly.
> 
> **`noteVerb`** is registered in **`src/registry/verbs.ts`**; README, generated skill copy (**`skill-gen.ts`**), and **`verbs.md`** document the new surface. Coverage includes **`test/unit/note.test.ts`**, phase4 read e2e (searchable via **`ask`**, visible in exported **`brief`**), and live CLI checks that **`note`** appears in the verb registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6429c0e56b3e51fe7f72381a465db96ffbe6b597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->