### PR TITLE
Add CSI case visualizations and agent HTML defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ overcast scan --pull --json            # enumerate sources → capture → sense
 # 3) ask questions over everything the case has accumulated (with citations)
 overcast ask "every white van, with timestamps" --json
 overcast brief --export ./brief.html
+overcast case status --export ./status.html --theme csi
+overcast case records --export ./records.html --theme csi
 
 # 4) add a human observation anchored to evidence
 overcast note "rear plate is missing" --ref <watch-record-id> --at 12-18 --tag vehicle --json
@@ -166,6 +168,22 @@ overcast
 
 A **case is just a directory** with a `.overcast/` store — switch cases with
 `cd` or `--case <dir>`. pi's per-directory sessions are the case history.
+
+Use the three report surfaces for different jobs:
+
+- `brief` answers "what does the evidence say?" It reports over the same
+  evidence-only boundary as case memory, so setup/read/meta records are excluded.
+- `case records` answers "what exactly happened?" It is the append-only audit log
+  and includes operational records such as setup, target/source changes, index
+  work, asks, briefs, and status checks.
+- `case status` answers "where is this case right now?" It summarizes setup
+  health, targets, sources, indexes, memory/index state, store counts, artifacts,
+  and match visualizations when available. It is a dashboard, not evidence for
+  later memory or briefs.
+
+Direct CLI HTML exports default to the compatible `plain` theme unless
+`--theme csi` is set. Agent/TUI tool calls default `.html` exports to `csi` for
+these report surfaces, while preserving an explicit `--theme plain`.
 
 For end-to-end recipes — first-run setup, person search, OSINT pulls, continuous
 monitoring, qmd memory, detection crops, and more — see

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -167,6 +167,12 @@ Raw detection payloads are intentionally not searchable. Use exact record reads
   `case memory index rebuild --memory qmd`.
 - **Local memory passages:** `case memory search "..."` returns snippets.
 - **Briefs:** `brief` reports over the same evidence boundary.
+- **Case status:** `case status` is a current-state dashboard: setup health,
+  targets, sources, indexes, memory/index state, store counts, artifacts, and
+  match visualizations when available.
+- **Case records:** `case records` is the append-only audit log. It includes
+  operational/read/meta records that are intentionally excluded from memory and
+  briefs, so use it for trace, provenance, and debugging.
 - **Remote media index:** `ask "..." --index <media-index>` (Q&A) or `--probe`
   (moment search).
 - **Remote face search:** `face --match ./person.jpg --index <face-index>`.
@@ -198,6 +204,14 @@ should not be used to create visual DBs; create them explicitly with
 `index create --type image-ransac --local` or `index create --type deepface-local
 --local`. Local-grep/qmd ingest the visual match records and summaries, not
 binary media, embeddings, frame samples, or visualization images.
+
+In short: open `brief` when you want the evidence narrative, `case status` when
+you want the live case dashboard, and `case records` when you need the full
+history of what the system and user did.
+
+Direct CLI HTML exports default to `plain` for compatibility. Agent/TUI tool
+calls default `.html` exports to the `csi` visualization theme when the verb
+supports themes, unless the call explicitly passes `--theme plain`.
 
 ## Recommended case lifecycles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@earendil-works/pi-ai": "0.80.1",
         "@earendil-works/pi-coding-agent": "0.80.1",
         "@earendil-works/pi-tui": "0.80.1",
+        "playwright": "*",
         "zod": "^3.24.1"
       },
       "bin": {
@@ -27,6 +28,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "playwright": "^1.61.1"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -4203,6 +4207,52 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss-load-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@earendil-works/pi-ai": "0.80.1",
         "@earendil-works/pi-coding-agent": "0.80.1",
         "@earendil-works/pi-tui": "0.80.1",
-        "playwright": "*",
         "zod": "^3.24.1"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"
+  },
+  "optionalDependencies": {
+    "playwright": "^1.61.1"
   }
 }

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -37,7 +37,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `prebrief` — Stand up a case: name + target + source in one shot (non-interactive via flags).
 - `ask` — Natural-language query over the case memory; answers with record.id + media.at citations.
 - `brief` — Synthesize the case records into a report (timeline + findings); --export to md/html.
-- `case` — Inspect/manage the current case: init | setup | info | records | memory | clear.
+- `case` — Inspect/manage the current case: init | setup | status | info | records | memory | clear.
 - `setup` — Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|show).
 - `provider` — Run provider setup/init hooks, or list/describe bound providers (provider setup|init|list|describe).
 - `doctor` — Preflight: check pi version, ffmpeg/ffprobe, Cloudglue creds, tinycloud, provider bindings.
@@ -57,7 +57,9 @@ overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in th
 overcast crop <face-or-see-record-id> --all --class face --json  # materialize detection crops as evidence
 overcast ask "every white van, with timestamps" --json
 overcast case memory index status --json  # inspect default local-grep case search
-overcast brief --export ./brief.html
+overcast brief --export ./brief.html      # evidence-only narrative report
+overcast case status --export ./status.html --theme csi   # current case dashboard
+overcast case records --export ./records.html --theme csi # full audit log
 ```
 
 Built-in source refs for `source add <type>:<ref>`:
@@ -72,6 +74,25 @@ Built-in source refs for `source add <type>:<ref>`:
 `overcast commands --json` dumps the authoritative verb registry. Full man
 pages are in [reference/verbs.md](reference/verbs.md) (progressive disclosure —
 read it when you need a verb's exact flags).
+
+### Brief vs status vs records
+
+Use `brief` for the evidence narrative: it reports over the same evidence-only
+boundary as case memory, so setup/read/meta records are excluded.
+
+Use `case status` for the current dashboard: setup health, targets, sources,
+indexes, memory/index state, record/store counts, artifacts, and match
+visualizations when available. Treat it as situational context, not evidence for
+later memory or briefs.
+
+Use `case records` for the audit trail: it includes the append-only operational
+history, including setup, target/source changes, index work, asks, briefs, and
+status checks.
+
+Direct CLI HTML exports default to `plain` for compatibility. In the
+interactive/headless agent tool surface, `.html` exports default to the
+`csi` visualization theme when the verb supports themes, unless the tool call
+explicitly passes `theme: "plain"`.
 
 ### Case search (default ask)
 

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -378,6 +378,7 @@ overcast brief  [options]
 Options:
   --scope <string>       Filter, e.g. since:24h or verb:watch
   --export <string>      Write a report file (.md or .html)
+  --theme <string>       HTML export theme: plain | csi (default: plain)
   --format <string>      json | md | txt
   --json                 Shorthand for --format json
 ```
@@ -483,17 +484,17 @@ Emits `finding` records.
 
 ### `overcast case`
 
