### PR TITLE
Release v0.0.5: version bump + doc consistency fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.4"
+    "version": "0.0.5"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": {
     "name": "kdr"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,11 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
 - **Read** — `ask` (cited retrieval over case memory; `--deep`/`--memory qmd` for
   semantic local search; `--index <id>` answers over a media-descriptions index,
   `--probe` for moment search), `brief` (timeline/findings report, `--export`
-  md/html).
-- **Case** — `case init | setup | info | records | memory | clear`. `case setup`
+  md/html, `--theme plain|csi`).
+- **Case** — `case init | setup | status | info | records | memory | clear`.
+  `case status`/`records`/`brief` HTML `--export` takes `--theme plain|csi`
+  (direct CLI defaults to `plain`; agent/TUI `.html` exports default to `csi`).
+  `case setup`
   is the first-run wizard + saved-setup manager (`status|show|edit|plan`, persisted
   to `.overcast/setup.json`). `case memory get <id> --field <name>
   --offset/--limit` pages a large record field in full — the non-truncating way to

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ surface + env vars.)
 | `monitor` | scan on a loop, diff the seen-set, pipe new items into a sense (`--once` / `--every`) |
 | `index` | index media into searchable corpora: remote media/entities/face indexes, plus local `image-ransac` and `deepface-local` DBs |
 | `target` / `source` / `note` | manage the standing scope, where to look, and human-authored observations |
+| `finding` | create and review findings (`create` / `list` / `accept` / `dismiss`) — manual + setup-automated |
 | `prebrief` | stand up a case (name + target + source) in one shot |
 
 **Read** — synthesize the case
@@ -459,9 +460,11 @@ Three surfaces from one source of truth (`src/registry/verbs.ts`):
 ```bash
 npm run build       # tsup (dev/library build)
 npm run typecheck   # tsc --noEmit
-npm test            # unit + offline e2e (fixture provider)
-npm run test:e2e    # full e2e (real clips + Cloudglue); OVERCAST_E2E_LIVE=1 for live cases
+npm test            # unit tests (offline; fixtures)
+npm run test:e2e    # offline e2e (fixture providers, no creds)
+npm run test:e2e:live  # live real-data e2e (builds the bun binary, sources .env)
 E2E_VERBOSE=1 npm run test:e2e  # include exact commands + output snippets in report.md
+npm run build:bun   # bun build --compile → dist/bin/overcast
 overcast commands --json   # the authoritative verb registry
 overcast doctor            # preflight
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "Apache-2.0",
   "author": "kdr",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.1.
 
-export const OVERCAST_VERSION = "0.0.4";
+export const OVERCAST_VERSION = "0.0.5";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.1";


### PR DESCRIPTION
## Summary

Patch release **0.0.4 → 0.0.5**, plus a doc-consistency pass over the surfaces that drifted since the last tag.

The four PRs since `v0.0.4` (#28 license, #29 visual DBs + local providers, #30 workflow skills, #31 CSI visualizations + agent HTML defaults) already shipped their own docs, so this is the bump + the small gaps left behind.

## Version bump (all surfaces in lockstep)
Bumped via `npm version 0.0.5 --no-git-tag-version`, which runs the repo's `version` lifecycle and syncs every surface:
- `package.json` + `package-lock.json`
- `src/version.ts` (`OVERCAST_VERSION`)
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (`metadata.version` + `plugins[].version`)

`node scripts/sync-version.mjs --check` passes; `overcast --version` reports `0.0.5`.

## Doc fixes
- **README** — corrected the Development test-script descriptions (`npm test` is unit-only; `test:e2e` is offline fixtures; added `test:e2e:live` and `build:bun`); added the `finding` verb to the verb table.
- **CLAUDE.md** — added the missing `case status` action to the Case bullet; noted the new `--theme plain|csi` HTML export and the agent/TUI `.html`→`csi` default from #31.

Shipped skills (`skills/overcast/...` + workflow skills) regenerate from the registry with **zero drift**.

## Release gates
- `npm run typecheck` ✓
- `npm test` → **425 pass / 0 fail** (incl. the version-sync guard + the CSI-default test)
- `npm run build` ✓

## After merge
Per `RELEASING.md`, tag `main` to trigger `release.yml`:
```
git checkout main && git pull
git tag v0.0.5 && git push origin v0.0.5
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string and documentation only; no runtime or behavioral code changes in the diff.
> 
> **Overview**
> **Patch release 0.0.4 → 0.0.5** across every version surface: `package.json` / lockfile, `src/version.ts` (`OVERCAST_VERSION`), and both Claude plugin manifests (`.claude-plugin/plugin.json` and `marketplace.json`).
> 
> **Documentation catch-up** (no application code in the diff): **README** adds the `finding` verb to the OSINT table and rewrites the Development section so `npm test` vs offline `test:e2e` vs `test:e2e:live` and `build:bun` match how scripts actually run. **CLAUDE.md** documents `case status` in the Case verb list, **`brief`/`case` HTML `--export --theme plain|csi`**, and that direct CLI HTML defaults to `plain` while agent/TUI `.html` exports default to `csi`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab6f0cd4597e11c8fa3ae2dfca8d9d1bf400f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->