### PR TITLE
Document provider sample coverage

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -102,6 +102,8 @@ overcast see ./clip.mp4  --detect "weapon, hard hat" --json      # video → fra
 - [`examples/providers/python/listen.py`](../examples/providers/python/listen.py) — a local-whisper `listen` provider (exec/http).
 - [`examples/providers/ts/see.ts`](../examples/providers/ts/see.ts) — a VLM `see` provider (exec/in-proc).
 - [`examples/providers/hf/{see,enhance}.sh`](../examples/providers/hf/) — Hugging Face captioner + model-enhance.
+- [`examples/providers/elevenlabs/{listen,enhance}.sh`](../examples/providers/elevenlabs/) — ElevenLabs Scribe STT + Voice Isolator audio enhance.
+- [`examples/providers/fal/{see,enhance}.sh`](../examples/providers/fal/) — fal.ai Florence-2, ESRGAN image enhance, and DeepFilterNet3 audio enhance.
 - [`examples/providers/detect/detect.py`](../examples/providers/detect/detect.py) — local open-vocabulary `see` object detector (OWLv2 / Grounding DINO), image + video.
 - [`examples/providers/sources/{youtube,tiktok,web}.sh`](../examples/providers/sources/) — yt-dlp + Apify + web-search (Tavily/Brave) source providers.
 


### PR DESCRIPTION
## Summary
- add missing ElevenLabs provider sample entry
- add missing fal.ai provider sample entry

## Testing
- not run; documentation-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration impact.
> 
> **Overview**
> The **Samples (runnable, in this repo)** section in `docs/providers.md` now includes ElevenLabs and fal.ai alongside the other shipped examples.
> 
> Two bullets link to `examples/providers/elevenlabs/{listen,enhance}.sh` (Scribe STT + Voice Isolator) and `examples/providers/fal/{see,enhance}.sh` (Florence-2, ESRGAN, DeepFilterNet3), matching the setup instructions already documented above in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9a3fd2140ad79042ed957da3181d22a06e5b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->