-A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case setup` runs/saves first-run setup and `case setup status|show|edit|plan` manages it; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search|index> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state and configured materialized memory indexes while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
+A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case setup` runs/saves first-run setup and `case setup status|show|edit|plan` manages it; `case status` reports setup/store/memory health; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search|index> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state and configured materialized memory indexes while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
 
 ```
 overcast case <action> [sub] [arg] [options]
 
-  Inspect/manage the current case: init | setup | info | records | memory | clear.
+  Inspect/manage the current case: init | setup | status | info | records | memory | clear.
 
-  A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case setup` runs/saves first-run setup and `case setup status|show|edit|plan` manages it; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search|index> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state and configured materialized memory indexes while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
+  A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case setup` runs/saves first-run setup and `case setup status|show|edit|plan` manages it; `case status` reports setup/store/memory health; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search|index> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state and configured materialized memory indexes while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
 
 Arguments:
-  action           init | setup | info | records | memory | clear
+  action           init | setup | status | info | records | memory | clear
   sub              setup/memory subcommand, or dir for init
   arg              record id (memory get), query (memory search), or index action
 
@@ -521,6 +522,8 @@ Options:
   --dry-run              setup/edit: preview without saving or applying
   --verb <string>        Filter records by kind
   --since <string>       Time filter (e.g. 24h, 2026-06-01)
+  --export <string>      Write a case status/log HTML report
+  --theme <string>       HTML export theme: plain | csi (default: plain)
   --field <string>       Payload field to read in full (memory get)
   --offset <number>      Start char offset when paging a field (memory get)
   --limit <number>       Max records/passages, or max chars when paging a field

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -522,7 +522,7 @@ Options:
   --dry-run              setup/edit: preview without saving or applying
   --verb <string>        Filter records by kind
   --since <string>       Time filter (e.g. 24h, 2026-06-01)
-  --export <string>      Write a case status/log HTML report
+  --export <string>      Write a case status/log report (.md or .html)
   --theme <string>       HTML export theme: plain | csi (default: plain)
   --field <string>       Payload field to read in full (memory get)
   --offset <number>      Start char offset when paging a field (memory get)

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -123,6 +123,15 @@ function renderRecords(records: OvercastRecord[]): string {
   return parts.join("\n\n");
 }
 
+function applyAgentHtmlDefaults(spec: VerbSpec, opts: VerbContext["opts"]): void {
+  const hasThemeFlag = spec.flags.some((f) => f.name === "theme");
+  if (!hasThemeFlag || opts.theme != null) return;
+  const exportPath = opts.export;
+  if (typeof exportPath === "string" && /\.html?$/i.test(exportPath.trim())) {
+    opts.theme = "csi";
+  }
+}
+
 // --- verb HUD call tag ------------------------------------------------------
 // A cyberpunk "recording-deck" tag for the tool-call line, colored by verb class
 // (a semantic split: you read what kind of op is running by its hue). Raw
@@ -221,6 +230,7 @@ export function toAgentTool(spec: VerbSpec, deps: ToolDeps): ToolDefinition {
         if (params[f.name] !== undefined)
           opts[f.name] = expandHomeArg(params[f.name]) as string | number | boolean;
       }
+      applyAgentHtmlDefaults(spec, opts);
       // reconstruct positional input + rest from the declared args
       const positionals: string[] = [];
       for (const arg of spec.args) {

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -12,6 +12,7 @@ import type { VerbSpec, VerbContext, FlagSpec } from "./types.js";
 import { makeRecord, type OvercastRecord, type JsonMap } from "../record.js";
 import { expandHome, expandHomeArg } from "../fs-path.js";
 import { renderRecord, pageCommand } from "../render.js";
+import { isHtmlExportPath } from "../report/html.js";
 import type { Case } from "../case.js";
 import type { Profile } from "../profile.js";
 
@@ -127,7 +128,7 @@ function applyAgentHtmlDefaults(spec: VerbSpec, opts: VerbContext["opts"]): void
   const hasThemeFlag = spec.flags.some((f) => f.name === "theme");
   if (!hasThemeFlag || opts.theme != null) return;
   const exportPath = opts.export;
-  if (typeof exportPath === "string" && /\.html?$/i.test(exportPath.trim())) {
+  if (typeof exportPath === "string" && isHtmlExportPath(exportPath.trim())) {
     opts.theme = "csi";
   }
 }

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -36,6 +36,10 @@ export function normalizeHtmlTheme(value: unknown): HtmlTheme | undefined {
   return undefined;
 }
 
+export function isHtmlExportPath(path: string): boolean {
+  return extname(path).toLowerCase() === ".html";
+}
+
 export function escapeHtml(s: unknown): string {
   return String(s ?? "")
     .replace(/&/g, "&amp;")

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -1,0 +1,308 @@
+import { existsSync, readFileSync } from "node:fs";
+import { extname } from "node:path";
+import type { OvercastRecord } from "../record.js";
+
+export type HtmlTheme = "plain" | "csi";
+
+export interface TimelineRecord {
+  id: string;
+  verb: string;
+  state?: string;
+  media?: { ref?: string; at?: number | [number, number] | string | null } | null;
+  meta?: Record<string, unknown>;
+  payload?: unknown;
+  error?: string;
+}
+
+export interface TimelineReport {
+  title: string;
+  subtitle?: string;
+  records: TimelineRecord[];
+  counts?: Record<string, number>;
+  total?: number;
+  kind?: string;
+}
+
+export interface StatusReport {
+  title: string;
+  subtitle?: string;
+  payload: Record<string, unknown>;
+}
+
+export function normalizeHtmlTheme(value: unknown): HtmlTheme | undefined {
+  if (value == null) return "plain";
+  const theme = String(value).trim().toLowerCase();
+  if (theme === "plain" || theme === "csi") return theme;
+  return undefined;
+}
+
+export function escapeHtml(s: unknown): string {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function mdToPlainHtml(md: string, title: string): string {
+  const out: string[] = [];
+  let fence: string | null = null;
+  for (const line of md.split("\n")) {
+    if (fence == null && /^`{3,}\s*$/.test(line)) {
+      fence = line.trim();
+      out.push("<pre>");
+      continue;
+    }
+    if (fence != null) {
+      if (line.trim() === fence) {
+        out.push("</pre>");
+        fence = null;
+      } else {
+        out.push(escapeHtml(line));
+      }
+      continue;
+    }
+    if (/^### /.test(line)) out.push(`<h3>${escapeHtml(line.slice(4))}</h3>`);
+    else if (/^# /.test(line)) out.push(`<h1>${escapeHtml(line.slice(2))}</h1>`);
+    else if (/^## /.test(line)) out.push(`<h2>${escapeHtml(line.slice(3))}</h2>`);
+    else if (/^- /.test(line)) out.push(`<li>${escapeHtml(line.slice(2))}</li>`);
+    else if (line.trim() === "") out.push("");
+    else out.push(`<p>${escapeHtml(line)}</p>`);
+  }
+  const body = out.join("\n");
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>
+<style>body{background:#08120c;color:#c6f7d5;font-family:ui-monospace,monospace;max-width:840px;margin:2rem auto;padding:1rem}
+h1,h2{color:#ffc400}code{color:#00ff7f}li{margin:2px 0}
+pre{white-space:pre-wrap;word-break:break-word;background:#0d1f14;padding:8px;border-radius:4px}</style></head><body>
+${body}
+</body></html>`;
+}
+
+export function renderCsiTimelineReport(report: TimelineReport): string {
+  const counts = report.counts ?? countByVerb(report.records);
+  const total = report.total ?? report.records.length;
+  const cards = report.records.map((record, index) => renderTimelineCard(record, index)).join("\n");
+  const countChips = Object.entries(counts).sort().map(([verb, count]) => `<span class="chip cyan">${escapeHtml(verb)} ${count}</span>`).join("");
+  return csiShell(report.title, report.subtitle, `
+    <section class="stats" aria-label="case report stats">
+      <div><span class="label">MODE</span><strong>${escapeHtml(report.kind ?? "timeline")}</strong></div>
+      <div><span class="label">RECORDS</span><strong>${total}</strong></div>
+      <div class="chips">${countChips || `<span class="chip amber">no records</span>`}</div>
+    </section>
+    <main class="timeline" data-csi-timeline="true">
+      ${cards || `<article class="card empty"><span class="label">EMPTY</span><p>No records matched this report.</p></article>`}
+    </main>
+  `);
+}
+
+export function renderCsiStatusReport(report: StatusReport): string {
+  const payload = report.payload;
+  const chips = statusChips(payload);
+  const tldr = renderTldr(payload.tldr);
+  const context = renderContextSections(payload);
+  const promoted = new Set(["tldr", "targets", "sources", "match_visualizations"]);
+  const panels = Object.entries(payload).filter(([key]) => !promoted.has(key)).map(([key, value]) => renderStatusPanel(key, value)).join("\n");
+  return csiShell(report.title, report.subtitle, `
+    ${tldr}
+    ${context}
+    <section class="stats" aria-label="case status stats">
+      ${chips}
+    </section>
+    <main class="grid" data-csi-status="true">
+      ${panels}
+    </main>
+  `);
+}
+
+function csiShell(title: string, subtitle: string | undefined, body: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>
+<style>
+:root{color-scheme:dark;--bg:#050708;--panel:#0b1214;--panel2:#10181b;--line:#1f3a3b;--green:#5cff96;--cyan:#38e8ff;--amber:#ffd166;--magenta:#ff4fd8;--text:#d8ffe4;--muted:#8aa69d;--bad:#ff6b6b}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at top left,#10241b 0,#050708 34rem);color:var(--text);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;line-height:1.45}
+.wrap{max-width:1180px;margin:0 auto;padding:28px 20px 48px}.top{border-bottom:1px solid var(--line);padding-bottom:18px;margin-bottom:18px}
+h1{margin:0;color:var(--green);font-size:28px;letter-spacing:0;text-transform:uppercase}.subtitle{color:var(--muted);margin-top:6px}
+.stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px;margin:0 0 18px}.stats>div,.panel,.card{background:linear-gradient(180deg,var(--panel),var(--panel2));border:1px solid var(--line);border-radius:6px;box-shadow:0 0 0 1px rgba(92,255,150,.04),0 0 24px rgba(56,232,255,.06)}
+.stats>div{padding:10px 12px}.label{display:block;color:var(--muted);font-size:10px;text-transform:uppercase}.stats strong{display:block;color:var(--amber);font-size:20px;margin-top:3px}.chips{display:flex;gap:6px;flex-wrap:wrap;align-content:center}
+.chip{display:inline-flex;align-items:center;min-height:22px;padding:2px 7px;border:1px solid var(--line);border-radius:999px;color:var(--green);background:#07100c}.cyan{color:var(--cyan)}.amber{color:var(--amber)}.magenta{color:var(--magenta)}.bad{color:var(--bad)}
+.timeline{position:relative;display:grid;gap:10px}.timeline:before{content:"";position:absolute;left:10px;top:0;bottom:0;width:1px;background:linear-gradient(var(--cyan),var(--magenta));opacity:.45}
+.card{position:relative;margin-left:28px;padding:12px 14px}.card:before{content:"";position:absolute;left:-23px;top:18px;width:10px;height:10px;border-radius:50%;background:var(--green);box-shadow:0 0 14px var(--green)}
+.card-head{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px}.id{color:var(--cyan)}.verb{color:var(--green);font-weight:700}.state{color:var(--amber)}.media{color:var(--magenta)}
+.summary{white-space:pre-wrap;word-break:break-word;color:#dfffe9}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:10px}.panel{padding:12px 14px}
+.tldr{margin:0 0 18px;padding:14px 16px;background:linear-gradient(180deg,#0c1712,#10181b);border:1px solid var(--line);border-radius:6px;box-shadow:0 0 30px rgba(92,255,150,.08)}.tldr p{margin:6px 0 10px;color:#e6ffed;font-size:15px}.tldr ul{margin:8px 0 0;padding-left:18px}.tldr li{margin:4px 0;color:#d8ffe4}.tldr .next li{color:var(--amber)}
+.context{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:10px;margin:0 0 18px}.context-card{background:linear-gradient(180deg,var(--panel),var(--panel2));border:1px solid var(--line);border-radius:6px;padding:10px 12px}.context-card img{width:100%;max-height:180px;object-fit:contain;background:#020504;border:1px solid var(--line);border-radius:4px;margin:8px 0}.context-card p{margin:6px 0;color:#dfffe9;word-break:break-word}.context-card .meta{color:var(--muted);font-size:12px}
+h2{margin:0 0 8px;color:var(--cyan);font-size:15px;text-transform:uppercase;letter-spacing:0}.kv{display:grid;grid-template-columns:minmax(90px,150px) 1fr;gap:4px 10px}.k{color:var(--muted)}.v{word-break:break-word}
+details{margin-top:8px;border-top:1px solid var(--line);padding-top:8px}summary{cursor:pointer;color:var(--amber)}pre{white-space:pre-wrap;word-break:break-word;margin:8px 0 0;color:#c7ffd8;background:#06100b;padding:8px;border-radius:4px}
+</style></head><body><div class="wrap" data-overcast-theme="csi"><header class="top"><h1>${escapeHtml(title)}</h1>${subtitle ? `<div class="subtitle">${escapeHtml(subtitle)}</div>` : ""}</header>${body}</div></body></html>`;
+}
+
+function renderContextSections(payload: Record<string, unknown>): string {
+  const targets = Array.isArray(payload.targets) ? payload.targets as Record<string, unknown>[] : [];
+  const sources = Array.isArray(payload.sources) ? payload.sources as Record<string, unknown>[] : [];
+  const matches = Array.isArray(payload.match_visualizations) ? payload.match_visualizations as Record<string, unknown>[] : [];
+  const cards = [
+    ...targets.slice(0, 6).map((item) => contextCard("TARGET", item, item.image)),
+    ...sources.slice(0, 6).map((item) => contextCard("SOURCE", item)),
+    ...matches.slice(0, 6).map((item) => contextCard("MATCH", item, item.ref)),
+  ].join("");
+  return cards ? `<section class="context" data-csi-context="true">${cards}</section>` : "";
+}
+
+function contextCard(kind: string, item: Record<string, unknown>, imageRef?: unknown): string {
+  const title = item.name ?? item.value ?? item.ref ?? item.id ?? kind;
+  const desc = item.description ?? "";
+  const img = imageTag(imageRef);
+  const meta = [item.kind, item.type, item.state].filter(Boolean).join(" / ");
+  return `<article class="context-card">
+    <span class="label">${escapeHtml(kind)}</span>
+    <p><strong>${escapeHtml(title)}</strong></p>
+    ${desc ? `<p>${escapeHtml(desc)}</p>` : ""}
+    ${img}
+    ${meta ? `<div class="meta">${escapeHtml(meta)}</div>` : ""}
+  </article>`;
+}
+
+function imageTag(ref: unknown): string {
+  if (typeof ref !== "string" || !ref.trim()) return "";
+  const src = imageSrc(ref.trim());
+  return src ? `<img alt="${escapeHtml(ref)}" src="${escapeHtml(src)}">` : "";
+}
+
+function imageSrc(ref: string): string | undefined {
+  if (/^data:image\//i.test(ref)) return ref;
+  if (!existsSync(ref)) return undefined;
+  const mime = imageMime(ref);
+  if (!mime) return undefined;
+  try {
+    return `data:${mime};base64,${readFileSync(ref).toString("base64")}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function imageMime(path: string): string | undefined {
+  switch (extname(path).toLowerCase()) {
+    case ".jpg":
+    case ".jpeg": return "image/jpeg";
+    case ".png": return "image/png";
+    case ".gif": return "image/gif";
+    case ".webp": return "image/webp";
+    case ".bmp": return "image/bmp";
+    case ".avif": return "image/avif";
+    default: return undefined;
+  }
+}
+
+function renderTldr(value: unknown): string {
+  if (value == null || typeof value !== "object") return "";
+  const obj = value as Record<string, unknown>;
+  const headline = typeof obj.headline === "string" ? obj.headline : "";
+  const findings = Array.isArray(obj.findings) ? obj.findings.map(String) : [];
+  const next = Array.isArray(obj.next) ? obj.next.map(String) : [];
+  return `<section class="tldr" data-csi-tldr="true">
+    <span class="label">TL;DR</span>
+    ${headline ? `<p>${escapeHtml(headline)}</p>` : ""}
+    ${findings.length ? `<ul>${findings.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : ""}
+    ${next.length ? `<ul class="next">${next.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : ""}
+  </section>`;
+}
+
+function renderTimelineCard(record: TimelineRecord, index: number): string {
+  const state = record.state ?? "ready";
+  const media = record.media?.ref ? `${record.media.ref}${record.media.at != null ? ` @${Array.isArray(record.media.at) ? record.media.at.join("-") : record.media.at}` : ""}` : "";
+  const summary = record.error ? `error: ${record.error}` : summarizePayload(record.payload);
+  const details = safeJson({ payload: record.payload, meta: record.meta, media: record.media });
+  return `<article class="card" data-record-id="${escapeHtml(record.id)}">
+    <div class="card-head">
+      <span class="label">#${index + 1}</span><span class="verb">${escapeHtml(record.verb)}</span><span class="id">${escapeHtml(record.id)}</span><span class="state">${escapeHtml(state)}</span>${media ? `<span class="media">${escapeHtml(media)}</span>` : ""}
+    </div>
+    <div class="summary">${escapeHtml(summary)}</div>
+    <details><summary>record details</summary><pre>${escapeHtml(details)}</pre></details>
+  </article>`;
+}
+
+function renderStatusPanel(key: string, value: unknown): string {
+  const rows = flatRows(value).slice(0, 12);
+  const kv = rows.map(([k, v]) => `<span class="k">${escapeHtml(k)}</span><span class="v">${escapeHtml(v)}</span>`).join("");
+  return `<section class="panel"><h2>${escapeHtml(key)}</h2><div class="kv">${kv || `<span class="k">value</span><span class="v">${escapeHtml(summaryValue(value))}</span>`}</div><details><summary>details</summary><pre>${escapeHtml(safeJson(value))}</pre></details></section>`;
+}
+
+function statusChips(payload: Record<string, unknown>): string {
+  const records = valueAt(payload, ["store", "records"]);
+  const targets = valueAt(payload, ["registries", "targets"]);
+  const sources = valueAt(payload, ["registries", "sources"]);
+  const indexes = valueAt(payload, ["registries", "indexes"]);
+  return [
+    `<div><span class="label">INITIALIZED</span><strong>${escapeHtml(valueAt(payload, ["initialized"]) ?? "false")}</strong></div>`,
+    `<div><span class="label">RECORDS</span><strong>${escapeHtml(records ?? 0)}</strong></div>`,
+    `<div class="chips"><span class="chip cyan">targets ${escapeHtml(targets ?? 0)}</span><span class="chip amber">sources ${escapeHtml(sources ?? 0)}</span><span class="chip magenta">indexes ${escapeHtml(indexes ?? 0)}</span></div>`,
+  ].join("");
+}
+
+function countByVerb(records: TimelineRecord[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const r of records) counts[r.verb] = (counts[r.verb] ?? 0) + 1;
+  return counts;
+}
+
+function summarizePayload(payload: unknown): string {
+  if (payload == null) return "(empty)";
+  if (typeof payload === "string") return payload.length > 480 ? `${payload.slice(0, 480)}...` : payload;
+  if (typeof payload !== "object") return String(payload);
+  const obj = payload as Record<string, unknown>;
+  for (const key of ["content", "transcript", "text", "caption", "ocr", "title", "snippet", "summary"]) {
+    const value = obj[key];
+    if (typeof value === "string" && value.trim()) return value.length > 480 ? `${value.slice(0, 480)}...` : value;
+  }
+  return Object.keys(obj).length ? `payload: ${Object.keys(obj).join(", ")}` : "(empty)";
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function flatRows(value: unknown, prefix = ""): Array<[string, string]> {
+  if (value == null || typeof value !== "object") return [[prefix || "value", summaryValue(value)]];
+  if (Array.isArray(value)) return [["count", String(value.length)], ...value.slice(0, 6).map((v, i): [string, string] => [`${prefix}${i}`, summaryValue(v)])];
+  const rows: Array<[string, string]> = [];
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v != null && typeof v === "object" && !Array.isArray(v)) {
+      const keys = Object.keys(v as Record<string, unknown>);
+      rows.push([key, keys.length ? keys.join(", ") : "{}"]);
+    } else {
+      rows.push([key, summaryValue(v)]);
+    }
+  }
+  return rows;
+}
+
+function summaryValue(value: unknown): string {
+  if (Array.isArray(value)) return `${value.length} item(s)`;
+  if (value != null && typeof value === "object") return Object.keys(value as Record<string, unknown>).join(", ") || "{}";
+  return String(value ?? "");
+}
+
+function valueAt(obj: Record<string, unknown>, path: string[]): unknown {
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}
+
+export function recordToTimelineRecord(record: OvercastRecord): TimelineRecord {
+  return {
+    id: record.id,
+    verb: record.verb,
+    state: record.state ?? "ready",
+    media: record.media ?? null,
+    meta: record.meta,
+    payload: record.payload,
+    error: record.error ?? undefined,
+  };
+}

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -92,7 +92,9 @@ overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in th
 overcast crop <face-or-see-record-id> --all --class face --json  # materialize detection crops as evidence
 overcast ask "every white van, with timestamps" --json
 overcast case memory index status --json  # inspect default local-grep case search
-overcast brief --export ./brief.html
+overcast brief --export ./brief.html      # evidence-only narrative report
+overcast case status --export ./status.html --theme csi   # current case dashboard
+overcast case records --export ./records.html --theme csi # full audit log
 \`\`\`
 
 Built-in source refs for \`source add <type>:<ref>\`:
@@ -107,6 +109,25 @@ Built-in source refs for \`source add <type>:<ref>\`:
 \`overcast commands --json\` dumps the authoritative verb registry. Full man
 pages are in [reference/verbs.md](reference/verbs.md) (progressive disclosure —
 read it when you need a verb's exact flags).
+
+### Brief vs status vs records
+
+Use \`brief\` for the evidence narrative: it reports over the same evidence-only
+boundary as case memory, so setup/read/meta records are excluded.
+
+Use \`case status\` for the current dashboard: setup health, targets, sources,
+indexes, memory/index state, record/store counts, artifacts, and match
+visualizations when available. Treat it as situational context, not evidence for
+later memory or briefs.
+
+Use \`case records\` for the audit trail: it includes the append-only operational
+history, including setup, target/source changes, index work, asks, briefs, and
+status checks.
+
+Direct CLI HTML exports default to \`plain\` for compatibility. In the
+interactive/headless agent tool surface, \`.html\` exports default to the
+\`csi\` visualization theme when the verb supports themes, unless the tool call
+explicitly passes \`theme: "plain"\`.
 
 ### Case search (default ask)
 

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -4,10 +4,11 @@
 
 import { spawn } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { makeRecord, type OvercastRecord } from "../record.js";
-import { openCase } from "../case.js";
+import { openCase, recordFiles } from "../case.js";
 import { humanSize } from "../render.js";
+import { mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiStatusReport, renderCsiTimelineReport } from "../report/html.js";
 import { matchesMemoryProvider, resolveMemory } from "../providers/memory/index.js";
 import { parseSince } from "../providers/memory/local.js";
 import { tokenizeCommand } from "../providers/sources/index.js";
@@ -113,6 +114,204 @@ function setupHealth(ctx: VerbContext, setup: CaseSetup | undefined): Record<str
     incomplete_indexes: incompleteIndexes,
     missing_videos: missingVideos,
   };
+}
+
+async function memoryIndexStatuses(ctx: VerbContext): Promise<unknown[]> {
+  const statuses = [];
+  for (const p of resolveMemory(ctx.case, ctx.profile)) {
+    try {
+      statuses.push(p.status ? await p.status() : { provider: p.id, backend: p.backend ?? p.id, state: "ready" });
+    } catch (e) {
+      statuses.push({ provider: p.id, backend: p.backend ?? p.id, state: "error", error: (e as Error).message });
+    }
+  }
+  return statuses;
+}
+
+async function buildCaseStatus(ctx: VerbContext): Promise<Record<string, unknown>> {
+  const c = ctx.case;
+  const clear = c.clearSummary();
+  const saved = loadSetup(c);
+  const records = c.records();
+  return {
+    dir: c.dir,
+    initialized: c.exists(),
+    info: c.exists() ? c.info() : null,
+    tldr: caseStatusTldr(ctx, records, clear.counts),
+    targets: statusTargets(ctx),
+    sources: statusSources(ctx),
+    match_visualizations: statusMatchVisualizations(records),
+    setup_health: setupHealth(ctx, saved),
+    memory_index: await memoryIndexStatuses(ctx),
+    store: {
+      records: clear.records,
+      counts: clear.counts,
+      record_files: recordFiles(c),
+      media_files: clear.media.files,
+      media_size: humanSize(clear.media.bytes),
+      index_files: clear.index.files,
+      index_size: humanSize(clear.index.bytes),
+      state_files: clear.stateFiles,
+      artifacts: clear.artifacts,
+    },
+    registries: {
+      targets: listTargets(c).length,
+      sources: listSources(c).length,
+      indexes: listIndexes(c).length,
+    },
+  };
+}
+
+function statusTargets(ctx: VerbContext): Record<string, unknown>[] {
+  return listTargets(ctx.case).map((target) => ({
+    id: target.id,
+    kind: target.kind,
+    value: target.value,
+    description: target.kind === "image"
+      ? `Reference image target: ${target.value}`
+      : target.kind === "name"
+        ? `Named investigation target: ${target.value}`
+        : `Investigation prompt target: ${target.value}`,
+    image: target.kind === "image" ? target.value : undefined,
+    created: target.created,
+  }));
+}
+
+function statusSources(ctx: VerbContext): Record<string, unknown>[] {
+  return listSources(ctx.case).map((source) => ({
+    id: source.id,
+    type: source.type,
+    ref: source.ref,
+    name: source.name,
+    enabled: source.enabled,
+    description: sourceDescription(source.type, source.ref, source.enabled),
+    created: source.created,
+  }));
+}
+
+function sourceDescription(type: string, ref: string, enabled: boolean): string {
+  const state = enabled ? "enabled" : "disabled";
+  switch (type) {
+    case "youtube": return `${state} YouTube source: ${ref}`;
+    case "tiktok": return `${state} TikTok source: ${ref}`;
+    case "web": return `${state} web search source: ${ref}`;
+    case "folder": return `${state} local folder source: ${ref}`;
+    default: return `${state} ${type} source: ${ref || "(no ref)"}`;
+  }
+}
+
+function statusMatchVisualizations(records: OvercastRecord[]): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (const record of records) {
+    if (!["image", "face"].includes(record.verb)) continue;
+    const payload = record.payload && typeof record.payload === "object" ? record.payload as Record<string, unknown> : {};
+    const paths = collectVisualRefs(payload);
+    for (const ref of paths) {
+      out.push({
+        record: record.id,
+        verb: record.verb,
+        state: record.state ?? "ready",
+        ref,
+        description: `${record.verb} visualization from ${record.id}`,
+      });
+    }
+  }
+  return out.slice(0, 12);
+}
+
+function collectVisualRefs(value: unknown): string[] {
+  const refs = new Set<string>();
+  const visit = (v: unknown, key = "") => {
+    if (typeof v === "string") {
+      if (/^data:image\//i.test(v) || (looksLikeImagePath(v) && /(?:draw|visual|thumb|thumbnail|crop|path|image)/i.test(key))) refs.add(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const item of v) visit(item, key);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const [k, child] of Object.entries(v as Record<string, unknown>)) visit(child, k);
+    }
+  };
+  visit(value);
+  return [...refs];
+}
+
+function looksLikeImagePath(value: string): boolean {
+  return /\.(avif|bmp|gif|jpe?g|png|webp)(?:[?#].*)?$/i.test(value);
+}
+
+function caseStatusTldr(ctx: VerbContext, records: OvercastRecord[], counts: Record<string, number>): Record<string, unknown> {
+  const targets = listTargets(ctx.case);
+  const targetText = targets.map((t) => t.value).slice(0, 4);
+  const readyRecords = records.filter((r) => (r.state ?? "ready") === "ready");
+  const evidenceKinds = ["watch", "listen", "see", "face", "image", "crop", "scan", "capture", "note", "finding"]
+    .filter((verb) => (counts[verb] ?? 0) > 0);
+  const headline = [
+    ctx.case.exists() ? `Case '${ctx.case.info().name}' is initialized` : "Case is not initialized",
+    targetText.length ? `tracking ${targetText.join(", ")}` : "with no standing target",
+    readyRecords.length ? `with ${readyRecords.length} ready record(s)` : "with no ready evidence yet",
+  ].join(" ");
+  const findings: string[] = [];
+  if (targetText.length) findings.push(`Targets in scope: ${targetText.join("; ")}.`);
+  if (evidenceKinds.length) findings.push(`Evidence present: ${evidenceKinds.map((verb) => `${verb} ${counts[verb]}`).join(", ")}.`);
+  for (const rec of recentEvidenceSummaries(records).slice(0, 4)) findings.push(rec);
+  if (!findings.length) findings.push("No evidence records have been added yet.");
+  const next: string[] = [];
+  if (!targetText.length) next.push("Add a target with `case setup --target ... --yes`.");
+  if (!evidenceKinds.length) next.push("Add evidence with watch/listen/see/face/image/note records.");
+  if ((counts.brief ?? 0) === 0 && evidenceKinds.length) next.push("Run `brief --export report.html --theme csi` for an evidence timeline.");
+  if (!next.length) next.push("Review the latest evidence cards and expand details for citations.");
+  return { headline, findings, next };
+}
+
+function recentEvidenceSummaries(records: OvercastRecord[]): string[] {
+  const out: string[] = [];
+  for (const rec of records.slice().reverse()) {
+    if (!["note", "finding", "face", "image", "watch", "see", "listen"].includes(rec.verb)) continue;
+    const summary = recordSummary(rec);
+    if (summary) out.push(`${rec.verb}: ${summary}`);
+  }
+  return out;
+}
+
+function recordSummary(rec: OvercastRecord): string | undefined {
+  if (rec.error) return `error: ${rec.error}`;
+  const payload = rec.payload;
+  if (typeof payload === "string") return truncateLine(payload);
+  const p = payload as Record<string, unknown>;
+  for (const key of ["summary", "text", "content", "caption", "transcript", "title", "snippet"]) {
+    const value = p[key];
+    if (typeof value === "string" && value.trim()) return truncateLine(value);
+  }
+  if (rec.verb === "face" || rec.verb === "image") {
+    const op = typeof p.op === "string" ? p.op : rec.verb;
+    const count = typeof p.count === "number" ? p.count : undefined;
+    return `${op}${count != null ? ` found ${count}` : ""}${rec.media?.ref ? ` in ${rec.media.ref}` : ""}`;
+  }
+  return undefined;
+}
+
+function truncateLine(text: string): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length > 220 ? `${oneLine.slice(0, 220)}...` : oneLine;
+}
+
+function caseRecordsMarkdown(title: string, records: OvercastRecord[], counts: Record<string, number>): string {
+  const lines = [`# ${title}`, "", `**Records:** ${records.length}`, "", "## Counts", ""];
+  for (const [verb, n] of Object.entries(counts).sort()) lines.push(`- \`${verb}\`: ${n}`);
+  lines.push("", "## Timeline", "");
+  for (const r of records) {
+    const at = r.media?.at != null ? ` @${Array.isArray(r.media.at) ? r.media.at.join("-") : r.media.at}` : "";
+    const media = r.media?.ref ? ` (${r.media.ref}${at})` : "";
+    lines.push(`### \`${r.verb}\` ${r.id} [${r.state ?? "ready"}]${media}`, "");
+  }
+  return lines.join("\n");
+}
+
+function statusMarkdown(title: string, payload: Record<string, unknown>): string {
+  return [`# ${title}`, "", "```json", JSON.stringify(payload, null, 2), "```", ""].join("\n");
 }
 
 interface SetupChange {
@@ -506,17 +705,17 @@ function currentCliInvocation(): { cmd: string; args: string[] } {
 export const caseVerb: VerbSpec = {
   name: "case",
   group: "state",
-  summary: "Inspect/manage the current case: init | setup | info | records | memory | clear.",
+  summary: "Inspect/manage the current case: init | setup | status | info | records | memory | clear.",
   description:
     "A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; " +
     "`case setup` runs/saves first-run setup and `case setup status|show|edit|plan` manages it; " +
-    "`case info` shows state; `case records [--verb] [--since]` lists records; " +
+    "`case status` reports setup/store/memory health; `case info` shows state; `case records [--verb] [--since]` lists records; " +
     "`case memory <list|get|search|index> [q]` routes to the bound memory providers. " +
     "`case clear` previews what would be lost; add `--yes` to clear records/media/state and configured materialized memory indexes while preserving the case id. " +
     "`case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] " +
     "[--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.",
   args: [
-    { name: "action", summary: "init | setup | info | records | memory | clear", required: true },
+    { name: "action", summary: "init | setup | status | info | records | memory | clear", required: true },
     { name: "sub", summary: "setup/memory subcommand, or dir for init" },
     { name: "arg", summary: "record id (memory get), query (memory search), or index action" },
   ],
@@ -544,6 +743,8 @@ export const caseVerb: VerbSpec = {
     { name: "dry-run", summary: "setup/edit: preview without saving or applying", type: "boolean" },
     { name: "verb", summary: "Filter records by kind", type: "string" },
     { name: "since", summary: "Time filter (e.g. 24h, 2026-06-01)", type: "string" },
+    { name: "export", summary: "Write a case status/log HTML report", type: "string" },
+    { name: "theme", summary: "HTML export theme: plain | csi", type: "string", choices: ["plain", "csi"], default: "plain" },
     { name: "field", summary: "Payload field to read in full (memory get)", type: "string" },
     { name: "offset", summary: "Start char offset when paging a field (memory get)", type: "number" },
     { name: "limit", summary: "Max records/passages, or max chars when paging a field", type: "number" },
@@ -598,6 +799,23 @@ export const caseVerb: VerbSpec = {
           state: "ready",
         }),
       ];
+    }
+
+    if (action === "status") {
+      const theme = normalizeHtmlTheme(ctx.opts.theme);
+      if (!theme) return [err(`invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
+      const payload = await buildCaseStatus(ctx);
+      let exported: string | undefined;
+      if (ctx.opts.export) {
+        const path = resolve(String(ctx.opts.export));
+        const title = `Case status — ${ctx.case.exists() ? ctx.case.info().name : "case"}`;
+        const html = theme === "csi"
+          ? renderCsiStatusReport({ title, subtitle: ctx.case.dir, payload })
+          : mdToPlainHtml(statusMarkdown(title, payload), title);
+        writeFileSync(path, html, "utf8");
+        exported = path;
+      }
+      return [makeRecord({ verb: "case", format: "json", payload: { ...payload, export: exported ?? null }, state: "ready" })];
     }
 
     if (action === "setup") {
@@ -832,9 +1050,30 @@ export const caseVerb: VerbSpec = {
         limit = n;
       }
       const view = recs.slice(0, limit).map((r) => ({
-        id: r.id, verb: r.verb, state: r.state ?? "ready", media: r.media?.ref ?? null,
+        id: r.id, verb: r.verb, state: r.state ?? "ready", media: r.media?.ref ?? null, at: r.media?.at ?? null,
       }));
-      return [makeRecord({ verb: "case", format: "json", payload: { count: recs.length, records: view }, state: "ready" })];
+      let exported: string | undefined;
+      if (ctx.opts.export) {
+        const theme = normalizeHtmlTheme(ctx.opts.theme);
+        if (!theme) return [err(`invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
+        const path = resolve(String(ctx.opts.export));
+        const counts: Record<string, number> = {};
+        for (const r of recs) counts[r.verb] = (counts[r.verb] ?? 0) + 1;
+        const title = `Case records — ${ctx.case.exists() ? ctx.case.info().name : "case"}`;
+        const html = theme === "csi"
+          ? renderCsiTimelineReport({
+              title,
+              subtitle: ctx.case.dir,
+              kind: "case log",
+              records: recs.map(recordToTimelineRecord),
+              counts,
+              total: recs.length,
+            })
+          : mdToPlainHtml(caseRecordsMarkdown(title, recs, counts), title);
+        writeFileSync(path, html, "utf8");
+        exported = path;
+      }
+      return [makeRecord({ verb: "case", format: "json", payload: { count: recs.length, records: view, export: exported ?? null }, state: "ready" })];
     }
 
     if (action === "memory") {
@@ -1061,6 +1300,6 @@ export const caseVerb: VerbSpec = {
       return [err("usage: case memory <list|get|search|index> [arg]")];
     }
 
-    return [err("usage: case <init|setup|info|records|memory|clear>")];
+    return [err("usage: case <init|setup|status|info|records|memory|clear>")];
   },
 };

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -8,7 +8,7 @@ import { join, resolve } from "node:path";
 import { makeRecord, type OvercastRecord } from "../record.js";
 import { openCase, recordFiles } from "../case.js";
 import { humanSize } from "../render.js";
-import { mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiStatusReport, renderCsiTimelineReport } from "../report/html.js";
+import { isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiStatusReport, renderCsiTimelineReport } from "../report/html.js";
 import { matchesMemoryProvider, resolveMemory } from "../providers/memory/index.js";
 import { parseSince } from "../providers/memory/local.js";
 import { tokenizeCommand } from "../providers/sources/index.js";
@@ -743,7 +743,7 @@ export const caseVerb: VerbSpec = {
     { name: "dry-run", summary: "setup/edit: preview without saving or applying", type: "boolean" },
     { name: "verb", summary: "Filter records by kind", type: "string" },
     { name: "since", summary: "Time filter (e.g. 24h, 2026-06-01)", type: "string" },
-    { name: "export", summary: "Write a case status/log HTML report", type: "string" },
+    { name: "export", summary: "Write a case status/log report (.md or .html)", type: "string" },
     { name: "theme", summary: "HTML export theme: plain | csi", type: "string", choices: ["plain", "csi"], default: "plain" },
     { name: "field", summary: "Payload field to read in full (memory get)", type: "string" },
     { name: "offset", summary: "Start char offset when paging a field (memory get)", type: "number" },
@@ -809,10 +809,11 @@ export const caseVerb: VerbSpec = {
       if (ctx.opts.export) {
         const path = resolve(String(ctx.opts.export));
         const title = `Case status — ${ctx.case.exists() ? ctx.case.info().name : "case"}`;
+        const md = statusMarkdown(title, payload);
         const html = theme === "csi"
           ? renderCsiStatusReport({ title, subtitle: ctx.case.dir, payload })
-          : mdToPlainHtml(statusMarkdown(title, payload), title);
-        writeFileSync(path, html, "utf8");
+          : mdToPlainHtml(md, title);
+        writeFileSync(path, isHtmlExportPath(path) ? html : md, "utf8");
         exported = path;
       }
       return [makeRecord({ verb: "case", format: "json", payload: { ...payload, export: exported ?? null }, state: "ready" })];
@@ -1049,7 +1050,8 @@ export const caseVerb: VerbSpec = {
         }
         limit = n;
       }
-      const view = recs.slice(0, limit).map((r) => ({
+      const limited = recs.slice(0, limit);
+      const view = limited.map((r) => ({
         id: r.id, verb: r.verb, state: r.state ?? "ready", media: r.media?.ref ?? null, at: r.media?.at ?? null,
       }));
       let exported: string | undefined;
@@ -1058,22 +1060,23 @@ export const caseVerb: VerbSpec = {
         if (!theme) return [err(`invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
         const path = resolve(String(ctx.opts.export));
         const counts: Record<string, number> = {};
-        for (const r of recs) counts[r.verb] = (counts[r.verb] ?? 0) + 1;
+        for (const r of limited) counts[r.verb] = (counts[r.verb] ?? 0) + 1;
         const title = `Case records — ${ctx.case.exists() ? ctx.case.info().name : "case"}`;
+        const md = caseRecordsMarkdown(title, limited, counts);
         const html = theme === "csi"
           ? renderCsiTimelineReport({
               title,
               subtitle: ctx.case.dir,
               kind: "case log",
-              records: recs.map(recordToTimelineRecord),
+              records: limited.map(recordToTimelineRecord),
               counts,
-              total: recs.length,
+              total: limited.length,
             })
-          : mdToPlainHtml(caseRecordsMarkdown(title, recs, counts), title);
-        writeFileSync(path, html, "utf8");
+          : mdToPlainHtml(md, title);
+        writeFileSync(path, isHtmlExportPath(path) ? html : md, "utf8");
         exported = path;
       }
-      return [makeRecord({ verb: "case", format: "json", payload: { count: recs.length, records: view, export: exported ?? null }, state: "ready" })];
+      return [makeRecord({ verb: "case", format: "json", payload: { count: limited.length, records: view, export: exported ?? null }, state: "ready" })];
     }
 
     if (action === "memory") {

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -298,8 +298,19 @@ function truncateLine(text: string): string {
   return oneLine.length > 220 ? `${oneLine.slice(0, 220)}...` : oneLine;
 }
 
-function caseRecordsMarkdown(title: string, records: OvercastRecord[], counts: Record<string, number>): string {
-  const lines = [`# ${title}`, "", `**Records:** ${records.length}`, "", "## Counts", ""];
+function sortRecordsChronologically(records: OvercastRecord[]): OvercastRecord[] {
+  return records
+    .map((r, i) => {
+      const parsed = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+      return { r, i, t: Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed };
+    })
+    .sort((a, b) => a.t - b.t || a.i - b.i)
+    .map((x) => x.r);
+}
+
+function caseRecordsMarkdown(title: string, records: OvercastRecord[], counts: Record<string, number>, total = records.length): string {
+  const label = total === records.length ? String(records.length) : `${records.length} of ${total}`;
+  const lines = [`# ${title}`, "", `**Records:** ${label}`, "", "## Counts", ""];
   for (const [verb, n] of Object.entries(counts).sort()) lines.push(`- \`${verb}\`: ${n}`);
   lines.push("", "## Timeline", "");
   for (const r of records) {
@@ -1050,7 +1061,8 @@ export const caseVerb: VerbSpec = {
         }
         limit = n;
       }
-      const limited = recs.slice(0, limit);
+      const total = recs.length;
+      const limited = sortRecordsChronologically(recs).slice(0, limit);
       const view = limited.map((r) => ({
         id: r.id, verb: r.verb, state: r.state ?? "ready", media: r.media?.ref ?? null, at: r.media?.at ?? null,
       }));
@@ -1062,7 +1074,7 @@ export const caseVerb: VerbSpec = {
         const counts: Record<string, number> = {};
         for (const r of limited) counts[r.verb] = (counts[r.verb] ?? 0) + 1;
         const title = `Case records — ${ctx.case.exists() ? ctx.case.info().name : "case"}`;
-        const md = caseRecordsMarkdown(title, limited, counts);
+        const md = caseRecordsMarkdown(title, limited, counts, total);
         const html = theme === "csi"
           ? renderCsiTimelineReport({
               title,
@@ -1070,13 +1082,13 @@ export const caseVerb: VerbSpec = {
               kind: "case log",
               records: limited.map(recordToTimelineRecord),
               counts,
-              total: limited.length,
+              total,
             })
           : mdToPlainHtml(md, title);
         writeFileSync(path, isHtmlExportPath(path) ? html : md, "utf8");
         exported = path;
       }
-      return [makeRecord({ verb: "case", format: "json", payload: { count: limited.length, records: view, export: exported ?? null }, state: "ready" })];
+      return [makeRecord({ verb: "case", format: "json", payload: { count: total, shown: limited.length, limit, truncated: total > limited.length, records: view, export: exported ?? null }, state: "ready" })];
     }
 
     if (action === "memory") {

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -5,6 +5,7 @@
 import { writeFileSync } from "node:fs";
 import { resolve, extname } from "node:path";
 import { makeRecord, memoryRecords, type OvercastRecord } from "../record.js";
+import { mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiTimelineReport } from "../report/html.js";
 import { resolveMemory, fanOutAnswer, matchesMemoryProvider } from "../providers/memory/index.js";
 import { parseSince } from "../providers/memory/local.js";
 import { tcAsk } from "../providers/tinycloud/collection.js";
@@ -180,6 +181,7 @@ interface BriefData {
   md: string;
   counts: Record<string, number>;
   total: number;
+  records: OvercastRecord[];
 }
 
 /** Build a markdown brief from the case records (timeline + by-kind sections). */
@@ -223,7 +225,7 @@ function buildBrief(records: OvercastRecord[], caseName: string): BriefData {
     const fence = fenceFor(body);
     lines.push(fence, body, fence, "");
   }
-  return { md: lines.join("\n"), counts, total: records.length };
+  return { md: lines.join("\n"), counts, total: records.length, records: sorted };
 }
 
 // Brief is an export artifact: embed each record's primary field IN FULL (not a
@@ -251,44 +253,6 @@ function briefBody(rec: OvercastRecord): string {
   return `payload: ${Object.keys(p).join(", ") || "(empty)"}`;
 }
 
-function mdToHtml(md: string, title: string): string {
-  // minimal, dependency-free md→html for the export artifact
-  const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  const out: string[] = [];
-  let fence: string | null = null; // the opening fence string while inside a code block
-  for (const line of md.split("\n")) {
-    if (fence == null && /^`{3,}\s*$/.test(line)) {
-      fence = line.trim();
-      out.push("<pre>");
-      continue;
-    }
-    if (fence != null) {
-      // inside a fence: everything is escaped literal data, closed only by the
-      // exact matching fence — embedded #/-/``` are NOT treated as markup.
-      if (line.trim() === fence) {
-        out.push("</pre>");
-        fence = null;
-      } else {
-        out.push(esc(line));
-      }
-      continue;
-    }
-    if (/^### /.test(line)) out.push(`<h3>${esc(line.slice(4))}</h3>`);
-    else if (/^# /.test(line)) out.push(`<h1>${esc(line.slice(2))}</h1>`);
-    else if (/^## /.test(line)) out.push(`<h2>${esc(line.slice(3))}</h2>`);
-    else if (/^- /.test(line)) out.push(`<li>${esc(line.slice(2))}</li>`);
-    else if (line.trim() === "") out.push("");
-    else out.push(`<p>${esc(line)}</p>`);
-  }
-  const body = out.join("\n");
-  return `<!doctype html><html><head><meta charset="utf-8"><title>${esc(title)}</title>
-<style>body{background:#08120c;color:#c6f7d5;font-family:ui-monospace,monospace;max-width:840px;margin:2rem auto;padding:1rem}
-h1,h2{color:#ffc400}code{color:#00ff7f}li{margin:2px 0}
-pre{white-space:pre-wrap;word-break:break-word;background:#0d1f14;padding:8px;border-radius:4px}</style></head><body>
-${body}
-</body></html>`;
-}
-
 export const briefVerb: VerbSpec = {
   name: "brief",
   group: "read",
@@ -300,6 +264,7 @@ export const briefVerb: VerbSpec = {
   flags: [
     { name: "scope", summary: "Filter, e.g. since:24h or verb:watch", type: "string" },
     { name: "export", summary: "Write a report file (.md or .html)", type: "string" },
+    { name: "theme", summary: "HTML export theme: plain | csi", type: "string", choices: ["plain", "csi"], default: "plain" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],
@@ -340,6 +305,8 @@ export const briefVerb: VerbSpec = {
     }
     const info = ctx.case.exists() ? ctx.case.info() : { name: "case" };
     const brief = buildBrief(records, info.name);
+    const theme = normalizeHtmlTheme(ctx.opts.theme);
+    if (!theme) return [readError("brief", `invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
     if (brief.total === 0) {
       return [
         makeRecord({
@@ -362,7 +329,17 @@ export const briefVerb: VerbSpec = {
     if (ctx.opts.export) {
       const path = resolve(String(ctx.opts.export));
       const isHtml = extname(path).toLowerCase() === ".html";
-      writeFileSync(path, isHtml ? mdToHtml(brief.md, `Brief — ${info.name}`) : brief.md, "utf8");
+      const html = theme === "csi"
+        ? renderCsiTimelineReport({
+            title: `Brief — ${info.name}`,
+            subtitle: ctx.case.dir,
+            kind: "brief",
+            records: brief.records.map(recordToTimelineRecord),
+            counts: brief.counts,
+            total: brief.total,
+          })
+        : mdToPlainHtml(brief.md, `Brief — ${info.name}`);
+      writeFileSync(path, isHtml ? html : brief.md, "utf8");
       exported = path;
     }
 

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -3,9 +3,9 @@
 // the bound memory providers (fan-out); currently the local provider.
 
 import { writeFileSync } from "node:fs";
-import { resolve, extname } from "node:path";
+import { resolve } from "node:path";
 import { makeRecord, memoryRecords, type OvercastRecord } from "../record.js";
-import { mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiTimelineReport } from "../report/html.js";
+import { isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiTimelineReport } from "../report/html.js";
 import { resolveMemory, fanOutAnswer, matchesMemoryProvider } from "../providers/memory/index.js";
 import { parseSince } from "../providers/memory/local.js";
 import { tcAsk } from "../providers/tinycloud/collection.js";
@@ -328,7 +328,7 @@ export const briefVerb: VerbSpec = {
     let exported: string | undefined;
     if (ctx.opts.export) {
       const path = resolve(String(ctx.opts.export));
-      const isHtml = extname(path).toLowerCase() === ".html";
+      const isHtml = isHtmlExportPath(path);
       const html = theme === "csi"
         ? renderCsiTimelineReport({
             title: `Brief — ${info.name}`,

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -23,6 +23,8 @@ import { PI_VERSION } from "../version.js";
 import { envPresent } from "../env.js";
 import { listSources } from "../state/source.js";
 import { existsSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
 function err(verb: string, message: string): OvercastRecord {
@@ -31,6 +33,17 @@ function err(verb: string, message: string): OvercastRecord {
 
 function quoteCommandArg(arg: string): string {
   return /^[A-Za-z0-9_./:=@+-]+$/.test(arg) ? arg : JSON.stringify(arg);
+}
+
+function packageRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, "package.json"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return process.cwd();
 }
 
 /** Minimum tinycloud the face + index verbs need (`face match` landed in
@@ -437,6 +450,28 @@ export const doctorVerb: VerbSpec = {
           : "optional semantic memory CLI missing — install with `npm install -g @tobilu/qmd`",
       });
     }
+
+    const playwrightProbe = [
+      "const { existsSync } = await import('node:fs');",
+      "try {",
+      "  const { chromium } = await import('playwright');",
+      "  const executablePath = chromium.executablePath();",
+      "  if (!executablePath || !existsSync(executablePath)) throw new Error('Chromium browser payload missing');",
+      "  console.log(executablePath);",
+      "} catch (e) {",
+      "  console.error(e && e.message ? e.message : String(e));",
+      "  process.exit(1);",
+      "}",
+    ].join("\n");
+    const playwright = await execCapture(process.execPath, ["-e", playwrightProbe], { cwd: packageRoot(), timeoutMs: 15_000 })
+      .catch((e) => ({ code: 1, stdout: "", stderr: (e as Error).message }));
+    checks.push({
+      name: "playwright",
+      ok: playwright.code === 0,
+      detail: playwright.code === 0
+        ? `optional HTML screenshot renderer available (${playwright.stdout.trim()})`
+        : "optional HTML screenshot renderer missing — run `npm install --include=optional` and `npx playwright install chromium`",
+    });
 
     const uv = await execCapture("uv", ["--version"], { timeoutMs: 15_000 }).catch(() => ({ code: 1, stdout: "", stderr: "" }));
     const localPy = localVisionPython();

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -22,8 +22,8 @@ import { localVisionPython } from "../providers/local/vision.js";
 import { PI_VERSION } from "../version.js";
 import { envPresent } from "../env.js";
 import { listSources } from "../state/source.js";
-import { existsSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
@@ -38,12 +38,30 @@ function quoteCommandArg(arg: string): string {
 function packageRoot(): string {
   let dir = dirname(fileURLToPath(import.meta.url));
   for (let i = 0; i < 8; i++) {
-    if (existsSync(join(dir, "package.json"))) return dir;
+    const pkg = join(dir, "package.json");
+    if (existsSync(pkg) && isRealPackage(pkg)) return dir;
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }
   return process.cwd();
+}
+
+function isRealPackage(pkgJsonPath: string): boolean {
+  try {
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+      dependencies?: unknown;
+      files?: unknown;
+    };
+    return pkg.dependencies != null || pkg.files != null;
+  } catch {
+    return false;
+  }
+}
+
+function nodeProbeExecutable(): string {
+  const exe = basename(process.execPath).toLowerCase();
+  return exe === "node" || exe === "node.exe" ? process.execPath : "node";
 }
 
 /** Minimum tinycloud the face + index verbs need (`face match` landed in
@@ -463,7 +481,7 @@ export const doctorVerb: VerbSpec = {
       "  process.exit(1);",
       "}",
     ].join("\n");
-    const playwright = await execCapture(process.execPath, ["-e", playwrightProbe], { cwd: packageRoot(), timeoutMs: 15_000 })
+    const playwright = await execCapture(nodeProbeExecutable(), ["-e", playwrightProbe], { cwd: packageRoot(), timeoutMs: 15_000 })
       .catch((e) => ({ code: 1, stdout: "", stderr: (e as Error).message }));
     checks.push({
       name: "playwright",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -65,9 +65,13 @@ bash test/e2e/live/run.sh 10 11 70   # just watch, listen, headless
 `13_enhance_view` · `20_sources` (Tavily/Apify/yt-dlp) · `21_pipeline`
 (source→capture→sense) · `22_monitor` (`--once` diff + bounded `--every`) ·
 `23_index` · `24_case_search` · `16_visual_db` (local image-ransac,
-`face:deepface-local`, and deepface-local with real media) · `30_read` (ask/brief over real records) · `40_profiles` · `50_piping` (jq /
-chaining) · `60_dist` (binary as artifact) · `70_headless` (agent `--mode json`
-event stream + `-p` tool use + watch/persist).
+`face:deepface-local`, and deepface-local with real media) · `30_read`
+(ask/brief over real records) · `31_visualization` (CSI status/brief/records
+exports with real visual targets and matches) · `32_headless_visualization`
+(headless agent `--mode json` export trace, default CSI HTML theme) ·
+`40_profiles` · `50_piping` (jq / chaining) · `60_dist` (binary as artifact) ·
+`70_headless` (agent `--mode json` event stream + `-p` tool use +
+watch/persist).
 
 The offline suite also covers setup management (`phase4_setup`): `case setup
 plan`, apply with target/note/source, `show`, `edit`, saved `.overcast/setup.json`,

--- a/test/e2e/live/cases/31_visualization.sh
+++ b/test/e2e/live/cases/31_visualization.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Real-video case visualization: seed evidence with a real watch, then export the
+# CSI-style self-contained HTML brief/status/log artifacts.
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; source "$LIVE/lib.sh"
+C="visualization"
+require_cred "$C" CLOUDGLUE_API_KEY "skipping (needs a real watch to visualize)" || exit 0
+
+CLIP="$SMOKE_DIR/viz_clip.mp4"
+have_media "$VIDEO_VISUAL" && clip_av 12 "$VIDEO_VISUAL" "$CLIP"
+[ -f "$CLIP" ] || { skip "$C" "no clip"; exit 0; }
+
+CASE=$(case_dir visualization)
+
+cond "case setup records named and visual targets for Will Smith and Starbucks"
+setup_args=(case setup --name case_visualization --target "Will Smith,Starbucks" --source "web:Will Smith Starbucks visual evidence" --note "Investigation scope: verify whether Will Smith face evidence and Starbucks logo/image evidence appear in the configured real media." --yes --no-index --json)
+have_media "$LOCAL_FACE_IMAGE" && setup_args+=(--face-ref "$LOCAL_FACE_IMAGE")
+have_media "$LOCAL_IMAGE_REF" && setup_args+=(--image-target "$LOCAL_IMAGE_REF")
+setup="$(oc "$CASE" "${setup_args[@]}")"
+assert_eq "$C.setup.state" "true" "$(echo "$setup" | jq -sr 'all(.state == "ready")')" "case setup records ready"
+assert_nonempty "$C.setup.targets" "$(echo "$setup" | jq -sr 'map(select(.payload.after).payload.after.targets | length) | .[-1] // empty')" "setup target scope recorded"
+
+cond "visualization case seeds a real watch record from a real video"
+w="$(OC_TIMEOUT=300 oc "$CASE" watch "$CLIP" --json)"
+assert_eq "$C.seed.state" "ready" "$(echo "$w" | jq -r '.state')" "seed watch ready"
+assert_nonempty "$C.seed.content" "$(echo "$w" | jq -r '.payload.content')" "watch content available"
+
+PY="${OC_VISUAL_DB_PY:-${OVERCAST_VISUAL_DB_PY:-python3}}"
+if [ ! -x "$PY" ] && [ -x "$LIVE/../../../.dev/visual-db-py/bin/python" ]; then
+  PY="$LIVE/../../../.dev/visual-db-py/bin/python"
+fi
+export OC_VISUAL_DB_PY="$PY"
+export OVERCAST_VISUAL_DB_PY="$PY"
+if have_media "$LOCAL_IMAGE_REF" && have_media "$LOCAL_IMAGE_VIDEO_A" && "$PY" - <<'PY' >/dev/null 2>&1
+import cv2, numpy
+PY
+then
+  cond "local image matching traces the Starbucks reference against real video"
+  img_index_rec="$(oc "$CASE" index create starbucks-viz --type image-ransac --local --json)"
+  IMG_INDEX="$(echo "$img_index_rec" | jq -r '.payload.index // empty')"
+  assert_nonempty "$C.starbucks.index" "$IMG_INDEX" "Starbucks image index id returned"
+  img_add="$(oc "$CASE" image add "$LOCAL_IMAGE_REF" --index "$IMG_INDEX" --json)"
+  assert_eq "$C.starbucks.add" "ready" "$(echo "$img_add" | jq -r '.state')" "Starbucks reference added"
+  img_match="$(OC_TIMEOUT=420 oc "$CASE" image match "$LOCAL_IMAGE_VIDEO_A" --index "$IMG_INDEX" --min-inliers "${OC_LOCAL_IMAGE_MIN_INLIERS:-8}" --min-ratio "${OC_LOCAL_IMAGE_MIN_RATIO:-0.25}" --fps "${OC_LOCAL_IMAGE_FPS:-0.7}" --max-frames "${OC_LOCAL_IMAGE_MAX_FRAMES:-12}" --draw --json)"
+  starbucks_state="$(echo "$img_match" | jq -r '.state // empty' 2>/dev/null || true)"
+  starbucks_count="$(echo "$img_match" | jq -r '.payload.count // 0' 2>/dev/null || echo 0)"
+  if [ "$starbucks_state" = "ready" ]; then
+    ok "$C.starbucks.match" "Starbucks image match ran"
+  else
+    skip "$C.starbucks.match" "Starbucks image matcher returned no ready record"
+  fi
+  if [ "$starbucks_state" = "ready" ] && [ "${starbucks_count:-0}" -gt 0 ]; then
+    ok "$C.starbucks.count" "found $starbucks_count Starbucks image match(es)"
+  else
+    skip "$C.starbucks.count" "Starbucks matcher ran but found 0 matches in the sampled frames"
+  fi
+  note_text="Starbucks image trace: local RANSAC compared the Starbucks reference image with candidate video A and returned ${starbucks_count:-0} match(es)."
+  oc "$CASE" note "$note_text" --tag "starbucks,image-match,tldr" --confidence medium --json >/dev/null
+else
+  skip "$C.starbucks" "missing Starbucks media or OpenCV deps"
+fi
+
+if have_media "$LOCAL_FACE_IMAGE" && have_media "$LOCAL_FACE_VIDEO" && "$PY" - <<'PY' >/dev/null 2>&1
+import deepface, numpy
+PY
+then
+  cond "local face matching traces the Will Smith reference against real video"
+  face_setup="$(oc "$CASE" provider setup apply --verb face --choice deepface-local --profile local --yes --json)"
+  assert_eq "$C.will.provider" "ready" "$(echo "$face_setup" | jq -r '.state')" "deepface-local provider setup ready"
+  face_index_rec="$(oc "$CASE" index create will-viz --type deepface-local --local --json)"
+  FACE_INDEX="$(echo "$face_index_rec" | jq -r '.payload.index // empty')"
+  assert_nonempty "$C.will.index" "$FACE_INDEX" "Will face index id returned"
+  face_add="$(oc "$CASE" index add "$LOCAL_FACE_IMAGE" --to "$FACE_INDEX" --json)"
+  assert_eq "$C.will.add" "ready" "$(echo "$face_add" | jq -r '.state')" "Will reference added"
+  face_match="$(OC_TIMEOUT=420 oc "$CASE" face "$LOCAL_FACE_VIDEO" --match "$LOCAL_FACE_IMAGE" --index "$FACE_INDEX" --profile local --min-similarity "${OC_LOCAL_FACE_MIN_SIMILARITY:-45}" --fps "${OC_LOCAL_FACE_FPS:-0.5}" --max-frames "${OC_LOCAL_FACE_MAX_FRAMES:-24}" --json)"
+  will_state="$(echo "$face_match" | jq -r '.state // empty' 2>/dev/null || true)"
+  will_count="$(echo "$face_match" | jq -r '.payload.count // 0' 2>/dev/null || echo 0)"
+  if [ "$will_state" = "ready" ]; then
+    ok "$C.will.match" "Will face match ran"
+  else
+    skip "$C.will.match" "Will face matcher returned no ready record"
+  fi
+  if [ "$will_state" = "ready" ] && [ "${will_count:-0}" -gt 0 ]; then
+    ok "$C.will.count" "found $will_count Will Smith face match(es)"
+  else
+    skip "$C.will.count" "Will matcher ran but found 0 matches in the sampled frames"
+  fi
+  note_text="Will Smith face trace: local DeepFace compared the Will Smith reference image with candidate video and returned ${will_count:-0} match(es)."
+  oc "$CASE" note "$note_text" --tag "will-smith,face-match,tldr" --confidence medium --json >/dev/null
+else
+  skip "$C.will" "missing Will Smith media or DeepFace deps"
+fi
+
+cond "case memory can produce a TL;DR over the visual matching findings"
+tldr="$(oc "$CASE" ask "TL;DR the Will Smith and Starbucks visual findings in this case" --json)"
+save_json "31_visualization_tldr" "$tldr" >/dev/null
+assert_eq "$C.tldr.state" "ready" "$(echo "$tldr" | jq -r '.state')" "ask TL;DR ready"
+assert_nonempty "$C.tldr.text" "$(echo "$tldr" | jq -r '.payload.text')" "ask returned TL;DR text"
+
+cond "brief exports a CSI HTML visualization with escaped case evidence"
+BHTML="$SMOKE_DIR/visualization-brief-csi.html"
+b="$(oc "$CASE" brief --export "$BHTML" --theme csi --json)"
+save_json "31_visualization_brief" "$b" >/dev/null
+assert_eq "$C.brief.state" "ready" "$(echo "$b" | jq -r '.state')" "brief ready"
+assert_eq "$C.brief.export" "$BHTML" "$(echo "$b" | jq -r '.payload.export')" "brief export path returned"
+if [ -f "$BHTML" ] && grep -q 'data-overcast-theme="csi"' "$BHTML" && grep -q 'data-csi-timeline="true"' "$BHTML"; then
+  ok "$C.brief.html" "CSI brief HTML exported: $BHTML"
+else
+  fail "$C.brief.html" "missing CSI brief HTML markers"
+fi
+
+cond "case status exports a CSI HTML status visualization"
+SHTML="$SMOKE_DIR/visualization-status-csi.html"
+s="$(oc "$CASE" case status --export "$SHTML" --theme csi --json)"
+save_json "31_visualization_status" "$s" >/dev/null
+assert_eq "$C.status.state" "ready" "$(echo "$s" | jq -r '.state')" "status ready"
+assert_eq "$C.status.export" "$SHTML" "$(echo "$s" | jq -r '.payload.export')" "status export path returned"
+assert_nonempty "$C.status.memory" "$(echo "$s" | jq -r '.payload.memory_index | length')" "memory provider status included"
+if [ -f "$SHTML" ] && grep -q 'data-overcast-theme="csi"' "$SHTML" && grep -q 'data-csi-status="true"' "$SHTML"; then
+  ok "$C.status.html" "CSI status HTML exported: $SHTML"
+else
+  fail "$C.status.html" "missing CSI status HTML markers"
+fi
+
+cond "case records exports a CSI HTML audit timeline"
+RHTML="$SMOKE_DIR/visualization-records-csi.html"
+r="$(oc "$CASE" case records --export "$RHTML" --theme csi --json)"
+save_json "31_visualization_records" "$r" >/dev/null
+assert_eq "$C.records.state" "ready" "$(echo "$r" | jq -r '.state')" "records ready"
+assert_eq "$C.records.export" "$RHTML" "$(echo "$r" | jq -r '.payload.export')" "records export path returned"
+if [ -f "$RHTML" ] && grep -q 'data-csi-timeline="true"' "$RHTML" && grep -q 'watch' "$RHTML"; then
+  ok "$C.records.html" "CSI records timeline exported: $RHTML"
+else
+  fail "$C.records.html" "missing CSI records timeline"
+fi

--- a/test/e2e/live/cases/32_headless_visualization.sh
+++ b/test/e2e/live/cases/32_headless_visualization.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Headless agent visualization export — seed a real case, ask the pi headless
+# agent to run the HTML exports, then parse the JSONL trace for tool result paths.
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; source "$LIVE/lib.sh"
+C="headless_visualization"
+require_cred "$C" CLOUDGLUE_API_KEY "headless agent needs a brain LLM" || exit 0
+
+CLIP="$SMOKE_DIR/headless_viz_clip.mp4"
+have_media "$VIDEO_VISUAL" && clip_av 10 "$VIDEO_VISUAL" "$CLIP"
+[ -f "$CLIP" ] || { skip "$C" "no real visual clip configured"; exit 0; }
+
+CASE=$(case_dir headless_visualization)
+OUT_DIR="$SMOKE_DIR/headless-visualization-agent"
+mkdir -p "$OUT_DIR"
+STATUS_HTML="$OUT_DIR/status.html"
+BRIEF_HTML="$OUT_DIR/brief.html"
+RECORDS_HTML="$OUT_DIR/records.html"
+EVENTS="$OUT_DIR/events.jsonl"
+TRACE_EXPORTS="$OUT_DIR/tool-exports.json"
+
+cond "seed a real case with Will Smith / Starbucks visual scope"
+setup_args=(case setup --name headless_visualization --target "Will Smith,Starbucks" --source "web:Will Smith Starbucks visual evidence" --note "Investigation scope: verify whether Will Smith face evidence and Starbucks logo/image evidence appear in the configured real media." --yes --no-index --json)
+have_media "$LOCAL_FACE_IMAGE" && setup_args+=(--face-ref "$LOCAL_FACE_IMAGE")
+have_media "$LOCAL_IMAGE_REF" && setup_args+=(--image-target "$LOCAL_IMAGE_REF")
+setup="$(oc "$CASE" "${setup_args[@]}")"
+assert_eq "$C.setup.state" "true" "$(echo "$setup" | jq -sr 'all(.state == "ready")')" "case setup records ready"
+
+cond "seed real watch evidence before the headless agent exports reports"
+w="$(OC_TIMEOUT=300 oc "$CASE" watch "$CLIP" --json)"
+assert_eq "$C.watch.state" "ready" "$(echo "$w" | jq -r '.state')" "real watch evidence ready"
+assert_nonempty "$C.watch.content" "$(echo "$w" | jq -r '.payload.content')" "watch content available"
+
+note_text="Starbucks / Will Smith visualization trace: this case contains real video evidence plus explicit target/source scope for the headless report export path."
+oc "$CASE" note "$note_text" --tag "starbucks,will-smith,headless-visualization,tldr" --confidence medium --json >/dev/null
+
+cond "headless agent exports status, brief, and records HTML using the agent default theme"
+prompt="Use overcast tools for this case and run exactly these exports without passing any theme argument: case status --export $STATUS_HTML; brief --export $BRIEF_HTML; case records --export $RECORDS_HTML. Reply with JSON only shaped like {\"status\":\"$STATUS_HTML\",\"brief\":\"$BRIEF_HTML\",\"records\":\"$RECORDS_HTML\"}."
+out="$(OC_TIMEOUT=360 oc "$CASE" --mode json "$prompt")"
+printf '%s' "$out" >"$EVENTS"
+assert_nonempty "$C.trace.nonempty" "$out" "headless JSONL trace captured"
+invalid=0; nlines=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  nlines=$((nlines + 1))
+  printf '%s' "$line" | jq -e . >/dev/null 2>&1 || invalid=$((invalid + 1))
+done <"$EVENTS"
+assert_eq "$C.trace.valid" "0" "$invalid" "every one of $nlines event lines is valid JSON"
+
+jq -sr '
+  [
+    .[]
+    | select(.type == "agent_end")
+    | .messages[]?
+    | select(.role == "toolResult")
+    | .details.records[]?
+    | select(.state == "ready" and (.payload.export? != null))
+    | {verb, export: .payload.export}
+  ]
+' "$EVENTS" >"$TRACE_EXPORTS"
+
+status_path="$(jq -r '[.[] | select(.verb == "case" and (.export | test("status\\.html$")))] | .[0].export // empty' "$TRACE_EXPORTS")"
+brief_path="$(jq -r '[.[] | select(.verb == "brief" and (.export | test("brief\\.html$")))] | .[0].export // empty' "$TRACE_EXPORTS")"
+records_path="$(jq -r '[.[] | select(.verb == "case" and (.export | test("records\\.html$")))] | .[0].export // empty' "$TRACE_EXPORTS")"
+assert_eq "$C.trace.status_path" "$STATUS_HTML" "$status_path" "trace exposed status export path"
+assert_eq "$C.trace.brief_path" "$BRIEF_HTML" "$brief_path" "trace exposed brief export path"
+assert_eq "$C.trace.records_path" "$RECORDS_HTML" "$records_path" "trace exposed records export path"
+
+tool_names="$(jq -sr '[.[] | select(.type == "agent_end") | .messages[]? | select(.role == "assistant") | .content[]? | select(.type == "toolCall") | .name] | join(",")' "$EVENTS")"
+if printf '%s' "$tool_names" | grep -q "case" && printf '%s' "$tool_names" | grep -q "brief"; then
+  ok "$C.trace.tool_calls" "agent trace includes case and brief tool calls"
+else
+  fail "$C.trace.tool_calls" "missing expected tool calls in trace: $tool_names"
+fi
+theme_arg_count="$(jq -sr '[.[] | select(.type == "agent_end") | .messages[]? | select(.role == "assistant") | .content[]? | select(.type == "toolCall") | select(.arguments.theme? != null)] | length' "$EVENTS")"
+assert_eq "$C.trace.no_theme_arg" "0" "${theme_arg_count:-0}" "agent did not pass an explicit theme argument"
+
+cond "headless-exported HTML files exist and contain CSI visualization markers from the default"
+if [ -f "$STATUS_HTML" ] && grep -q 'data-overcast-theme="csi"' "$STATUS_HTML" && grep -q 'data-csi-status="true"' "$STATUS_HTML" && grep -q "TL;DR" "$STATUS_HTML"; then
+  ok "$C.status.html" "headless status HTML exported: $STATUS_HTML"
+else
+  fail "$C.status.html" "missing status CSI markers"
+fi
+if [ -f "$BRIEF_HTML" ] && grep -q 'data-overcast-theme="csi"' "$BRIEF_HTML" && grep -q 'data-csi-timeline="true"' "$BRIEF_HTML"; then
+  ok "$C.brief.html" "headless brief HTML exported: $BRIEF_HTML"
+else
+  fail "$C.brief.html" "missing brief CSI markers"
+fi
+if [ -f "$RECORDS_HTML" ] && grep -q 'data-csi-timeline="true"' "$RECORDS_HTML" && grep -q 'watch' "$RECORDS_HTML"; then
+  ok "$C.records.html" "headless records HTML exported: $RECORDS_HTML"
+else
+  fail "$C.records.html" "missing records CSI timeline"
+fi

--- a/test/unit/case-verb.test.ts
+++ b/test/unit/case-verb.test.ts
@@ -38,6 +38,70 @@ test("case records --verb filters", async () => {
   });
 });
 
+test("case status returns combined status payload", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    addTarget(c, "subject");
+    const targetImg = join(dir, "target.png");
+    writeFileSync(targetImg, "fake png");
+    addTarget(c, targetImg, { image: true });
+    addSource(c, "web:subject");
+    addIndex(c, { id: "idx_case", name: "Case Index", type: "media-descriptions" });
+    const matchImg = join(dir, "match.jpg");
+    writeFileSync(matchImg, "fake jpg");
+    c.writeRecord(makeRecord({ verb: "image", payload: { op: "match", matches: [{ match_draw_path: matchImg }], count: 1 }, state: "ready" }));
+
+    const [rec] = await caseVerb.run(ctx(dir, "status"));
+    const payload = rec.payload as Record<string, unknown>;
+    assert.equal(rec.state, "ready");
+    assert.equal(payload.initialized, true);
+    assert.equal(((payload.store as Record<string, unknown>).records), 3);
+    assert.equal(((payload.registries as Record<string, unknown>).targets), 2);
+    assert.equal(((payload.registries as Record<string, unknown>).sources), 1);
+    assert.equal(((payload.registries as Record<string, unknown>).indexes), 1);
+    assert.ok(Array.isArray(payload.memory_index));
+    assert.match(String((payload.tldr as Record<string, unknown>).headline), /tracking subject/);
+    assert.equal((payload.targets as unknown[]).length, 2);
+    assert.equal((payload.sources as unknown[]).length, 1);
+    assert.equal((payload.match_visualizations as unknown[]).length, 1);
+  });
+});
+
+test("case status --export html --theme csi writes report", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    addTarget(c, "subject");
+    addSource(c, "web:subject");
+    const htmlPath = join(dir, "status.html");
+    const [rec] = await caseVerb.run(ctx(dir, "status", [], { export: htmlPath, theme: "csi" }));
+    const payload = rec.payload as Record<string, unknown>;
+    const html = readFileSync(htmlPath, "utf8");
+    assert.equal(payload.export, htmlPath);
+    assert.match(html, /data-overcast-theme="csi"/);
+    assert.match(html, /data-csi-status="true"/);
+    assert.match(html, /data-csi-tldr="true"/);
+    assert.match(html, /data-csi-context="true"/);
+    assert.match(html, /Case status/);
+  });
+});
+
+test("case records --export html --theme csi writes timeline", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "unsafe <b>markup</b>" }, media: { ref: "note.txt", at: 12 } }));
+    const htmlPath = join(dir, "case-log.html");
+    const [rec] = await caseVerb.run(ctx(dir, "records", [], { export: htmlPath, theme: "csi" }));
+    const payload = rec.payload as Record<string, unknown>;
+    const html = readFileSync(htmlPath, "utf8");
+    assert.equal(payload.export, htmlPath);
+    assert.match(html, /data-csi-timeline="true"/);
+    assert.match(html, /watch/);
+    assert.match(html, /note\.txt @12/);
+    assert.match(html, /&lt;b&gt;markup&lt;\/b&gt;/);
+    assert.doesNotMatch(html, /<b>markup<\/b>/);
+  });
+});
+
 test("case clear previews what will be lost and requires --yes", async () => {
   await withCase(async (dir) => {
     const c = openCase(dir);

--- a/test/unit/case-verb.test.ts
+++ b/test/unit/case-verb.test.ts
@@ -105,8 +105,8 @@ test("case records --export html --theme csi writes timeline", async () => {
 test("case report exports honor file extension and records limit", async () => {
   await withCase(async (dir) => {
     const c = openCase(dir);
-    c.writeRecord(makeRecord({ verb: "note", payload: { text: "first limited note" } }));
-    c.writeRecord(makeRecord({ verb: "note", payload: { text: "second limited note" } }));
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "first limited note" }, meta: { time: "2020-01-01T00:00:00Z" } }));
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "second limited note" }, meta: { time: "2026-01-01T00:00:00Z" } }));
 
     const statusMd = join(dir, "status.md");
     await caseVerb.run(ctx(dir, "status", [], { export: statusMd, theme: "csi" }));
@@ -120,9 +120,13 @@ test("case report exports honor file extension and records limit", async () => {
     const payload = rec.payload as Record<string, unknown>;
     const view = payload.records as unknown[];
     const html = readFileSync(recordsHtml, "utf8");
-    assert.equal(payload.count, 1);
+    assert.equal(payload.count, 2);
+    assert.equal(payload.shown, 1);
+    assert.equal(payload.limit, 1);
+    assert.equal(payload.truncated, true);
     assert.equal(view.length, 1);
     assert.match(html, /data-csi-timeline="true"/);
+    assert.match(html, /<strong>2<\/strong>/);
     assert.match(html, /first limited note/);
     assert.doesNotMatch(html, /second limited note/);
 
@@ -130,8 +134,34 @@ test("case report exports honor file extension and records limit", async () => {
     await caseVerb.run(ctx(dir, "records", [], { verb: "note", export: recordsMd, theme: "csi", limit: 1 }));
     const md = readFileSync(recordsMd, "utf8");
     assert.match(md, /^# Case records/m);
+    assert.match(md, /\*\*Records:\*\* 1 of 2/);
     assert.doesNotMatch(md, /<html/i);
     assert.doesNotMatch(md, /second limited note/);
+  });
+});
+
+test("case records reports sort dated entries chronologically before limiting", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "DATED-2026" }, meta: { time: "2026-01-01T00:00:00Z" } }));
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "UNDATED-A" } }));
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "DATED-2020" }, meta: { time: "2020-01-01T00:00:00Z" } }));
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "UNDATED-B" } }));
+
+    const recordsHtml = join(dir, "records.html");
+    const [rec] = await caseVerb.run(ctx(dir, "records", [], { verb: "note", export: recordsHtml, theme: "csi", limit: 4 }));
+    const payload = rec.payload as Record<string, unknown>;
+    const records = payload.records as Array<Record<string, unknown>>;
+    const html = readFileSync(recordsHtml, "utf8");
+    assert.equal(payload.count, 4);
+    assert.equal(payload.shown, 4);
+    assert.equal(payload.truncated, false);
+    assert.deepEqual(records.map((r) => r.verb), ["note", "note", "note", "note"]);
+    const order = ["DATED-2020", "DATED-2026", "UNDATED-A", "UNDATED-B"].map((s) => html.indexOf(s));
+    assert.ok(order.every((i) => i >= 0));
+    assert.ok(order[0] < order[1], "2020 before 2026");
+    assert.ok(order[1] < order[2], "dated before undated");
+    assert.ok(order[2] < order[3], "undated kept in insertion order");
   });
 });
 

--- a/test/unit/case-verb.test.ts
+++ b/test/unit/case-verb.test.ts
@@ -102,6 +102,39 @@ test("case records --export html --theme csi writes timeline", async () => {
   });
 });
 
+test("case report exports honor file extension and records limit", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "first limited note" } }));
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "second limited note" } }));
+
+    const statusMd = join(dir, "status.md");
+    await caseVerb.run(ctx(dir, "status", [], { export: statusMd, theme: "csi" }));
+    const statusText = readFileSync(statusMd, "utf8");
+    assert.match(statusText, /^# Case status/m);
+    assert.doesNotMatch(statusText, /<html/i);
+    assert.doesNotMatch(statusText, /data-overcast-theme="csi"/);
+
+    const recordsHtml = join(dir, "records.html");
+    const [rec] = await caseVerb.run(ctx(dir, "records", [], { verb: "note", export: recordsHtml, theme: "csi", limit: 1 }));
+    const payload = rec.payload as Record<string, unknown>;
+    const view = payload.records as unknown[];
+    const html = readFileSync(recordsHtml, "utf8");
+    assert.equal(payload.count, 1);
+    assert.equal(view.length, 1);
+    assert.match(html, /data-csi-timeline="true"/);
+    assert.match(html, /first limited note/);
+    assert.doesNotMatch(html, /second limited note/);
+
+    const recordsMd = join(dir, "records.md");
+    await caseVerb.run(ctx(dir, "records", [], { verb: "note", export: recordsMd, theme: "csi", limit: 1 }));
+    const md = readFileSync(recordsMd, "utf8");
+    assert.match(md, /^# Case records/m);
+    assert.doesNotMatch(md, /<html/i);
+    assert.doesNotMatch(md, /second limited note/);
+  });
+});
+
 test("case clear previews what will be lost and requires --yes", async () => {
   await withCase(async (dir) => {
     const c = openCase(dir);

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -788,7 +788,26 @@ test("brief verb builds a report and --export writes md + html", async () => {
     const html = readFileSync(htmlPath, "utf8");
     assert.match(html, /<h1>/);
     assert.match(html, /white van/);
+    assert.doesNotMatch(html, /data-overcast-theme="csi"/);
   });
+});
+
+test("brief --export html --theme csi writes escaped CSI report", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-briefcsi-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "seen <script>alert(1)</script> near docks" }, media: { ref: "v.mp4" } }));
+    const htmlPath = join(dir, "csi.html");
+    const [rec] = await briefVerb.run(ctx(c, undefined, { export: htmlPath, theme: "csi" }));
+    const html = readFileSync(htmlPath, "utf8");
+    assert.equal((rec.payload as Record<string, unknown>).export, htmlPath);
+    assert.match(html, /data-overcast-theme="csi"/);
+    assert.match(html, /data-csi-timeline="true"/);
+    assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+    assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("brief on an empty evidence set is transient and does not export", async () => {

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -900,3 +900,19 @@ test("brief html export does not reparse embedded content as markup", async () =
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("brief treats only .html as an HTML export", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-briefhtm-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "brief htm marker" } }));
+    const htmPath = join(dir, "brief.htm");
+    await briefVerb.run(ctx(c, undefined, { export: htmPath, theme: "csi" }));
+    const out = readFileSync(htmPath, "utf8");
+    assert.match(out, /^# Brief/m);
+    assert.doesNotMatch(out, /<html/i);
+    assert.doesNotMatch(out, /data-overcast-theme="csi"/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/unit/to-agent-tool.test.ts
+++ b/test/unit/to-agent-tool.test.ts
@@ -152,6 +152,40 @@ test("greedy budget: small records inline, the big one previews (mixed batch)", 
   assert.match(text, /emitted 2 record\(s\)/);
 });
 
+test("agent tool defaults HTML exports to CSI when the verb supports themes", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-agent-theme-"));
+  try {
+    const seen: Array<Record<string, unknown>> = [];
+    const spec: VerbSpec = {
+      name: "brief",
+      group: "read",
+      summary: "brief",
+      args: [],
+      flags: [
+        { name: "export", summary: "export", type: "string" },
+        { name: "theme", summary: "theme", type: "string", choices: ["plain", "csi"], default: "plain" },
+      ],
+      outputKind: "brief",
+      run: async (ctx) => {
+        seen.push({ ...ctx.opts });
+        return [makeRecord({ verb: "brief", payload: { export: ctx.opts.export, theme: ctx.opts.theme } })];
+      },
+    };
+    const c = openCase(dir); c.ensure();
+    const tool = toAgentTool(spec, { getCase: () => c, getProfile: () => defaultProfile() });
+
+    await tool.execute("call_1", { export: join(dir, "report.html") }, undefined as never);
+    await tool.execute("call_2", { export: join(dir, "report.md") }, undefined as never);
+    await tool.execute("call_3", { export: join(dir, "plain.html"), theme: "plain" }, undefined as never);
+
+    assert.equal(seen[0].theme, "csi");
+    assert.equal(seen[1].theme, undefined);
+    assert.equal(seen[2].theme, "plain");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("case memory get tool schema forwards subcommand and record id", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-agent-case-"));
   try {

--- a/test/unit/to-agent-tool.test.ts
+++ b/test/unit/to-agent-tool.test.ts
@@ -177,10 +177,12 @@ test("agent tool defaults HTML exports to CSI when the verb supports themes", as
     await tool.execute("call_1", { export: join(dir, "report.html") }, undefined as never);
     await tool.execute("call_2", { export: join(dir, "report.md") }, undefined as never);
     await tool.execute("call_3", { export: join(dir, "plain.html"), theme: "plain" }, undefined as never);
+    await tool.execute("call_4", { export: join(dir, "report.htm") }, undefined as never);
 
     assert.equal(seen[0].theme, "csi");
     assert.equal(seen[1].theme, undefined);
     assert.equal(seen[2].theme, "plain");
+    assert.equal(seen[3].theme, undefined);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Adds a shared self-contained HTML report renderer with a CSI theme for brief timelines, case records, and case status dashboards.
- Adds `case status`, export/theme flags for `case status` and `case records`, and target/source/match visualization context in status reports.
- Extends `brief --export` with `--theme plain|csi` while preserving plain HTML as the direct CLI default.
- Defaults interactive/headless agent exact `.html` exports to the CSI theme when a report verb supports themes, while preserving explicit `theme: "plain"` and leaving `.htm`/markdown exports alone.
- Makes `case status` and `case records` honor the export extension: `.html` writes HTML, other paths write markdown; `case records --limit` applies to the exported report while the JSON payload keeps total/shown/truncated metadata.
- Sorts case record report timelines chronologically, matching brief behavior for dated records while preserving stable order for undated records.
- Adds optional Playwright doctor coverage plus live e2e cases for real-data visualization and headless agent trace parsing/default theming.
- Updates README, flows docs, generated skills, verb reference, and e2e docs to explain `brief` vs `case status` vs `case records` and the CLI-vs-agent theme defaults.

## Validation

- `node --test --import tsx test/unit/setup.test.ts test/unit/case-verb.test.ts test/unit/read.test.ts test/unit/to-agent-tool.test.ts`
- `node --test --import tsx test/unit/case-verb.test.ts`
- `npm run typecheck`
- `npm test`
- `shellcheck -S warning test/e2e/live/cases/31_visualization.sh test/e2e/live/cases/32_headless_visualization.sh`
- `OVERCAST_USE_NODE=1 bash test/e2e/live/run.sh 31_visualization`
- `OVERCAST_USE_NODE=1 bash test/e2e/live/run.sh 32_headless_visualization`
- `bash test/e2e/live/run.sh 60_dist`
- `npm run build:bun && ./dist/bin/overcast doctor --json | jq '.payload.checks[] | select(.name=="playwright")'`

## Notes

- Direct CLI HTML exports remain plain by default for compatibility.
- The headless visualization e2e omits any theme argument and verifies the agent trace has no explicit theme while the exported HTML still contains CSI markers.
- Playwright is optional; `doctor` now checks both the optional package and installed Chromium browser payload without requiring it for core health.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive reporting, documentation, and optional Playwright; export paths write local files with HTML escaping, and CLI plain defaults limit behavior change for direct users.
> 
> **Overview**
> Adds a shared **`src/report/html.ts`** renderer with **`plain`** and **`csi`** themes for self-contained HTML exports, including escaped timeline cards and status dashboards (TL;DR, targets/sources, match visuals, store/memory panels).
> 
> **`brief`**, **`case status`**, and **`case records`** gain **`--export`** and **`--theme plain|csi`**; CLI HTML still defaults to **`plain`**, while **`.html`** (not **`.htm`**) selects HTML vs markdown by extension. **`case status`** is a new subcommand with a rich JSON payload; **`case records`** exports chronologically sorted timelines and applies **`--limit`** to exported output as well as the JSON view.
> 
> Agent/TUI tools auto-set **`theme: csi`** when exporting to **`.html`** on verbs that support themes, unless **`theme: plain`** is explicit.
> 
> Docs/skills/verb reference explain **brief vs status vs records**. **`doctor`** optionally probes Playwright/Chromium; **`playwright`** is an optional dependency. Live e2e cases **`31_visualization`** and **`32_headless_visualization`** exercise CSI exports and default agent theming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e955faa24fc637163cffb6e9b8006b675d17928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->