### PR TITLE
Add basic-clip local CLIP DB + `similar` semantic-search verb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,11 +47,21 @@ OC_LOCAL_FACE_IMAGE=/path/to/person-reference.jpg
 OC_LOCAL_IMAGE_REF=/path/to/logo-reference.jpg
 OC_LOCAL_IMAGE_VIDEO_A=/path/to/candidate-a.mp4
 OC_LOCAL_IMAGE_VIDEO_B=/path/to/candidate-b.mp4
-# Python for local image/face DB providers. Recommended setup:
+# Local basic-clip (CLIP semantic) DB e2e (test/e2e/live/cases/17_clip_db.sh):
+OC_CLIP_IMAGE_REF=/path/to/reference.jpg          # embedded + used as an image query
+OC_CLIP_VIDEO=/path/to/scene-video.mp4            # optional: embedded (frame-sampled)
+# OC_CLIP_TEXT=a red car at night                 # optional text query (default: "a person")
+# Python for local image/face/CLIP DB providers. Recommended setup:
 #   scripts/visual-db-uv.sh          # image DB deps
 #   scripts/visual-db-uv.sh --face   # image + face DB deps
+#   scripts/visual-db-uv.sh --clip   # CLIP (open_clip + torch) DB deps
+#   scripts/visual-db-uv.sh --all    # all of the above
 # Then set this to the printed venv Python if you do not use the default path.
 OC_VISUAL_DB_PY=
+# Optional CLIP model overrides (defaults: ViT-B-32 / openai weights / cpu):
+# OC_CLIP_MODEL=ViT-B-32
+# OC_CLIP_PRETRAINED=openai
+# OC_CLIP_DEVICE=cpu
 # Optional LIVE e2e assertion thresholds. Normal CLI use can omit these and pass
 # flags per command instead. Provider defaults when flags are omitted are:
 # image min-inliers=15 min-ratio=0.4 max-frames=8; face min-similarity=68 max-frames=8.

--- a/.env.example
+++ b/.env.example
@@ -47,10 +47,13 @@ OC_LOCAL_FACE_IMAGE=/path/to/person-reference.jpg
 OC_LOCAL_IMAGE_REF=/path/to/logo-reference.jpg
 OC_LOCAL_IMAGE_VIDEO_A=/path/to/candidate-a.mp4
 OC_LOCAL_IMAGE_VIDEO_B=/path/to/candidate-b.mp4
-# Local basic-clip (CLIP semantic) DB e2e (test/e2e/live/cases/17_clip_db.sh):
-OC_CLIP_IMAGE_REF=/path/to/reference.jpg          # embedded + used as an image query
-OC_CLIP_VIDEO=/path/to/scene-video.mp4            # optional: embedded (frame-sampled)
-# OC_CLIP_TEXT=a red car at night                 # optional text query (default: "a person")
+# Local basic-clip (CLIP semantic) DB e2e (test/e2e/live/cases/17_clip_db.sh).
+# ALL OPTIONAL — when unset, the case derives real fixtures itself: it clips
+# OC_VIDEO_OBJECTS/OC_VIDEO_SMALL, extracts frames with ffmpeg, and captions a
+# frame with `see` to produce the text queries.
+# OC_CLIP_VIDEO=/path/to/scene-video.mp4          # video A override (embedded, frame-sampled)
+# OC_CLIP_IMAGE_REF=/path/to/reference.jpg        # image-member override
+# OC_CLIP_TEXT=a red car at night                 # fallback text query when `see` is unavailable
 # Python for local image/face/CLIP DB providers. Recommended setup:
 #   scripts/visual-db-uv.sh          # image DB deps
 #   scripts/visual-db-uv.sh --face   # image + face DB deps

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/
 *.swo
 planning/
 overcast-session-*.html
+__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,9 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
   `OVERCAST_FFMPEG` / `OVERCAST_FFPROBE`); the internal media toolkit, NOT bundled.
 - uv-managed visual DB Python — optional for visual DBs and
   `face:deepface-local`: `scripts/visual-db-uv.sh --face` installs OpenCV/Numpy and
-  DeepFace/TensorFlow. Override with `OC_VISUAL_DB_PY` /
-  `OVERCAST_VISUAL_DB_PY`.
+  DeepFace/TensorFlow; `--clip` adds OpenAI CLIP (open_clip + torch + pillow) for
+  the `basic-clip` semantic DB; `--all` installs both. Override with
+  `OC_VISUAL_DB_PY` / `OVERCAST_VISUAL_DB_PY`.
 - TypeScript / ESM / Node ≥22; `tsup` (dev build) + `bun build --compile` (binary).
 
 ## Invariants (do not violate)
@@ -51,11 +52,12 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
    `src/registry/verbs.ts`; the CLI subcommand, the pi AgentTool, and the skill doc
    are generated from it. `overcast commands --json` is the source of truth.
 6. **Providers are pluggable.** Three classes share one machinery — **sense**
-   (`watch/listen/see/face/enhance`), **source** (`scan/capture/monitor`; youtube,
+   (`watch/listen/see/face/similar/enhance`), **source** (`scan/capture/monitor`; youtube,
    tiktok, web), and **memory** (`ask/brief`; local-grep, optional qmd). Bindings live in the profile;
    transports are `exec` (default), `http`, `in-proc`. Default sense binding =
    tinycloud (exec); `face:deepface-local` is the local DeepFace profile provider for
-   face detection/matching.
+   face detection/matching, and `basic-clip` is the local OpenAI CLIP DB for
+   `similar` (cross-modal semantic search).
 7. **ffmpeg is internal**, not a pluggable provider — `enhance`, `crop`, `view`,
    and frame extraction shell out to the **system** `ffmpeg`/`ffprobe` (PATH or
    `OVERCAST_FFMPEG`/`OVERCAST_FFPROBE`); `overcast doctor` checks it's installed.
@@ -84,7 +86,10 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `face:deepface-local` locally: detect faces, `--match <jpeg|png>` to find/rank a
   person in a clip, or `--index` to search a face-analysis / deepface-local index),
   `image` (local OpenCV RANSAC image/video-frame matching against
-  `image-ransac` indexes), `enhance` (system ffmpeg ops or a bound model).
+  `image-ransac` indexes), `similar` (local OpenAI CLIP cross-modal semantic
+  search — `add`/`match` image→image, `search` text→image — against `basic-clip`
+  indexes; videos frame-sampled + pooled, or per-frame moments), `enhance` (system
+  ffmpeg ops or a bound model).
 - **Inspect** — `view` (self-contained HTML media player; `--at`, `--spectrogram`,
   `--no-open`), `crop` (materialize `face`/`see` detection boxes into cropped
   image evidence records via ffmpeg — `--all/--id/--class/--kind`, `--pad`,
@@ -95,7 +100,8 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   (`scan --local`). `index` (create/attach/add/list/show/delete/remove/entities —
   typed remote tinycloud indexes: media-descriptions → `ask --index`, entities →
   `index entities`, face-analysis → `face --index`; local DBs:
-  `image-ransac` for `image match`, `deepface-local` for local face search).
+  `image-ransac` for `image match`, `deepface-local` for local face search,
+  `basic-clip` for `similar` CLIP semantic search).
   Built-in source refs: `youtube:@handle`, `youtube:search:<q>`,
   `youtube:playlist:<id>` or a URL; `tiktok:@user`, `tiktok:#tag`; `web:<q>`.
 - **State** — `target` / `source` manage standing scope; `note` records human
@@ -134,16 +140,16 @@ index mirrors). `case setup` saves a *mutable* setup model to
 (`payload.op = startup_setup` / `startup_setup_update`).
 
 Case memory is **evidence-only**. `ask` / `brief` read primary evidence
-(`watch listen see face crop note scan capture enhance` + root `finding`s) through
+(`watch listen see face similar crop note scan capture enhance` + root `finding`s) through
 bound memory providers — `local-grep` (always on) and optional `qmd` (semantic;
 `setup memory qmd`, then rebuild before querying). Read/meta and operational
 records (`ask brief case setup doctor provider skills index target source
 prebrief`, finding review-rows, dismissed findings) are excluded even when they
-match the query. `face`/`see` detections index only compact summaries / counts /
-moments — raw boxes and thumbnails stay in the record for exact reads and `crop`.
-Local visual DB artifacts stay in typed local indexes: local-grep/qmd ingest the
-records and summaries, not binary media, embeddings, sampled frames, match
-visualizations, or raw face boxes.
+match the query. `face`/`see`/`similar` detections index only compact summaries /
+counts / moments / matched refs — raw boxes, thumbnails, and vectors stay in the
+record. Local visual DB artifacts stay in typed local indexes: local-grep/qmd
+ingest the records and summaries, not binary media, embeddings, sampled frames,
+match visualizations, or raw face boxes.
 The saved setup's memory signal list + per-provider `indexable` flags narrow what
 each case searches. Provider execution always follows the **active profile
 binding**; case setup records expected choices/policy and can clear built-ins like

--- a/README.md
+++ b/README.md
@@ -162,7 +162,14 @@ overcast index create localfaces --type deepface-local --local --json
 overcast index add ./suspect.jpg --to localfaces --json
 overcast face ./clip.mp4 --match ./suspect.jpg --index localfaces --fps 0.5 --max-frames 32 --json
 
-# 9) launch the interactive agent (pi TUI) in the current case
+# 9) semantic (CLIP) search: find images/video moments by text or by example image
+scripts/visual-db-uv.sh --clip
+overcast index create scenes --type basic-clip --local --granularity frame --json
+overcast similar add ./clip.mp4 --index scenes --json          # embed + cache (videos frame-sampled)
+overcast similar search "a red car at night" --index scenes --json   # text → image/video moments
+overcast similar match ./reference.jpg --index scenes --json         # image → image/video moments
+
+# 10) launch the interactive agent (pi TUI) in the current case
 overcast
 ```
 
@@ -205,6 +212,7 @@ surface + env vars.)
 | `see` | caption / OCR / detect on an image, image URL, or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM) |
 | `face` | detect faces in a video, `--match <img>` to find a person, or search a face-analysis index |
 | `image` | match images/video frames against a local OpenCV RANSAC image index |
+| `similar` | cross-modal semantic search over a local CLIP (`basic-clip`) index — `search` by text, `match` by image, video moments included |
 | `enhance` | denoise / normalize / upscale via bundled ffmpeg, or a bound model provider |
 | `view` | open media in a scrubbable local HTML player (timeline markers, spectrogram) |
 | `crop` | materialize face/object detections as cropped image records with provenance |
@@ -215,7 +223,7 @@ surface + env vars.)
 | `scan` | sweep registered sources for the target; if no sources are enabled, scan local case media/indexes; `--pull` to capture + sense external hits |
 | `capture` | fetch a URL / scan-hit / local path into the case |
 | `monitor` | scan on a loop, diff the seen-set, pipe new items into a sense (`--once` / `--every`) |
-| `index` | index media into searchable corpora: remote media/entities/face indexes, plus local `image-ransac` and `deepface-local` DBs |
+| `index` | index media into searchable corpora: remote media/entities/face indexes, plus local `image-ransac`, `deepface-local`, and `basic-clip` DBs |
 | `target` / `source` / `note` | manage the standing scope, where to look, and human-authored observations |
 | `finding` | create and review findings (`create` / `list` / `accept` / `dismiss`) — manual + setup-automated |
 | `prebrief` | stand up a case (name + target + source) in one shot |
@@ -330,11 +338,11 @@ credential-blocked, or failed. Hits with no fetchable ref/url emit explicit
 errors in both commands. `monitor` marks hard failures seen after surfacing the
 error, while pending/credential gaps remain retryable.
 
-Catalog presets: `cloudglue`, `hf`, `fal`, `elevenlabs`, `owl-local`, and
-`deepface-local`.
-Single choices use `--verb <watch|listen|see|face|enhance> --choice <id>`, such
-as `listen:elevenlabs`, `see:fal`, `see:hf`, `see:owl-local`,
-`face:deepface-local`, or `enhance:ffmpeg`.
+Catalog presets: `cloudglue`, `hf`, `fal`, `elevenlabs`, `owl-local`,
+`deepface-local`, and `basic-clip`.
+Single choices use `--verb <watch|listen|see|face|similar|enhance> --choice <id>`,
+such as `listen:elevenlabs`, `see:fal`, `see:hf`, `see:owl-local`,
+`face:deepface-local`, `similar:basic-clip`, or `enhance:ffmpeg`.
 
 The local image DB is selected by local index type. Local face detection/matching
 can be selected as a profile provider with `face:deepface-local`, while the searchable
@@ -366,7 +374,7 @@ for cadence, and add `--max-frames` when you want a hard cap.
 
 | class | verbs | shipped providers |
 |---|---|---|
-| **sense** | watch / listen / see / face / enhance | Cloudglue (default), the brain LLM (default `see`), Hugging Face, fal.ai, ElevenLabs, ffmpeg |
+| **sense** | watch / listen / see / face / similar / enhance | Cloudglue (default), the brain LLM (default `see`), local CLIP (`similar`), Hugging Face, fal.ai, ElevenLabs, ffmpeg |
 | **source** | scan / capture / monitor | youtube (yt-dlp), tiktok (Apify), web (Tavily/Brave) |
 | **memory** | ask / brief | `local-grep` case search (always on); optional lifecycle-managed qmd semantic search; typed tinycloud media indexes via `ask --index` |
 

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -290,12 +290,12 @@ overcast view <watch-record-id>
 overcast brief --export report.md
 ```
 
-### 4. Local visual DB: logos, signs, landmarks, and faces
+### 4. Local visual DB: logos, faces, and semantic (CLIP) search
 
 When you need a local, inspectable visual match DB instead of a remote index.
 
 ```bash
-scripts/visual-db-uv.sh --face
+scripts/visual-db-uv.sh --face   # or --clip for CLIP, --all for both
 overcast doctor --json
 overcast provider setup apply --verb face --choice deepface-local --profile local --yes --json
 
@@ -307,6 +307,12 @@ overcast index create localfaces --type deepface-local --local --json
 overcast index add ./person.jpg --to localfaces --json
 overcast face ./candidate.mp4 --match ./person.jpg --index localfaces \
   --fps 0.5 --max-frames 32 --min-similarity 20 --json
+
+# CLIP semantic DB — query by text or image (image->image / text->image)
+overcast index create scenes --type basic-clip --local --granularity frame --json
+overcast similar add ./candidate.mp4 --index scenes --json
+overcast similar search "a red car at night" --index scenes --json
+overcast similar match ./reference.jpg --index scenes --json
 ```
 
 Use `--draw` on `image match` to write RANSAC visualizations into the case media
@@ -314,7 +320,13 @@ store. Local face results include frame timestamps, similarity, and boxes. Use
 `--fps` for video sampling cadence; add `--max-frames` when you need to cap
 runtime. With `--profile local`, plain `face ./candidate.mp4` runs local
 DeepFace detection through the `face:deepface-local` provider; `deepface-local` indexes are
-only needed when you want a reusable/searchable local face DB.
+only needed when you want a reusable/searchable local face DB. `basic-clip` is the
+semantic option: `similar add` embeds + caches members (videos are frame-sampled and
+pooled, or stored per-frame with `--granularity frame` so matches carry `at`), then
+`similar match`/`similar search` rank by cosine similarity (0–100). Stand up a
+frame-level and a video-level index side by side in the wizard (one comma-separated
+`--index`; per-index config pairs use `;`):
+`case setup --index "moments:basic-clip@granularity=frame,clips:basic-clip@granularity=video" --yes`.
 
 ### 5. Local-media-only person search
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -174,19 +174,20 @@ overcast crop <see-record-id> --all --class person --json        # materialize d
 - Env: `DETECT_MODEL`, `DETECT_THRESHOLD` (default 0.1), `DETECT_MAX_FRAMES` (default 8). overcast passes `OVERCAST_FFMPEG` / `OVERCAST_FFPROBE` (the system ffmpeg/ffprobe) so video frame extraction works.
 - *Note:* `nvidia/LocateAnything-3B` is a higher-quality open-vocab grounding model but it's a 3B VLM (~7.7 GB, GPU-class); swap it in via a local-transformers provider if you have the hardware.
 
-## Visual DBs (`image-ransac` and `deepface-local`)
+## Visual DBs (`image-ransac`, `deepface-local`, and `basic-clip`)
 
 Visual DBs are selected by **index type**. The DeepFace face detector can
 also be selected as a profile provider with `face:deepface-local`, but the searchable
-local face DB is still the `deepface-local` index type. The case setup wizard's
-`--index` path is for remote/default index creation today, so use `index create
---local` per case for `image-ransac` and `deepface-local`. They use shipped Python
-providers under `examples/providers/visual-db/` and a uv-managed Python
-environment:
+local face DB is still the `deepface-local` index type. Create them per case with
+`index create --local`, or add them in the setup wizard via `case setup --index
+"<name>:<type>"` (for `basic-clip`, an optional `@k=v;k=v` config suffix — pairs
+separated by `;` — pins sampling/pooling; see below). They use shipped Python providers under
+`examples/providers/visual-db/` and a uv-managed Python environment:
 
 ```bash
 scripts/visual-db-uv.sh          # image matching: opencv-python + numpy
 scripts/visual-db-uv.sh --face   # face matching too: deepface + tf-keras
+scripts/visual-db-uv.sh --clip   # CLIP semantic search: open_clip + torch + pillow
 overcast doctor --json              # reports uv + visual-db readiness
 
 overcast provider setup apply --verb face --choice deepface-local --profile local --yes --json
@@ -215,7 +216,30 @@ overcast face ./clip.mp4 --match ./person.jpg --index localfaces --fps 0.5 --max
 overcast face --match ./person.jpg --index localfaces --json
 ```
 
-Both emit ordinary Overcast records (`image.match` or `face.analysis`) and write
+`basic-clip` is a local OpenAI CLIP (open_clip) DB for **cross-modal semantic
+similarity** — find images/video moments that resemble a photo (image→image) or a
+phrase (text→image). Members are embedded and cached on `add` (`.npy` under the
+index dir); queries only embed the query and do a cosine top-K (scores are
+cosine×100, 0–100). Videos are frame-sampled and pooled (`max` default, or `mean`),
+or stored per-frame (`--granularity frame`) so queries return moments with `at`.
+Sampling is `uniform` windows or, with `--sampling shots`, tinycloud `watch` shot
+boundaries. Query with the `similar` verb (`add` / `match` / `search`):
+
+```bash
+overcast index create scenes --type basic-clip --local --granularity frame --sampling shots --json
+overcast similar add ./clip.mp4 --index scenes --json          # embed + cache (video → frames)
+overcast similar add ./photo.jpg --index scenes --json
+overcast similar search "a red car at night" --index scenes --limit 10 --json   # text → image
+overcast similar match ./query.jpg --index scenes --json                        # image → image
+```
+
+The record (`similar.match`) emits ranked `payload.matches[]` (`ref`, `similarity`,
+`granularity`, and `at` for frame-level). CLIP model/weights are overridable via
+`OC_CLIP_MODEL` (default `ViT-B-32`) and `OC_CLIP_PRETRAINED` (default `openai`);
+`OC_CLIP_DEVICE` defaults to `cpu`.
+
+These emit ordinary Overcast records (`image.match`, `face.analysis`, or
+`similar.match`) and write
 local artifacts under the case `.overcast/` store. Local-grep/qmd memory indexes
 should index the records and summaries only; do not ingest raw media, embeddings,
 sampled frames, face boxes, or match visualization images as text. Add `note`,
@@ -233,7 +257,7 @@ sample 8 frames.
 - [`examples/providers/elevenlabs/{listen,enhance}.sh`](../examples/providers/elevenlabs/) — ElevenLabs Scribe STT + Voice Isolator audio enhance.
 - [`examples/providers/fal/{see,enhance}.sh`](../examples/providers/fal/) — fal.ai Florence-2, ESRGAN image enhance, and DeepFilterNet3 audio enhance.
 - [`examples/providers/detect/detect.py`](../examples/providers/detect/detect.py) — OWLv2 open-vocabulary `see` object detector (OWLv2 / Grounding DINO), image + video.
-- [`examples/providers/visual-db/{image_match,face_match}.py`](../examples/providers/visual-db/) — local image RANSAC and DeepFace matching for visual DB indexes.
+- [`examples/providers/visual-db/{image_match,face_match,clip_match}.py`](../examples/providers/visual-db/) — local image RANSAC, DeepFace, and CLIP (basic-clip) matching for visual DB indexes.
 - [`examples/providers/sources/{youtube,tiktok,web}.sh`](../examples/providers/sources/) — yt-dlp + Apify + web-search (Tavily/Brave) source providers.
 
 ## Source providers (built-in types)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -252,11 +252,16 @@ overcast face --match ./person.jpg --index localfaces --json
 `basic-clip` is a local OpenAI CLIP (open_clip) DB for **cross-modal semantic
 similarity** — find images/video moments that resemble a photo (image→image) or a
 phrase (text→image). Members are embedded and cached on `add` (`.npy` under the
-index dir); queries only embed the query and do a cosine top-K (scores are
-cosine×100, 0–100). Videos are frame-sampled and pooled (`max` default, or `mean`),
-or stored per-frame (`--granularity frame`) so queries return moments with `at`.
-Sampling is `uniform` windows or, with `--sampling shots`, tinycloud `watch` shot
-boundaries. Query with the `similar` verb (`add` / `match` / `search`):
+index dir); queries only embed the query, do a cosine top-K (scores are
+cosine×100, 0–100), and **never write the cache**. Videos are frame-sampled and
+pooled (`max` default, or `mean`), or stored per-frame (`--granularity frame`) so
+queries return moments with `at`. Sampling is `uniform` windows or, with
+`--sampling shots`, tinycloud `watch` shot boundaries (reused from existing watch
+evidence when present). The pooling/granularity/sampling config is a property of
+the **index**, set at `index create` and persisted to its `config.json` — member
+embedding always follows it (`similar add` rejects per-add overrides), while
+sampling flags on `similar match` shape only the query video's embedding. Query
+with the `similar` verb (`add` / `match` / `search`):
 
 ```bash
 overcast index create scenes --type basic-clip --local --granularity frame --sampling shots --json

--- a/examples/providers/visual-db/clip_match.py
+++ b/examples/providers/visual-db/clip_match.py
@@ -15,7 +15,9 @@ import sys
 import tempfile
 from pathlib import Path
 
-VIDEO_EXTS = (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi", ".mpeg", ".mpg", ".ts", ".mts", ".m2ts", ".wmv", ".flv", ".ogv")
+# Video extensions must cover everything the TS intake gate (media-ref.ts AV_RE)
+# accepts as video, or a valid clip is misrouted to the image path and fails.
+VIDEO_EXTS = (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi", ".mpeg", ".mpg", ".ts", ".mts", ".m2ts", ".wmv", ".flv", ".3gp", ".3g2", ".ogv", ".mxf")
 
 
 def emit(rec):
@@ -352,9 +354,10 @@ def op_query(args):
         summary = "no semantic matches for that text" if not results else "%d semantic match%s" % (len(results), "" if len(results) == 1 else "es")
     else:
         summary = "no visually-similar media" if not results else "%d visual match%s" % (len(results), "" if len(results) == 1 else "es")
+    # media anchors the QUERY (text, or the query file) — a matched member's `at`
+    # belongs to that member's clip and lives in payload.matches[], so copying it
+    # here would point record.media.at at the wrong media/moment.
     media = {"ref": args.input}
-    if results and "at" in results[0]:
-        media["at"] = results[0]["at"]
     payload = {
         "op": op, "index": args.index, "summary": summary,
         "matches": results, "count": len(results),

--- a/examples/providers/visual-db/clip_match.py
+++ b/examples/providers/visual-db/clip_match.py
@@ -233,6 +233,14 @@ def build_member(ref, args, index_dir, frames_at=None):
             if meta.get("config_hash") == chash and abs(float(meta.get("mtime", -1)) - mtime) < 1e-6:
                 vecs = np.load(str(npy))
                 return vecs, meta.get("ats", [None] * len(vecs)), meta.get("granularity", args.granularity)
+            # stale rebuild (query-time cache miss): reuse the shot markers the
+            # member was ORIGINALLY embedded with, so a shots-sampled member is
+            # not silently re-embedded on a uniform grid. An explicit frames_at
+            # (a fresh `add`) always wins.
+            if frames_at is None:
+                prior = meta.get("frames_at")
+                if isinstance(prior, list) and prior:
+                    frames_at = [float(x) for x in prior]
         except Exception:
             pass
     vecs, ats = embed_media(ref, args, frames_at=frames_at)
@@ -242,7 +250,8 @@ def build_member(ref, args, index_dir, frames_at=None):
     np.save(str(npy), vecs)
     sidecar.write_text(json.dumps({
         "ref": ref, "kind": "video" if is_video(path) else "image",
-        "granularity": args.granularity, "ats": ats, "config_hash": chash, "mtime": mtime,
+        "granularity": args.granularity, "ats": ats, "frames_at": frames_at,
+        "config_hash": chash, "mtime": mtime,
         "model": load_model()["name"],
     }))
     return vecs, ats, args.granularity

--- a/examples/providers/visual-db/clip_match.py
+++ b/examples/providers/visual-db/clip_match.py
@@ -230,7 +230,14 @@ def build_member(ref, args, index_dir, frames_at=None):
     if npy.exists() and sidecar.exists():
         try:
             meta = json.loads(sidecar.read_text())
-            if meta.get("config_hash") == chash and abs(float(meta.get("mtime", -1)) - mtime) < 1e-6:
+            fresh = meta.get("config_hash") == chash and abs(float(meta.get("mtime", -1)) - mtime) < 1e-6
+            # frames_at is NOT part of config_hash, so an explicit marker list (a
+            # fresh `add` with new shot boundaries) must also match what was
+            # cached — otherwise re-adding with different markers would appear
+            # successful while silently keeping the old vectors.
+            if fresh and frames_at is not None and meta.get("frames_at") != frames_at:
+                fresh = False
+            if fresh:
                 vecs = np.load(str(npy))
                 return vecs, meta.get("ats", [None] * len(vecs)), meta.get("granularity", args.granularity)
             # stale rebuild (query-time cache miss): reuse the shot markers the

--- a/examples/providers/visual-db/clip_match.py
+++ b/examples/providers/visual-db/clip_match.py
@@ -266,9 +266,10 @@ def build_member(ref, args, index_dir, frames_at=None, persist=True):
                 return vecs, meta.get("ats", [None] * len(vecs)), meta.get("granularity", args.granularity)
             # stale rebuild (query-time cache miss): reuse the shot markers the
             # member was ORIGINALLY embedded with, so a shots-sampled member is
-            # not silently re-embedded on a uniform grid. An explicit frames_at
-            # (a fresh `add`) always wins.
-            if frames_at is None:
+            # not silently re-embedded on a uniform grid. Only while the config
+            # still says shots — after a switch to uniform the grid must win —
+            # and an explicit frames_at (a fresh `add`) always wins.
+            if frames_at is None and args.sampling == "shots":
                 prior = meta.get("frames_at")
                 if isinstance(prior, list) and prior:
                     frames_at = [float(x) for x in prior]
@@ -301,7 +302,10 @@ def op_add(args):
             frames_at = [float(x) for x in args.frames_at.split(",") if x.strip() != ""]
         except ValueError:
             frames_at = None
-    built = build_member(ref, args, args.index_dir, frames_at=frames_at)
+    # member embeddings are ALWAYS keyed on the persisted index config — add and
+    # query must agree, or add would persist a config_hash queries never reuse.
+    member_args = index_config_args(args)
+    built = build_member(ref, member_args, args.index_dir, frames_at=frames_at)
     if not built:
         fail("could not embed media (no readable frames): %s" % ref, ref, "add")
     vecs, ats, granularity = built
@@ -311,7 +315,7 @@ def op_add(args):
         "payload": {
             "op": "add", "index": args.index, "file": ref,
             "granularity": granularity, "vectors": int(vecs.shape[0]),
-            "sampling": {"mode": args.sampling, "window": args.window, "max_frames": args.max_frames, "fps": args.fps, "frames_at": frames_at},
+            "sampling": {"mode": member_args.sampling, "window": member_args.window, "max_frames": member_args.max_frames, "fps": member_args.fps, "frames_at": frames_at},
             "summary": "embedded %s into %s (%d vector%s)" % (Path(ref).name, args.index, vecs.shape[0], "" if vecs.shape[0] == 1 else "s"),
         },
         "media": {"ref": ref},

--- a/examples/providers/visual-db/clip_match.py
+++ b/examples/providers/visual-db/clip_match.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+# Local CLIP semantic DB (`basic-clip`) provider for overcast's `similar` verb.
+# Cross-modal similarity via OpenAI CLIP (open_clip): image->image (`match`) and
+# text->image (`search`). Embeddings are precomputed + cached on `add` under
+# <index-dir>/emb/<sha1(ref)>.npy (+ .json sidecar); queries only embed the query
+# and do a cosine top-K. Same wire contract as image_match.py / face_match.py:
+# read members from .overcast/indexes.json, emit ONE JSON record on stdout.
+import argparse
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+VIDEO_EXTS = (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi", ".mpeg", ".mpg", ".ts", ".mts", ".m2ts", ".wmv", ".flv", ".ogv")
+
+
+def emit(rec):
+    sys.stdout.write(json.dumps(rec) + "\n")
+
+
+def fail(msg, inp="", op="match", state="error"):
+    emit({
+        "verb": "similar",
+        "format": "json",
+        "payload": {"op": op, "matches": [], "count": 0},
+        "media": {"ref": inp} if inp else None,
+        "error": msg,
+        "state": state,
+    })
+    sys.exit(0)
+
+
+def parse():
+    p = argparse.ArgumentParser()
+    p.add_argument("--op", choices=["add", "match", "search"], required=True)
+    p.add_argument("--index", required=True)
+    p.add_argument("--index-dir", required=True)
+    p.add_argument("--min-similarity", type=float, default=0.0)
+    p.add_argument("--limit", type=int, default=20)
+    p.add_argument("--offset", type=int, default=0)
+    p.add_argument("--pooling", choices=["max", "mean"], default="max")
+    p.add_argument("--granularity", choices=["video", "frame"], default="video")
+    p.add_argument("--sampling", choices=["uniform", "shots"], default="uniform")
+    p.add_argument("--window", type=float, default=10.0)
+    p.add_argument("--max-frames", type=int, dest="max_frames")
+    p.add_argument("--fps", type=float)
+    p.add_argument("--frames-at", dest="frames_at")
+    p.add_argument("input")
+    return p.parse_args()
+
+
+def members_full(index_dir, index_id):
+    idx_file = Path(index_dir).parent.parent / "indexes.json"
+    try:
+        store = json.loads(idx_file.read_text())
+    except Exception:
+        return []
+    for idx in store.get("indexes", []):
+        if idx.get("id") == index_id:
+            return [{"ref": m.get("ref"), "recordId": m.get("recordId")} for m in idx.get("members", []) if m.get("ref")]
+    return []
+
+
+# ---- ffmpeg frame sampling (mirrors image_match.py) ------------------------
+
+def duration(path):
+    probe = os.environ.get("OVERCAST_FFPROBE") or "ffprobe"
+    try:
+        out = subprocess.run([probe, "-v", "error", "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", path], capture_output=True, text=True, timeout=30)
+        return float(out.stdout.strip())
+    except Exception:
+        return 0.0
+
+
+def sample_times(dur, window, max_frames, fps):
+    if dur <= 0:
+        return [0.0]
+    if fps and fps > 0:
+        count = max(1, int(math.ceil(dur * fps)))
+        interval = 1.0 / fps
+        times = [min(dur, (i + 0.5) * interval) for i in range(count)]
+    elif window and window > 0:
+        count = max(1, int(math.ceil(dur / window)))
+        times = [min(dur, (i + 0.5) * window) for i in range(count)]
+    else:
+        count = max(1, max_frames or 8)
+        times = [dur * (i + 0.5) / count for i in range(count)]
+    if max_frames and max_frames > 0 and len(times) > max_frames:
+        # keep an even spread when capping
+        step = len(times) / max_frames
+        times = [times[min(len(times) - 1, int(i * step))] for i in range(max_frames)]
+    return [round(t, 2) for t in times]
+
+
+def extract_frames(path, times, workdir):
+    ffmpeg = os.environ.get("OVERCAST_FFMPEG") or "ffmpeg"
+    out = []
+    for i, at in enumerate(times):
+        f = Path(workdir) / ("f%d.jpg" % i)
+        cmd = [ffmpeg, "-y", "-ss", "%.3f" % max(0.0, at), "-i", path, "-frames:v", "1", "-q:v", "2", str(f)]
+        r = subprocess.run(cmd, capture_output=True, timeout=60)
+        if r.returncode == 0 and f.exists():
+            out.append((round(at, 2), f))
+    return out
+
+
+# ---- CLIP model (lazy) -----------------------------------------------------
+
+_MODEL = None
+
+
+def load_model():
+    global _MODEL
+    if _MODEL is None:
+        import open_clip
+        import torch
+        model_name = os.environ.get("OC_CLIP_MODEL", "ViT-B-32")
+        pretrained = os.environ.get("OC_CLIP_PRETRAINED", "openai")
+        device = os.environ.get("OC_CLIP_DEVICE", "cpu")
+        model, _, preprocess = open_clip.create_model_and_transforms(model_name, pretrained=pretrained, device=device)
+        model.eval()
+        tokenizer = open_clip.get_tokenizer(model_name)
+        _MODEL = {"model": model, "preprocess": preprocess, "tokenizer": tokenizer, "device": device, "name": model_name, "pretrained": pretrained, "torch": torch}
+    return _MODEL
+
+
+def embed_images(paths):
+    import numpy as np
+    m = load_model()
+    torch = m["torch"]
+    from PIL import Image
+    tensors = []
+    for p in paths:
+        img = Image.open(p).convert("RGB")
+        tensors.append(m["preprocess"](img))
+    batch = torch.stack(tensors).to(m["device"])
+    with torch.no_grad():
+        feats = m["model"].encode_image(batch)
+        feats = feats / feats.norm(dim=-1, keepdim=True)
+    return feats.cpu().numpy().astype("float32")
+
+
+def embed_text(text):
+    m = load_model()
+    torch = m["torch"]
+    tokens = m["tokenizer"]([text]).to(m["device"])
+    with torch.no_grad():
+        feats = m["model"].encode_text(tokens)
+        feats = feats / feats.norm(dim=-1, keepdim=True)
+    return feats.cpu().numpy().astype("float32")
+
+
+def l2norm(v):
+    import numpy as np
+    n = np.linalg.norm(v, axis=-1, keepdims=True)
+    n[n == 0] = 1.0
+    return (v / n).astype("float32")
+
+
+def pool(vectors, method):
+    import numpy as np
+    v = vectors.mean(axis=0, keepdims=True) if method == "mean" else vectors.max(axis=0, keepdims=True)
+    return l2norm(v)
+
+
+def is_video(path):
+    return str(path).lower().endswith(VIDEO_EXTS)
+
+
+def config_hash(args):
+    m = load_model()
+    payload = json.dumps({
+        "pooling": args.pooling, "granularity": args.granularity, "sampling": args.sampling,
+        "window": args.window, "max_frames": args.max_frames, "fps": args.fps,
+        "model": m["name"], "pretrained": m["pretrained"],
+    }, sort_keys=True)
+    return hashlib.sha1(payload.encode()).hexdigest()
+
+
+# ---- embedding cache -------------------------------------------------------
+
+def cache_paths(index_dir, ref):
+    key = hashlib.sha1(ref.encode()).hexdigest()
+    emb_dir = Path(index_dir) / "emb"
+    return emb_dir / ("%s.npy" % key), emb_dir / ("%s.json" % key)
+
+
+def embed_media(ref, args, frames_at=None):
+    """Return (vectors (N,D) float32, ats [N] with None for images/pooled)."""
+    import numpy as np
+    path = Path(ref)
+    if not is_video(path):
+        vecs = embed_images([str(path)])
+        return vecs, [None]
+    dur = duration(str(path))
+    if frames_at:
+        times = [t for t in frames_at if t is not None]
+        if dur > 0:
+            times = [min(dur, max(0.0, t)) for t in times]
+    else:
+        times = sample_times(dur, args.window, args.max_frames, args.fps)
+    with tempfile.TemporaryDirectory() as wd:
+        frames = extract_frames(str(path), times, wd)
+        if not frames:
+            return np.zeros((0, 1), dtype="float32"), []
+        vecs = embed_images([str(f) for _, f in frames])
+        ats = [at for at, _ in frames]
+    if args.granularity == "frame":
+        return l2norm(vecs), ats
+    return pool(vecs, args.pooling), [None]
+
+
+def build_member(ref, args, index_dir, frames_at=None):
+    """Load a member's cached vectors (fresh) or embed + cache them. Returns
+    (vectors, ats, granularity) or None when the ref is unreadable."""
+    import numpy as np
+    path = Path(ref)
+    if not path.exists():
+        return None
+    npy, sidecar = cache_paths(index_dir, ref)
+    chash = config_hash(args)
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    if npy.exists() and sidecar.exists():
+        try:
+            meta = json.loads(sidecar.read_text())
+            if meta.get("config_hash") == chash and abs(float(meta.get("mtime", -1)) - mtime) < 1e-6:
+                vecs = np.load(str(npy))
+                return vecs, meta.get("ats", [None] * len(vecs)), meta.get("granularity", args.granularity)
+        except Exception:
+            pass
+    vecs, ats = embed_media(ref, args, frames_at=frames_at)
+    if vecs.shape[0] == 0:
+        return None
+    npy.parent.mkdir(parents=True, exist_ok=True)
+    np.save(str(npy), vecs)
+    sidecar.write_text(json.dumps({
+        "ref": ref, "kind": "video" if is_video(path) else "image",
+        "granularity": args.granularity, "ats": ats, "config_hash": chash, "mtime": mtime,
+        "model": load_model()["name"],
+    }))
+    return vecs, ats, args.granularity
+
+
+# ---- ops -------------------------------------------------------------------
+
+def op_add(args):
+    ref = args.input
+    if not Path(ref).exists():
+        fail("input not found: %s" % ref, ref, "add")
+    frames_at = None
+    if args.frames_at:
+        try:
+            frames_at = [float(x) for x in args.frames_at.split(",") if x.strip() != ""]
+        except ValueError:
+            frames_at = None
+    built = build_member(ref, args, args.index_dir, frames_at=frames_at)
+    if not built:
+        fail("could not embed media (no readable frames): %s" % ref, ref, "add")
+    vecs, ats, granularity = built
+    emit({
+        "verb": "similar",
+        "format": "json",
+        "payload": {
+            "op": "add", "index": args.index, "file": ref,
+            "granularity": granularity, "vectors": int(vecs.shape[0]),
+            "sampling": {"mode": args.sampling, "window": args.window, "max_frames": args.max_frames, "fps": args.fps, "frames_at": frames_at},
+            "summary": "embedded %s into %s (%d vector%s)" % (Path(ref).name, args.index, vecs.shape[0], "" if vecs.shape[0] == 1 else "s"),
+        },
+        "media": {"ref": ref},
+        "meta": {"provider": "local:basic-clip", "model": load_model()["name"]},
+        "state": "ready",
+    })
+
+
+def query_vector(args, op):
+    if op == "search":
+        return embed_text(args.input)
+    # match: an image, or a video pooled to one vector
+    ref = args.input
+    if not Path(ref).exists():
+        fail("input not found: %s" % ref, ref, "match")
+    if not is_video(ref):
+        return embed_images([ref])
+    frames_at = None
+    if args.frames_at:
+        try:
+            frames_at = [float(x) for x in args.frames_at.split(",") if x.strip() != ""]
+        except ValueError:
+            frames_at = None
+    vecs, _ = embed_media(ref, argparse.Namespace(**{**vars(args), "granularity": "frame"}), frames_at=frames_at)
+    if vecs.shape[0] == 0:
+        fail("could not extract frames from query video", ref, "match")
+    return pool(vecs, args.pooling)
+
+
+def op_query(args):
+    import numpy as np
+    op = args.op
+    members = members_full(args.index_dir, args.index)
+    if not members:
+        fail("local basic-clip index has no members — add some with `similar add ... --index %s`" % args.index, args.input, op)
+    qv = query_vector(args, op)[0]
+    if args.min_similarity < 0 or args.min_similarity > 100:
+        fail("--min-similarity must be between 0 and 100", args.input, op)
+    if args.limit <= 0:
+        fail("--limit must be positive", args.input, op)
+    if args.offset < 0:
+        fail("--offset must be non-negative", args.input, op)
+    results = []
+    for mem in members:
+        built = build_member(mem["ref"], args, args.index_dir)
+        if not built:
+            continue
+        vecs, ats, granularity = built
+        for j in range(vecs.shape[0]):
+            score = float(np.dot(qv, vecs[j]) * 100.0)
+            if score < args.min_similarity:
+                continue
+            item = {"ref": mem["ref"], "similarity": round(score, 2), "granularity": granularity}
+            if mem.get("recordId"):
+                item["recordId"] = mem["recordId"]
+            at = ats[j] if j < len(ats) else None
+            if at is not None:
+                item["at"] = at
+            results.append(item)
+    results.sort(key=lambda x: x.get("similarity", 0), reverse=True)
+    results = results[args.offset:args.offset + args.limit]
+    if op == "search":
+        summary = "no semantic matches for that text" if not results else "%d semantic match%s" % (len(results), "" if len(results) == 1 else "es")
+    else:
+        summary = "no visually-similar media" if not results else "%d visual match%s" % (len(results), "" if len(results) == 1 else "es")
+    media = {"ref": args.input}
+    if results and "at" in results[0]:
+        media["at"] = results[0]["at"]
+    payload = {
+        "op": op, "index": args.index, "summary": summary,
+        "matches": results, "count": len(results),
+    }
+    if op == "search":
+        payload["query"] = args.input
+    emit({
+        "verb": "similar",
+        "format": "json",
+        "payload": payload,
+        "media": media,
+        "meta": {"provider": "local:basic-clip", "model": load_model()["name"]},
+        "state": "ready",
+    })
+
+
+def main():
+    args = parse()
+    inp = args.input
+    if args.op != "search":
+        if inp.startswith("http://") or inp.startswith("https://"):
+            fail("local basic-clip only supports local files; capture remote media first", inp, args.op)
+    try:
+        import numpy  # noqa: F401
+        import open_clip  # noqa: F401
+        import torch  # noqa: F401
+        from PIL import Image  # noqa: F401
+    except Exception as e:
+        fail("basic-clip deps missing: %s (run scripts/visual-db-uv.sh --clip)" % e, inp, args.op)
+    if args.op == "add":
+        op_add(args)
+    else:
+        op_query(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/providers/visual-db/clip_match.py
+++ b/examples/providers/visual-db/clip_match.py
@@ -216,9 +216,31 @@ def embed_media(ref, args, frames_at=None):
     return pool(vecs, args.pooling), [None]
 
 
-def build_member(ref, args, index_dir, frames_at=None):
+def index_config_args(args):
+    """Member-side embedding config = the PERSISTED index config (config.json),
+    not the per-query CLI flags. Query flags shape only the query embedding —
+    keying member caches on them would let a one-off query re-embed and mutate
+    the stored corpus. Falls back to the shipped defaults when absent/corrupt."""
+    cfg = {}
+    try:
+        cfg = json.loads((Path(args.index_dir) / "config.json").read_text())
+    except Exception:
+        pass
+    return argparse.Namespace(**{
+        **vars(args),
+        "pooling": cfg.get("pooling") or "max",
+        "granularity": cfg.get("granularity") or "video",
+        "sampling": cfg.get("sampling") or "uniform",
+        "window": float(cfg.get("window") or 10.0),
+        "max_frames": cfg.get("maxFrames"),
+        "fps": cfg.get("fps"),
+    })
+
+
+def build_member(ref, args, index_dir, frames_at=None, persist=True):
     """Load a member's cached vectors (fresh) or embed + cache them. Returns
-    (vectors, ats, granularity) or None when the ref is unreadable."""
+    (vectors, ats, granularity) or None when the ref is unreadable. persist=False
+    (query-time) keeps a rebuilt embedding in memory only — reads never write."""
     import numpy as np
     path = Path(ref)
     if not path.exists():
@@ -255,14 +277,15 @@ def build_member(ref, args, index_dir, frames_at=None):
     vecs, ats = embed_media(ref, args, frames_at=frames_at)
     if vecs.shape[0] == 0:
         return None
-    npy.parent.mkdir(parents=True, exist_ok=True)
-    np.save(str(npy), vecs)
-    sidecar.write_text(json.dumps({
-        "ref": ref, "kind": "video" if is_video(path) else "image",
-        "granularity": args.granularity, "ats": ats, "frames_at": frames_at,
-        "config_hash": chash, "mtime": mtime,
-        "model": load_model()["name"],
-    }))
+    if persist:
+        npy.parent.mkdir(parents=True, exist_ok=True)
+        np.save(str(npy), vecs)
+        sidecar.write_text(json.dumps({
+            "ref": ref, "kind": "video" if is_video(path) else "image",
+            "granularity": args.granularity, "ats": ats, "frames_at": frames_at,
+            "config_hash": chash, "mtime": mtime,
+            "model": load_model()["name"],
+        }))
     return vecs, ats, args.granularity
 
 
@@ -332,8 +355,9 @@ def op_query(args):
     if args.offset < 0:
         fail("--offset must be non-negative", args.input, op)
     results = []
+    member_args = index_config_args(args)
     for mem in members:
-        built = build_member(mem["ref"], args, args.index_dir)
+        built = build_member(mem["ref"], member_args, args.index_dir, persist=False)
         if not built:
             continue
         vecs, ats, granularity = built

--- a/examples/providers/visual-db/face_match.py
+++ b/examples/providers/visual-db/face_match.py
@@ -8,7 +8,9 @@ import sys
 import tempfile
 from pathlib import Path
 
-VIDEO_EXTS = (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi", ".mpeg", ".mpg", ".ts", ".mts", ".m2ts", ".wmv", ".flv", ".ogv")
+# Video extensions must cover everything the TS intake gate (media-ref.ts AV_RE)
+# accepts as video, or a valid clip is misrouted to the image path and fails.
+VIDEO_EXTS = (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi", ".mpeg", ".mpg", ".ts", ".mts", ".m2ts", ".wmv", ".flv", ".3gp", ".3g2", ".ogv", ".mxf")
 
 
 def emit(rec):

--- a/examples/providers/visual-db/image_match.py
+++ b/examples/providers/visual-db/image_match.py
@@ -9,7 +9,9 @@ import tempfile
 import uuid
 from pathlib import Path
 
-VIDEO_EXTS = (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi", ".mpeg", ".mpg", ".ts", ".mts", ".m2ts", ".wmv", ".flv", ".ogv")
+# Video extensions must cover everything the TS intake gate (media-ref.ts AV_RE)
+# accepts as video, or a valid clip is misrouted to the image path and fails.
+VIDEO_EXTS = (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi", ".mpeg", ".mpg", ".ts", ".mts", ".m2ts", ".wmv", ".flv", ".3gp", ".3g2", ".ogv", ".mxf")
 
 
 def emit(rec):

--- a/scripts/visual-db-uv.sh
+++ b/scripts/visual-db-uv.sh
@@ -4,7 +4,8 @@
 # Usage:
 #   scripts/visual-db-uv.sh          # image matching deps: opencv + numpy
 #   scripts/visual-db-uv.sh --face   # also install DeepFace stack
-#   scripts/visual-db-uv.sh --all    # same as --face
+#   scripts/visual-db-uv.sh --clip   # also install OpenAI CLIP (open_clip + torch)
+#   scripts/visual-db-uv.sh --all    # install both the DeepFace and CLIP stacks
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,13 +29,20 @@ uv pip install --python "$VENV/bin/python" --upgrade pip wheel setuptools
 uv pip install --python "$VENV/bin/python" opencv-python numpy
 
 case "$MODE" in
-  --face|--all|face|all)
+  --face|face)
     uv pip install --python "$VENV/bin/python" deepface tf-keras
+    ;;
+  --clip|clip)
+    uv pip install --python "$VENV/bin/python" open-clip-torch torch pillow
+    ;;
+  --all|all)
+    uv pip install --python "$VENV/bin/python" deepface tf-keras
+    uv pip install --python "$VENV/bin/python" open-clip-torch torch pillow
     ;;
   --image|image|"")
     ;;
   *)
-    echo "unknown mode: $MODE (expected --image | --face | --all)" >&2
+    echo "unknown mode: $MODE (expected --image | --face | --clip | --all)" >&2
     exit 2
     ;;
 esac

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -23,6 +23,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `see` — Understand an image or a single video frame (caption, OCR, detections).
 - `face` — Detect, match, or search faces in video (and across face-analysis indexes).
 - `image` — Match images or video frames against a local RANSAC image index.
+- `similar` — Find images/video moments by visual or text similarity in a local CLIP (basic-clip) index.
 - `enhance` — Produce better media (denoise/normalize/upscale/...) via ffmpeg or a bound model provider.
 - `view` — Open media in a lightweight local viewer (scrubbable player) or hand off to the OS.
 - `crop` — Materialize face/object detections as cropped image records with provenance.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -161,9 +161,9 @@ Options:
   --min-similarity <number> match/search: similarity floor (0–100)
   --limit <number>       match/search: max results
   --offset <number>      match/search: result offset
-  --pooling <string>     video: pool frame embeddings by max | mean (default index config)
-  --granularity <string> video: video (one vector/video) | frame (one vector/frame → moments)
-  --sampling <string>    video: uniform windows | shots (tinycloud watch boundaries)
+  --pooling <string>     match: pool the query video's frames by max | mean (members follow the index config)
+  --granularity <string> video (one vector/video) | frame (moments) — set at `index create`; members always follow the index config
+  --sampling <string>    match query video: uniform windows | shots (tinycloud watch boundaries); members follow the index config
   --window <number>      video: seconds per uniform sampling window
   --fps <number>         video: frame sampling rate; --max-frames can cap it
   --max-frames <number>  video: frame sample count/cap

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -140,6 +140,39 @@ Options:
 
 Emits `image.match` records.
 
+### `overcast similar`
+
+`similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB (videos are frame-sampled and pooled). `similar match <image|video> --index <id>` ranks members by image→image similarity; `similar search "<text>" --index <id>` ranks members by text→image similarity. Runs OpenAI CLIP locally (open_clip); scores are cosine×100 (0–100).
+
+```
+overcast similar <action> [input]... [options]
+
+  Find images/video moments by visual or text similarity in a local CLIP (basic-clip) index.
+
+  `similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB (videos are frame-sampled and pooled). `similar match <image|video> --index <id>` ranks members by image→image similarity; `similar search "<text>" --index <id>` ranks members by text→image similarity. Runs OpenAI CLIP locally (open_clip); scores are cosine×100 (0–100).
+
+Arguments:
+  action           add | match | search
+  input            image/video path, URL, record id (add/match) — or a text query (search)
+
+Options:
+  --index <string>       local basic-clip index id/name
+  --to <string>          alias for --index when adding
+  --min-similarity <number> match/search: similarity floor (0–100)
+  --limit <number>       match/search: max results
+  --offset <number>      match/search: result offset
+  --pooling <string>     video: pool frame embeddings by max | mean (default index config)
+  --granularity <string> video: video (one vector/video) | frame (one vector/frame → moments)
+  --sampling <string>    video: uniform windows | shots (tinycloud watch boundaries)
+  --window <number>      video: seconds per uniform sampling window
+  --fps <number>         video: frame sampling rate; --max-frames can cap it
+  --max-frames <number>  video: frame sample count/cap
+  --format <string>      json | md | txt
+  --json                 Shorthand for --format json
+```
+
+Emits `similar.match` records.
+
 ### `overcast enhance`
 
 Default: deterministic, modality-dispatched ops on the bundled ffmpeg (denoise/normalize/voice-isolate/upscale/stabilize/grayscale). Bind a model provider for AI upscaling/restoration via `setup provider enhance <spec>` (samples: fal esrgan/deepfilternet3, HF, ElevenLabs voice isolation). Emits a media.enhanced record whose media.ref is the output path — chain it into watch/listen/see.
@@ -314,7 +347,7 @@ Arguments:
   arg2             entities: the video/record-id (index entities <id> <video>)
 
 Options:
-  --type <string>        create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac
+  --type <string>        create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | basic-clip
   --local                create a local index instead of a tinycloud-backed index
   --description <string> create: human description
   --prompt <string>      create entities: free-text extraction prompt
@@ -327,6 +360,10 @@ Options:
   --no-download          add: don't materialize the source locally
   --limit <number>       entities: max entities
   --offset <number>      entities: entity offset
+  --pooling <string>     create basic-clip: pool video frames by max | mean
+  --granularity <string> create basic-clip: video | frame (moment-level)
+  --sampling <string>    create basic-clip: uniform | shots (watch boundaries)
+  --window <number>      create basic-clip: seconds per uniform sampling window
   --format <string>      json | md | txt
   --json                 Shorthand for --format json
 ```

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -80,6 +80,20 @@ export function providerChoices(): ProviderChoice[] {
       indexableDefault: true,
     },
     {
+      id: "basic-clip",
+      verb: "similar",
+      label: "Local CLIP (basic-clip)",
+      summary: "Local OpenAI CLIP semantic DB; basic-clip indexes are the local vector store for `similar` (text/image search).",
+      descriptor: {
+        type: "inproc",
+        backend: "basic-clip",
+        id: "basic-clip",
+        init: { command: `bash ${localVisionSetup} --clip` },
+      },
+      env: ["OC_VISUAL_DB_PY"],
+      indexableDefault: true,
+    },
+    {
       id: "ffmpeg",
       verb: "enhance",
       label: "Local ffmpeg",
@@ -177,6 +191,9 @@ export const PROVIDER_PRESETS: Record<string, Array<{ verb: string; choice: stri
   ],
   "deepface-local": [
     { verb: "face", choice: "deepface-local" },
+  ],
+  "basic-clip": [
+    { verb: "similar", choice: "basic-clip" },
   ],
 };
 

--- a/src/providers/local/vision.ts
+++ b/src/providers/local/vision.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { makeRecord, type OvercastRecord } from "../../record.js";
 import { runExecProvider } from "../run.js";
 import { providerEnv } from "../provider-env.js";
@@ -7,6 +8,7 @@ import { shippedPath } from "../../pkg.js";
 import type { Case } from "../../case.js";
 
 export type LocalFaceOp = "detect" | "match" | "search";
+export type LocalClipOp = "add" | "match" | "search";
 
 function script(name: string): string | undefined {
   return shippedPath("examples", "providers", "visual-db", name);
@@ -14,6 +16,55 @@ function script(name: string): string | undefined {
 
 export function localIndexDir(c: Case, indexId: string): string {
   return join(c.indexDir, indexId);
+}
+
+/** Per-index config for a local `basic-clip` (CLIP) DB, persisted as
+ *  `<index-dir>/config.json` at create time. Query flags override these. */
+export interface ClipConfig {
+  pooling: "max" | "mean";
+  granularity: "video" | "frame";
+  sampling: "uniform" | "shots";
+  /** seconds per uniform sampling window (one frame per window) */
+  window: number;
+  maxFrames: number | null;
+  fps: number | null;
+}
+
+export function defaultClipConfig(): ClipConfig {
+  return { pooling: "max", granularity: "video", sampling: "uniform", window: 10, maxFrames: null, fps: null };
+}
+
+/** Read a basic-clip index's config.json, merged over defaults (missing file =
+ *  all defaults). Tolerates a corrupt/partial file by falling back to defaults. */
+export function readClipConfig(indexDir: string): ClipConfig {
+  const file = join(indexDir, "config.json");
+  const base = defaultClipConfig();
+  try {
+    if (!existsSync(file)) return base;
+    const parsed = JSON.parse(readFileSync(file, "utf8")) as Partial<ClipConfig>;
+    return { ...base, ...parsed };
+  } catch {
+    return base;
+  }
+}
+
+export function writeClipConfig(indexDir: string, config: ClipConfig): void {
+  mkdirSync(indexDir, { recursive: true });
+  writeFileSync(join(indexDir, "config.json"), JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+/** Delete a basic-clip member's cached embedding (`emb/<sha1(ref)>.npy` + json).
+ *  Mirrors the Python cache key (sha1 of the resolved ref). */
+export function removeClipEmbedding(indexDir: string, ref: string): void {
+  const key = createHash("sha1").update(ref).digest("hex");
+  for (const ext of ["npy", "json"]) {
+    const f = join(indexDir, "emb", `${key}.${ext}`);
+    try {
+      if (existsSync(f)) rmSync(f, { force: true });
+    } catch {
+      /* best-effort cache cleanup */
+    }
+  }
 }
 
 function missingScript(verb: string, input: string, name: string): OvercastRecord {
@@ -120,6 +171,60 @@ export async function runLocalFace(
   if (opts.start) args.push("--start", opts.start);
   if (opts.end) args.push("--end", opts.end);
   const rec = await runExecProvider("face", localVisionPython(), input, {
+    env: { ...providerEnv(c.mediaDir), OVERCAST_INDEX_DIR: localIndexDir(c, opts.indexId) },
+    extraArgs: [path, ...args],
+    timeoutMs: 15 * 60_000,
+    signal: opts.signal,
+  });
+  rec.meta = { ...rec.meta, case: c.dir };
+  return rec;
+}
+
+/**
+ * Local CLIP semantic DB (`basic-clip`): embed + cache images/videos and query by
+ * image (`match`) or text (`search`). Mirrors runLocalImage/runLocalFace — shells
+ * out to examples/providers/visual-db/clip_match.py through the uv-managed Python.
+ * For `search`, `input` is the text query (Python treats the trailing positional
+ * as text when --op search, as a media path otherwise).
+ */
+export async function runLocalClip(
+  c: Case,
+  input: string,
+  opts: {
+    indexId: string;
+    op: LocalClipOp;
+    minSimilarity?: number;
+    limit?: number;
+    offset?: number;
+    pooling?: "max" | "mean";
+    granularity?: "video" | "frame";
+    sampling?: "uniform" | "shots";
+    window?: number;
+    maxFrames?: number;
+    fps?: number;
+    /** explicit frame-marker seconds (from watch/shot boundaries) */
+    framesAt?: number[];
+    signal?: AbortSignal;
+  },
+): Promise<OvercastRecord> {
+  const path = script("clip_match.py");
+  if (!path) return missingScript("similar", input, "clip_match.py");
+  const args = [
+    "--op", opts.op,
+    "--index", opts.indexId,
+    "--index-dir", localIndexDir(c, opts.indexId),
+  ];
+  if (opts.minSimilarity != null) args.push("--min-similarity", String(opts.minSimilarity));
+  if (opts.limit != null) args.push("--limit", String(opts.limit));
+  if (opts.offset != null) args.push("--offset", String(opts.offset));
+  if (opts.pooling) args.push("--pooling", opts.pooling);
+  if (opts.granularity) args.push("--granularity", opts.granularity);
+  if (opts.sampling) args.push("--sampling", opts.sampling);
+  if (opts.window != null) args.push("--window", String(opts.window));
+  if (opts.maxFrames != null) args.push("--max-frames", String(opts.maxFrames));
+  if (opts.fps != null) args.push("--fps", String(opts.fps));
+  if (opts.framesAt?.length) args.push("--frames-at", opts.framesAt.join(","));
+  const rec = await runExecProvider("similar", localVisionPython(), input, {
     env: { ...providerEnv(c.mediaDir), OVERCAST_INDEX_DIR: localIndexDir(c, opts.indexId) },
     extraArgs: [path, ...args],
     timeoutMs: 15 * 60_000,

--- a/src/providers/memory/fields.ts
+++ b/src/providers/memory/fields.ts
@@ -44,6 +44,9 @@ const FIELD_POLICY: Record<string, string[]> = {
   ],
   see: ["caption", "ocr", "text", "summary", "counts", "categories", "objects", "labels"],
   face: ["summary", "op", "moments", "reference", "index"],
+  // a positive semantic match IS evidence; keep it compact (summary + query text +
+  // matched refs only — never the vectors / per-frame scores in the raw payload).
+  similar: ["summary", "query", "matches[].ref"],
   crop: ["summary", "kind", "class", "detection_id", "source_record", "source_verb", "source_media", "at", "confidence", "crop"],
   note: ["title", "text", "tags", "confidence", "ref"],
   scan: ["title", "snippet", "url", "source", "published"],

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -10,6 +10,7 @@ import { providerEnv } from "../providers/provider-env.js";
 import { listenVerb, seeVerb, enhanceVerb, viewVerb } from "../verbs/senses.js";
 import { faceVerb } from "../verbs/face.js";
 import { imageVerb } from "../verbs/image.js";
+import { similarVerb } from "../verbs/similar.js";
 import { cropVerb } from "../verbs/crop.js";
 import { resolveVideoArg } from "../verbs/media-ref.js";
 import {
@@ -89,6 +90,7 @@ export const VERBS: VerbSpec[] = [
   seeVerb,
   faceVerb,
   imageVerb,
+  similarVerb,
   enhanceVerb,
   viewVerb,
   cropVerb,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -20,7 +20,8 @@ export type IndexType =
   | "face-analysis"
   | "rich-transcripts"
   | "deepface-local"
-  | "image-ransac";
+  | "image-ransac"
+  | "basic-clip";
 
 export interface IndexMember {
   /** the video ref registered (path / URL) */
@@ -80,6 +81,12 @@ export function normalizeIndexType(input: string): IndexType | undefined {
     case "images":
     case "visual":
       return "image-ransac";
+    case "basic-clip":
+    case "basic-clip-db":
+    case "clip":
+    case "clips":
+    case "semantic":
+      return "basic-clip";
     case "rich-transcripts":
     case "rich-transcript":
     case "transcripts":

--- a/src/state/setup.ts
+++ b/src/state/setup.ts
@@ -3,12 +3,25 @@ import { dirname } from "node:path";
 import type { Case } from "../case.js";
 import type { IndexType } from "./index.js";
 
+/** Optional per-index config carried in the saved setup (basic-clip only today:
+ *  pooling/granularity/sampling/window/maxFrames/fps). Written to the index's
+ *  config.json at create time; other index types leave it unset. */
+export interface SetupIndexConfig {
+  pooling?: string;
+  granularity?: string;
+  sampling?: string;
+  window?: number;
+  maxFrames?: number;
+  fps?: number;
+}
+
 export interface SetupIndex {
   id?: string;
   name: string;
   type: IndexType | string;
   default_signals: string[];
   mode?: "create" | "attach";
+  config?: SetupIndexConfig;
 }
 
 export interface SetupVideoRoute {

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -527,7 +527,11 @@ async function applySetupIndexing(ctx: VerbContext, setup: CaseSetup, operations
         if (!signals.has("similar add") && !signals.has("similar")) continue;
         const recs = await similarVerb.run({ ...ctx, input: "add", rest: [route.ref], opts: { index: id } });
         records.push(...recs);
-        operations.push(`${indexingOperationLabel(recs)}: ${route.ref} -> ${id}`);
+        // label from the similar (embed) record only — shots sampling can return
+        // a READY auxiliary watch record next to a FAILED embed, which would
+        // otherwise read as "indexing started" with no member registered.
+        const embed = recs.filter((r) => r.verb === "similar");
+        operations.push(`${indexingOperationLabel(embed.length ? embed : recs)}: ${route.ref} -> ${id}`);
         continue;
       }
       if (!signals.has("index add")) continue;

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -275,7 +275,7 @@ function caseStatusTldr(ctx: VerbContext, records: OvercastRecord[], counts: Rec
   const targets = listTargets(ctx.case);
   const targetText = targets.map((t) => t.value).slice(0, 4);
   const readyRecords = records.filter((r) => (r.state ?? "ready") === "ready");
-  const evidenceKinds = ["watch", "listen", "see", "face", "image", "crop", "scan", "capture", "note", "finding"]
+  const evidenceKinds = ["watch", "listen", "see", "face", "image", "similar", "crop", "scan", "capture", "note", "finding"]
     .filter((verb) => (counts[verb] ?? 0) > 0);
   const headline = [
     ctx.case.exists() ? `Case '${ctx.case.info().name}' is initialized` : "Case is not initialized",
@@ -289,7 +289,7 @@ function caseStatusTldr(ctx: VerbContext, records: OvercastRecord[], counts: Rec
   if (!findings.length) findings.push("No evidence records have been added yet.");
   const next: string[] = [];
   if (!targetText.length) next.push("Add a target with `case setup --target ... --yes`.");
-  if (!evidenceKinds.length) next.push("Add evidence with watch/listen/see/face/image/note records.");
+  if (!evidenceKinds.length) next.push("Add evidence with watch/listen/see/face/image/similar/note records.");
   if ((counts.brief ?? 0) === 0 && evidenceKinds.length) next.push("Run `brief --export report.html --theme csi` for an evidence timeline.");
   if (!next.length) next.push("Review the latest evidence cards and expand details for citations.");
   return { headline, findings, next };
@@ -298,7 +298,7 @@ function caseStatusTldr(ctx: VerbContext, records: OvercastRecord[], counts: Rec
 function recentEvidenceSummaries(records: OvercastRecord[]): string[] {
   const out: string[] = [];
   for (const rec of records.slice().reverse()) {
-    if (!["note", "finding", "face", "image", "watch", "see", "listen"].includes(rec.verb)) continue;
+    if (!["note", "finding", "face", "image", "similar", "watch", "see", "listen"].includes(rec.verb)) continue;
     const summary = recordSummary(rec);
     if (summary) out.push(`${rec.verb}: ${summary}`);
   }
@@ -314,7 +314,7 @@ function recordSummary(rec: OvercastRecord): string | undefined {
     const value = p[key];
     if (typeof value === "string" && value.trim()) return truncateLine(value);
   }
-  if (rec.verb === "face" || rec.verb === "image") {
+  if (rec.verb === "face" || rec.verb === "image" || rec.verb === "similar") {
     const op = typeof p.op === "string" ? p.op : rec.verb;
     const count = typeof p.count === "number" ? p.count : undefined;
     return `${op}${count != null ? ` found ${count}` : ""}${rec.media?.ref ? ` in ${rec.media.ref}` : ""}`;

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -17,8 +17,10 @@ import { redactSecrets } from "../env.js";
 import { addSource, listSources, parseSourceSpec, removeSource } from "../state/source.js";
 import { addTarget, listTargets, removeTarget } from "../state/target.js";
 import { addIndex, listIndexes, normalizeIndexType, removeIndex } from "../state/index.js";
-import { emptySetup, loadSetup, saveSetup, setupSummary, type CaseSetup, type SetupIndex } from "../state/setup.js";
+import { emptySetup, loadSetup, saveSetup, setupSummary, type CaseSetup, type SetupIndex, type SetupIndexConfig } from "../state/setup.js";
 import { indexVerb } from "./index.js";
+import { similarVerb } from "./similar.js";
+import { readClipConfig } from "../providers/local/vision.js";
 import { isAv } from "./media-ref.js";
 import { findProviderChoice } from "../providers/catalog.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
@@ -73,10 +75,36 @@ function summarizeSavedSetup(setup: CaseSetup | undefined): Record<string, unkno
   return setupSummary(setup);
 }
 
+/** Parse an optional trailing `@k=v;k=v` config suffix (basic-clip). Pairs are
+ *  `;`-separated (NOT comma — `--index` is itself a comma-separated list). Split
+ *  off BEFORE the `:` split so it doesn't collide with the `id:type:name` attach
+ *  form. Keys: pooling, granularity, sampling, window, max-frames|maxFrames, fps. */
+function parseIndexConfigSuffix(spec: string): { base: string; config?: SetupIndexConfig } {
+  const at = spec.indexOf("@");
+  if (at < 0) return { base: spec };
+  const base = spec.slice(0, at);
+  const config: SetupIndexConfig = {};
+  for (const pair of spec.slice(at + 1).split(";")) {
+    const eq = pair.indexOf("=");
+    if (eq < 0) continue;
+    const key = pair.slice(0, eq).trim().toLowerCase();
+    const value = pair.slice(eq + 1).trim();
+    if (!value) continue;
+    if (key === "pooling") config.pooling = value;
+    else if (key === "granularity") config.granularity = value;
+    else if (key === "sampling") config.sampling = value;
+    else if (key === "window") config.window = Number(value);
+    else if (key === "max-frames" || key === "maxframes") config.maxFrames = Number(value);
+    else if (key === "fps") config.fps = Number(value);
+  }
+  return { base, config: Object.keys(config).length ? config : undefined };
+}
+
 function parseIndexSpec(spec: string, signals: string[]): SetupIndex {
-  const parts = spec.split(":").map((p) => p.trim()).filter(Boolean);
+  const { base, config } = parseIndexConfigSuffix(spec);
+  const parts = base.split(":").map((p) => p.trim()).filter(Boolean);
   let id: string | undefined;
-  let name = parts[0] ?? spec;
+  let name = parts[0] ?? base;
   let rawType = parts[1] ?? "media-descriptions";
   if (parts.length >= 3) {
     id = parts[0];
@@ -90,6 +118,7 @@ function parseIndexSpec(spec: string, signals: string[]): SetupIndex {
     type,
     mode: id ? "attach" : "create",
     default_signals: signals.length ? signals : (DEFAULT_SIGNAL_BY_INDEX_TYPE[type] ?? []),
+    ...(config ? { config } : {}),
   };
 }
 
@@ -361,13 +390,20 @@ function setupFromExistingRegistries(ctx: VerbContext, caseName: string): CaseSe
     const type = normalizeIndexType(i.type) ?? i.type;
     const defaultSignals = DEFAULT_SIGNAL_BY_INDEX_TYPE[type] ?? [];
     setup.default_signals[i.id] = defaultSignals;
-    return {
+    const index: SetupIndex = {
       id: i.id,
       name: i.name,
       type,
       mode: "attach",
       default_signals: defaultSignals,
     };
+    // reflect a local basic-clip index's real config so `case setup show/plan`
+    // report how it samples/pools (config lives in the index dir, not indexes.json).
+    if (type === "basic-clip" && i.backend === "local") {
+      const c = readClipConfig(join(ctx.case.indexDir, i.id));
+      index.config = { pooling: c.pooling, granularity: c.granularity, sampling: c.sampling, window: c.window, maxFrames: c.maxFrames ?? undefined, fps: c.fps ?? undefined };
+    }
+    return index;
   });
   const videoRefs = [...new Set(listIndexes(ctx.case).flatMap((i) => i.members.map((m) => m.ref)))];
   setup.media.videos = videoRefs;
@@ -455,7 +491,7 @@ async function applySetupIndexing(ctx: VerbContext, setup: CaseSetup, operations
       ...ctx,
       input: "create",
       rest: [index.name],
-      opts: { type: index.type },
+      opts: { type: index.type, ...indexConfigToFlags(index.config) },
     });
     records.push(...recs);
     const created = recs.find(accepted);
@@ -485,6 +521,15 @@ async function applySetupIndexing(ctx: VerbContext, setup: CaseSetup, operations
       const id = index.id;
       if (!id || !route.indexes.includes(id)) continue;
       const signals = new Set([...route.signals, ...(setup.default_signals[id] ?? index.default_signals)]);
+      // basic-clip embeds members via the `similar` verb (opt-in `similar add`
+      // signal); every other index type registers via `index add`.
+      if (index.type === "basic-clip") {
+        if (!signals.has("similar add") && !signals.has("similar")) continue;
+        const recs = await similarVerb.run({ ...ctx, input: "add", rest: [route.ref], opts: { index: id } });
+        records.push(...recs);
+        operations.push(`${indexingOperationLabel(recs)}: ${route.ref} -> ${id}`);
+        continue;
+      }
       if (!signals.has("index add")) continue;
       const recs = await indexVerb.run({
         ...ctx,
@@ -498,6 +543,19 @@ async function applySetupIndexing(ctx: VerbContext, setup: CaseSetup, operations
   }
 
   return records;
+}
+
+/** Map a saved SetupIndexConfig into `index create` flags (basic-clip). */
+function indexConfigToFlags(config: SetupIndexConfig | undefined): Record<string, string | number> {
+  if (!config) return {};
+  const flags: Record<string, string | number> = {};
+  if (config.pooling) flags.pooling = config.pooling;
+  if (config.granularity) flags.granularity = config.granularity;
+  if (config.sampling) flags.sampling = config.sampling;
+  if (config.window != null) flags.window = config.window;
+  if (config.maxFrames != null) flags["max-frames"] = config.maxFrames;
+  if (config.fps != null) flags.fps = config.fps;
+  return flags;
 }
 
 function buildSetupChange(ctx: VerbContext, base: CaseSetup, op: "startup_setup" | "startup_setup_update", apply: boolean): SetupChange {

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -521,10 +521,11 @@ async function applySetupIndexing(ctx: VerbContext, setup: CaseSetup, operations
       const id = index.id;
       if (!id || !route.indexes.includes(id)) continue;
       const signals = new Set([...route.signals, ...(setup.default_signals[id] ?? index.default_signals)]);
-      // basic-clip embeds members via the `similar` verb (opt-in `similar add`
-      // signal); every other index type registers via `index add`.
+      // basic-clip embeds members via the `similar` verb. The generic `index add`
+      // signal opts in too — the standard "watch,index add" route must not leave
+      // a CLIP index silently empty just because it embeds through a different verb.
       if (index.type === "basic-clip") {
-        if (!signals.has("similar add") && !signals.has("similar")) continue;
+        if (!signals.has("similar add") && !signals.has("similar") && !signals.has("index add")) continue;
         const recs = await similarVerb.run({ ...ctx, input: "add", rest: [route.ref], opts: { index: id } });
         records.push(...recs);
         // label from the similar (embed) record only — shots sampling can return

--- a/src/verbs/index.ts
+++ b/src/verbs/index.ts
@@ -38,15 +38,21 @@ import {
   setMembers,
 } from "../state/index.js";
 import { providerEnv } from "../providers/provider-env.js";
-import { localIndexDir } from "../providers/local/vision.js";
-import { resolveVideoArg, resolveImageArg, isRegisterableMediaRecord, isImage } from "./media-ref.js";
+import {
+  localIndexDir,
+  writeClipConfig,
+  defaultClipConfig,
+  removeClipEmbedding,
+  type ClipConfig,
+} from "../providers/local/vision.js";
+import { resolveVideoArg, resolveImageArg, resolveVisualArg, isRegisterableMediaRecord, isImage } from "./media-ref.js";
 import { badNumber, numFlag } from "./validate.js";
 import { tinycloudBaseFromRun } from "../providers/tinycloud/envelope.js";
 import type { Case } from "../case.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
 const VALID_ACTIONS = ["create", "attach", "add", "list", "show", "delete", "remove", "entities"];
-const LOCAL_INDEX_TYPES = new Set(["deepface-local", "image-ransac"]);
+const LOCAL_INDEX_TYPES = new Set(["deepface-local", "image-ransac", "basic-clip"]);
 const LOCAL_VIDEO_RE = /\.(mp4|m4v|mov|webm|mkv|avi|mpe?g|m2ts|mts|ts|wmv|flv|3gp|3g2|ogv|mxf)$/i;
 const LOCAL_IMAGE_MEDIA_VERBS = new Set(["capture", "image", "face"]);
 
@@ -56,6 +62,35 @@ function err(message: string): OvercastRecord {
 
 function isLocalIndex(entry: { backend?: string; type: string }): boolean {
   return entry.backend === "local";
+}
+
+/** Build a validated basic-clip ClipConfig from create flags, merged over the
+ *  defaults. Returns an error string for a bad enum/number value. */
+function clipConfigFromOpts(opts: Record<string, unknown>): { config?: ClipConfig; error?: string } {
+  const cfg = defaultClipConfig();
+  const enumFlag = <T extends string>(name: string, allowed: readonly T[]): T | undefined | string => {
+    const v = opts[name];
+    if (v == null) return undefined;
+    const s = String(v);
+    return (allowed as readonly string[]).includes(s) ? (s as T) : `--${name} must be one of: ${allowed.join(", ")} (got '${s}')`;
+  };
+  const pooling = enumFlag("pooling", ["max", "mean"] as const);
+  if (typeof pooling === "string" && pooling.startsWith("--")) return { error: pooling };
+  const granularity = enumFlag("granularity", ["video", "frame"] as const);
+  if (typeof granularity === "string" && granularity.startsWith("--")) return { error: granularity };
+  const sampling = enumFlag("sampling", ["uniform", "shots"] as const);
+  if (typeof sampling === "string" && sampling.startsWith("--")) return { error: sampling };
+  if (pooling) cfg.pooling = pooling as ClipConfig["pooling"];
+  if (granularity) cfg.granularity = granularity as ClipConfig["granularity"];
+  if (sampling) cfg.sampling = sampling as ClipConfig["sampling"];
+  for (const [name, key] of [["window", "window"], ["max-frames", "maxFrames"], ["fps", "fps"]] as const) {
+    const v = opts[name];
+    if (v == null) continue;
+    const n = Number(v);
+    if (!Number.isFinite(n) || n <= 0) return { error: `--${name} expects a positive number (got '${String(v)}')` };
+    cfg[key] = n;
+  }
+  return { config: cfg };
 }
 
 function indexRecord(rec: OvercastRecord): OvercastRecord {
@@ -181,7 +216,7 @@ function resolveTarget(c: Case, explicit?: string, type?: string): { id?: string
   // once a target resolves, so a sole unknown stub must still match `--type face`.
   if (type) cols = cols.filter((x) => x.type === type || x.type === "unknown");
   if (cols.length === 1) return { id: cols[0].id };
-  if (cols.length === 0) return { error: "no indexes in this case — create one with `overcast index create <name> --type <media|entities|face|deepface-local|image-ransac>`" };
+  if (cols.length === 0) return { error: "no indexes in this case — create one with `overcast index create <name> --type <media|entities|face|deepface-local|image-ransac|basic-clip>`" };
   return { error: `multiple indexes; specify one (ids: ${cols.map((x) => x.id).join(", ")})` };
 }
 
@@ -278,7 +313,7 @@ export const indexVerb: VerbSpec = {
     { name: "arg2", summary: "entities: the video/record-id (index entities <id> <video>)", required: false },
   ],
   flags: [
-    { name: "type", summary: "create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac", type: "string" },
+    { name: "type", summary: "create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | basic-clip", type: "string" },
     { name: "local", summary: "create a local index instead of a tinycloud-backed index", type: "boolean" },
     { name: "description", summary: "create: human description", type: "string" },
     { name: "prompt", summary: "create entities: free-text extraction prompt", type: "string" },
@@ -291,6 +326,10 @@ export const indexVerb: VerbSpec = {
     { name: "no-download", summary: "add: don't materialize the source locally", type: "boolean" },
     { name: "limit", summary: "entities: max entities", type: "number" },
     { name: "offset", summary: "entities: entity offset", type: "number" },
+    { name: "pooling", summary: "create basic-clip: pool video frames by max | mean", type: "string", choices: ["max", "mean"] },
+    { name: "granularity", summary: "create basic-clip: video | frame (moment-level)", type: "string", choices: ["video", "frame"] },
+    { name: "sampling", summary: "create basic-clip: uniform | shots (watch boundaries)", type: "string", choices: ["uniform", "shots"] },
+    { name: "window", summary: "create basic-clip: seconds per uniform sampling window", type: "number" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],
@@ -319,11 +358,11 @@ export const indexVerb: VerbSpec = {
       const rawType = ctx.opts.type != null ? String(ctx.opts.type) : "media-descriptions";
       const type = normalizeIndexType(rawType);
       if (!type) {
-        return [err(`unknown --type '${rawType}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac)`)];
+        return [err(`unknown --type '${rawType}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | basic-clip)`)];
       }
       const local = ctx.opts.local === true || LOCAL_INDEX_TYPES.has(type);
       if (ctx.opts.local === true && !LOCAL_INDEX_TYPES.has(type)) {
-        return [err(`--local only supports deepface-local or image-ransac indexes (got ${type})`)];
+        return [err(`--local only supports deepface-local, image-ransac, or basic-clip indexes (got ${type})`)];
       }
       // reject a provided-but-blank text/path flag (a typo) — sweep all of create's
       // value flags together, so a blank `--schema=`/`--prompt=`/`--description=`
@@ -342,8 +381,17 @@ export const indexVerb: VerbSpec = {
       }
       if (schema && !existsSync(schema)) return [err(`--schema file not found: ${schema}`)];
       if (local) {
+        // basic-clip carries a per-index CLIP config (pooling/granularity/sampling
+        // /window); persist it to config.json so `similar` + the wizard agree.
+        let clipConfig: ClipConfig | undefined;
+        if (type === "basic-clip") {
+          const built = clipConfigFromOpts(ctx.opts);
+          if (built.error) return [err(`index create: ${built.error}`)];
+          clipConfig = built.config;
+        }
         const id = `local_${type.replace(/-/g, "_")}_${randomBytes(4).toString("hex")}`;
         mkdirSync(localIndexDir(c, id), { recursive: true });
+        if (clipConfig) writeClipConfig(localIndexDir(c, id), clipConfig);
         const entry = addIndex(c, { id, type, name, description, backend: "local" });
         return [makeRecord({
           verb: "index",
@@ -356,6 +404,7 @@ export const indexVerb: VerbSpec = {
             type: entry.type,
             backend: "local",
             path: localIndexDir(c, id),
+            ...(clipConfig ? { config: clipConfig } : {}),
           },
           meta: { provider: "local", case: c.dir },
           state: "ready",
@@ -375,7 +424,7 @@ export const indexVerb: VerbSpec = {
       if (!requested) return [err("usage: index attach <remote-index-id-or-name> [--type <media|entities|face>]")];
       const typeHint = ctx.opts.type != null ? normalizeIndexType(String(ctx.opts.type)) : undefined;
       if (ctx.opts.type != null && !typeHint) {
-        return [err(`unknown --type '${ctx.opts.type}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac)`)];
+        return [err(`unknown --type '${ctx.opts.type}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | basic-clip)`)];
       }
       if (typeHint && LOCAL_INDEX_TYPES.has(typeHint)) {
         return [err(`index attach: ${typeHint} is local-only; create it with \`index create <name> --type ${typeHint} --local\``)];
@@ -488,6 +537,11 @@ export const indexVerb: VerbSpec = {
       }
       const targetEntry = findIndex(c, id);
       if (targetEntry && isLocalIndex(targetEntry)) {
+        // basic-clip members must be embedded (CLIP vectors), not just referenced —
+        // that path lives on the `similar` verb, which computes + caches them.
+        if (targetEntry.type === "basic-clip") {
+          return [err(`index add: '${id}' is a basic-clip index — embed members with \`similar add <image|video> --index ${id}\` (it computes and caches CLIP vectors)`)];
+        }
         if (ctx.opts["no-upload"] === true || ctx.opts["no-download"] === true) {
           return [err("index add: --no-upload/--no-download only apply to tinycloud indexes")];
         }
@@ -670,14 +724,19 @@ export const indexVerb: VerbSpec = {
       if (from.error) return [err(`index remove: ${from.error}`)];
       const local = findIndex(c, from.id!);
       if (local && isLocalIndex(local)) {
-        const img = resolveImageArg(c, arg, "index remove", { requireExists: false, requireReady: false });
-        if (img.error) return [err(img.error)];
-        const removed = removeMember(c, from.id!, img.ref!);
+        // basic-clip members can be videos (image-ransac/deepface store stills), so
+        // accept either; also drop the removed member's cached embedding.
+        const resolved = local.type === "basic-clip"
+          ? resolveVisualArg(c, arg, "index remove", { requireExists: false, requireReady: false })
+          : resolveImageArg(c, arg, "index remove", { requireExists: false, requireReady: false });
+        if (resolved.error) return [err(resolved.error)];
+        const removed = removeMember(c, from.id!, resolved.ref!);
+        if (local.type === "basic-clip" && removed) removeClipEmbedding(localIndexDir(c, from.id!), resolved.ref!);
         return [makeRecord({
           verb: "index",
           format: "json",
-          payload: { op: "remove", index: from.id, file: img.ref, backend: "local", removed },
-          media: { ref: img.ref! },
+          payload: { op: "remove", index: from.id, file: resolved.ref, backend: "local", removed },
+          media: { ref: resolved.ref! },
           meta: { provider: "local", case: c.dir },
           state: "ready",
         })];

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -156,10 +156,12 @@ export const similarVerb: VerbSpec = {
     const indexDir = localIndexDir(ctx.case, idx.id!);
     const cfg = effectiveConfig(indexDir, ctx.opts);
 
-    // ONE shared opts block for all three actions. Every op must carry the FULL
-    // effective sampling config: the Python side keys its embedding cache on it
-    // (config_hash), so an op that omitted sampling/window/fps would miss the
-    // cache and silently re-embed members with defaults.
+    // ONE shared opts block for all three actions, carrying the FULL effective
+    // sampling config. `add` keys the member cache on it (config_hash); for
+    // match/search it shapes only the QUERY embedding — the Python side pins
+    // member-cache reads to the persisted index config (config.json) and never
+    // writes the cache at query time, so a one-off override can't re-key or
+    // mutate stored member vectors.
     const baseOpts = {
       indexId: idx.id!,
       pooling: cfg.pooling,

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -1,0 +1,213 @@
+// `similar` verb: cross-modal semantic search over a local `basic-clip` CLIP DB.
+// `similar add <image|video>` embeds + caches a member (videos are sampled and
+// pooled); `similar match <image|video>` queries image→image; `similar search
+// "<text>"` queries text→image. Deliberately local-only (OpenAI CLIP via
+// open_clip); remote searchable video indexes stay under `index`/`ask`/`face`.
+
+import { existsSync, mkdirSync } from "node:fs";
+import { makeRecord, isReady, type OvercastRecord } from "../record.js";
+import { addMember, findIndex, resolveIndexRef } from "../state/index.js";
+import {
+  localIndexDir,
+  runLocalClip,
+  readClipConfig,
+  type ClipConfig,
+} from "../providers/local/vision.js";
+import { resolveVisualArg } from "./media-ref.js";
+import { badNumber } from "./validate.js";
+import { providerBinding } from "../providers/bindings.js";
+import { isCustomBinding, runBoundProvider } from "../providers/run.js";
+import { providerEnv } from "../providers/provider-env.js";
+import { runWatch } from "../providers/tinycloud/watch.js";
+import type { Case } from "../case.js";
+import type { VerbContext, VerbSpec } from "../registry/types.js";
+
+function err(message: string): OvercastRecord {
+  return makeRecord({ verb: "similar", format: "json", payload: { error: message }, error: message, state: "error" });
+}
+
+/** Resolve + validate a local basic-clip index the query/add targets. */
+function localClipIndex(ctxCase: Case, value: unknown): { id?: string; error?: string } {
+  const raw = value != null ? String(value).trim() : "";
+  if (!raw) return { error: "--index requires a local basic-clip index id/name" };
+  const r = resolveIndexRef(ctxCase, raw);
+  if (r.error) return { error: r.error };
+  const entry = r.entry ?? findIndex(ctxCase, raw);
+  if (!entry) return { error: `unknown local basic-clip index: ${raw}` };
+  if (entry.type !== "basic-clip") return { error: `index ${entry.id} is type '${entry.type}', not basic-clip` };
+  if (entry.backend !== "local") return { error: `index ${entry.id} is not local; create one with \`index create <name> --type basic-clip --local\`` };
+  return { id: entry.id };
+}
+
+/** Effective config for a query/add: index config.json overridden by CLI flags. */
+function effectiveConfig(indexDir: string, opts: VerbContext["opts"]): ClipConfig {
+  const cfg = readClipConfig(indexDir);
+  const pooling = opts.pooling === "mean" || opts.pooling === "max" ? opts.pooling : cfg.pooling;
+  const granularity = opts.granularity === "frame" || opts.granularity === "video" ? opts.granularity : cfg.granularity;
+  const sampling = opts.sampling === "shots" || opts.sampling === "uniform" ? opts.sampling : cfg.sampling;
+  return {
+    pooling,
+    granularity,
+    sampling,
+    window: opts.window != null ? Number(opts.window) : cfg.window,
+    maxFrames: opts["max-frames"] != null ? Number(opts["max-frames"]) : cfg.maxFrames,
+    fps: opts.fps != null ? Number(opts.fps) : cfg.fps,
+  };
+}
+
+/** Segment-start seconds from a watch record's `payload.detailed.segments[]`. */
+function segmentStarts(rec: OvercastRecord | undefined): number[] {
+  const detailed = (rec?.payload as Record<string, unknown> | undefined)?.detailed as Record<string, unknown> | undefined;
+  const segs = detailed?.segments;
+  if (!Array.isArray(segs)) return [];
+  const out: number[] = [];
+  for (const s of segs) {
+    if (!s || typeof s !== "object") continue;
+    const seg = s as Record<string, unknown>;
+    const raw = seg.start_seconds ?? seg.start ?? seg.start_time;
+    const n = typeof raw === "number" ? raw : Number(raw);
+    if (Number.isFinite(n) && n >= 0) out.push(n);
+  }
+  return [...new Set(out)].sort((a, b) => a - b);
+}
+
+/** Shot markers for a video: reuse an existing `watch` record's segments; else
+ *  invoke the bound watch provider once. Returns [] when none are available (the
+ *  caller falls back to uniform sampling). */
+async function shotMarkers(ctx: VerbContext, ref: string): Promise<number[]> {
+  const existing = ctx.case
+    .records()
+    .find((r) => r.verb === "watch" && r.media?.ref === ref && isReady(r));
+  const reused = segmentStarts(existing);
+  if (reused.length) return reused;
+  // No watch evidence yet — call the bound watch provider (as watchVerb does) to
+  // obtain shot boundaries. Reuse-first avoids re-paying for an already-watched clip.
+  const binding = providerBinding(ctx, "watch");
+  const rec = isCustomBinding(binding)
+    ? await runBoundProvider("watch", binding!, ref, { env: providerEnv(ctx.case.mediaDir), timeoutMs: 15 * 60_000, signal: ctx.signal })
+    : await runWatch(ref, { run: binding?.run, signal: ctx.signal });
+  return isReady(rec) ? segmentStarts(rec) : [];
+}
+
+export const similarVerb: VerbSpec = {
+  name: "similar",
+  group: "sense",
+  summary: "Find images/video moments by visual or text similarity in a local CLIP (basic-clip) index.",
+  description:
+    "`similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB " +
+    "(videos are frame-sampled and pooled). " +
+    "`similar match <image|video> --index <id>` ranks members by image→image similarity; " +
+    "`similar search \"<text>\" --index <id>` ranks members by text→image similarity. " +
+    "Runs OpenAI CLIP locally (open_clip); scores are cosine×100 (0–100).",
+  args: [
+    { name: "action", summary: "add | match | search", required: true },
+    { name: "input", summary: "image/video path, URL, record id (add/match) — or a text query (search)", required: false, variadic: true },
+  ],
+  flags: [
+    { name: "index", summary: "local basic-clip index id/name", type: "string" },
+    { name: "to", summary: "alias for --index when adding", type: "string" },
+    { name: "min-similarity", summary: "match/search: similarity floor (0–100)", type: "number" },
+    { name: "limit", summary: "match/search: max results", type: "number" },
+    { name: "offset", summary: "match/search: result offset", type: "number" },
+    { name: "pooling", summary: "video: pool frame embeddings by max | mean (default index config)", type: "string", choices: ["max", "mean"] },
+    { name: "granularity", summary: "video: video (one vector/video) | frame (one vector/frame → moments)", type: "string", choices: ["video", "frame"] },
+    { name: "sampling", summary: "video: uniform windows | shots (tinycloud watch boundaries)", type: "string", choices: ["uniform", "shots"] },
+    { name: "window", summary: "video: seconds per uniform sampling window", type: "number" },
+    { name: "fps", summary: "video: frame sampling rate; --max-frames can cap it", type: "number" },
+    { name: "max-frames", summary: "video: frame sample count/cap", type: "number" },
+    { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
+    { name: "json", summary: "Shorthand for --format json", type: "boolean" },
+  ],
+  outputKind: "similar.match",
+  providerKey: "similar",
+  run: async (ctx) => {
+    const action = ctx.input;
+    if (action !== "add" && action !== "match" && action !== "search") {
+      return [err("usage: similar <add|match|search> <image|video|text> --index <local-basic-clip-index>")];
+    }
+    const indexValue = ctx.opts.index ?? ctx.opts.to;
+    const idx = localClipIndex(ctx.case, indexValue);
+    if (idx.error) return [err(`similar ${action}: ${idx.error}`)];
+
+    const numErr =
+      badNumber(ctx.opts, "min-similarity", (n) => n >= 0 && n <= 100, "0–100") ??
+      badNumber(ctx.opts, "limit", (n) => n > 0, "a positive number") ??
+      badNumber(ctx.opts, "offset", (n) => n >= 0, "a non-negative number") ??
+      badNumber(ctx.opts, "window", (n) => n > 0, "a positive number") ??
+      badNumber(ctx.opts, "fps", (n) => n > 0, "a positive number") ??
+      badNumber(ctx.opts, "max-frames", (n) => n > 0, "a positive number");
+    if (numErr) return [err(`similar ${action}: ${numErr}`)];
+
+    const indexDir = localIndexDir(ctx.case, idx.id!);
+    const cfg = effectiveConfig(indexDir, ctx.opts);
+
+    // ---- search (text → image) ----
+    if (action === "search") {
+      const text = ctx.rest.join(" ").trim();
+      if (!text) return [err("similar search requires a text query")];
+      const rec = await runLocalClip(ctx.case, text, {
+        indexId: idx.id!,
+        op: "search",
+        minSimilarity: ctx.opts["min-similarity"] != null ? Number(ctx.opts["min-similarity"]) : undefined,
+        limit: ctx.opts.limit != null ? Number(ctx.opts.limit) : undefined,
+        offset: ctx.opts.offset != null ? Number(ctx.opts.offset) : undefined,
+        pooling: cfg.pooling,
+        granularity: cfg.granularity,
+        signal: ctx.signal,
+      });
+      return [rec];
+    }
+
+    // ---- add / match (both take a visual arg) ----
+    const arg = ctx.rest[0];
+    if (!arg) return [err(`similar ${action} requires an image/video input`)];
+    const q = resolveVisualArg(ctx.case, arg, `similar ${action}`);
+    if (q.error) return [err(q.error)];
+    if (!/^https?:\/\//i.test(q.ref!) && !existsSync(q.ref!)) return [err(`similar ${action}: input not found: ${q.ref}`)];
+
+    // shot markers only apply to video sampling; resolve them in TS so the local
+    // clip provider stays pure-CLIP (no tinycloud coupling).
+    let framesAt: number[] | undefined;
+    if (q.kind === "video" && cfg.sampling === "shots") {
+      const markers = await shotMarkers(ctx, q.ref!);
+      if (markers.length) framesAt = markers;
+    }
+
+    if (action === "add") {
+      const entry = findIndex(ctx.case, idx.id!);
+      const already = entry?.members.some((m) => m.ref === q.ref);
+      mkdirSync(indexDir, { recursive: true });
+      if (!already) addMember(ctx.case, idx.id!, { ref: q.ref!, recordId: q.recordId });
+      const rec = await runLocalClip(ctx.case, q.ref!, {
+        indexId: idx.id!,
+        op: "add",
+        pooling: cfg.pooling,
+        granularity: cfg.granularity,
+        sampling: cfg.sampling,
+        window: cfg.window,
+        maxFrames: cfg.maxFrames ?? undefined,
+        fps: cfg.fps ?? undefined,
+        framesAt,
+        signal: ctx.signal,
+      });
+      return [rec];
+    }
+
+    const rec = await runLocalClip(ctx.case, q.ref!, {
+      indexId: idx.id!,
+      op: "match",
+      minSimilarity: ctx.opts["min-similarity"] != null ? Number(ctx.opts["min-similarity"]) : undefined,
+      limit: ctx.opts.limit != null ? Number(ctx.opts.limit) : undefined,
+      offset: ctx.opts.offset != null ? Number(ctx.opts.offset) : undefined,
+      pooling: cfg.pooling,
+      granularity: cfg.granularity,
+      sampling: cfg.sampling,
+      window: cfg.window,
+      maxFrames: cfg.maxFrames ?? undefined,
+      fps: cfg.fps ?? undefined,
+      framesAt,
+      signal: ctx.signal,
+    });
+    return [rec];
+  },
+};

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -84,7 +84,15 @@ async function shotMarkers(ctx: VerbContext, ref: string): Promise<{ markers: nu
     return state !== "error" && state !== "needs_credentials";
   });
   if (evidence.length) {
-    return { markers: segmentStarts(evidence.find(isReady)) };
+    // prefer the NEWEST ready record that actually carries segments — a video
+    // may have been re-watched with better segmentation, and an early
+    // segmentless (e.g. speech-only) record must not mask a later one that has
+    // shot boundaries. Records are append-ordered, so scan in reverse.
+    for (const r of evidence.filter(isReady).reverse()) {
+      const markers = segmentStarts(r);
+      if (markers.length) return { markers };
+    }
+    return { markers: [] };
   }
   // No watch evidence yet — call the bound watch provider (as watchVerb does) to
   // obtain shot boundaries. Reuse-first avoids re-paying for an already-watched clip.

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -124,9 +124,9 @@ export const similarVerb: VerbSpec = {
     { name: "min-similarity", summary: "match/search: similarity floor (0–100)", type: "number" },
     { name: "limit", summary: "match/search: max results", type: "number" },
     { name: "offset", summary: "match/search: result offset", type: "number" },
-    { name: "pooling", summary: "video: pool frame embeddings by max | mean (default index config)", type: "string", choices: ["max", "mean"] },
-    { name: "granularity", summary: "video: video (one vector/video) | frame (one vector/frame → moments)", type: "string", choices: ["video", "frame"] },
-    { name: "sampling", summary: "video: uniform windows | shots (tinycloud watch boundaries)", type: "string", choices: ["uniform", "shots"] },
+    { name: "pooling", summary: "match: pool the query video's frames by max | mean (members follow the index config)", type: "string", choices: ["max", "mean"] },
+    { name: "granularity", summary: "video (one vector/video) | frame (moments) — set at `index create`; members always follow the index config", type: "string", choices: ["video", "frame"] },
+    { name: "sampling", summary: "match query video: uniform windows | shots (tinycloud watch boundaries); members follow the index config", type: "string", choices: ["uniform", "shots"] },
     { name: "window", summary: "video: seconds per uniform sampling window", type: "number" },
     { name: "fps", summary: "video: frame sampling rate; --max-frames can cap it", type: "number" },
     { name: "max-frames", summary: "video: frame sample count/cap", type: "number" },
@@ -154,14 +154,21 @@ export const similarVerb: VerbSpec = {
     if (numErr) return [err(`similar ${action}: ${numErr}`)];
 
     const indexDir = localIndexDir(ctx.case, idx.id!);
-    const cfg = effectiveConfig(indexDir, ctx.opts);
+    // member embeddings follow the PERSISTED index config — a per-add override
+    // would persist a config_hash queries (keyed on config.json) never reuse, so
+    // reject the flags outright rather than silently ignoring them.
+    if (action === "add") {
+      const flag = ["pooling", "granularity", "sampling", "window", "fps", "max-frames"].find((f) => ctx.opts[f] != null);
+      if (flag) return [err(`similar add: --${flag} doesn't apply per-add — member embedding follows the index config; set it at \`index create --type basic-clip\``)];
+    }
+    const cfg = action === "add" ? readClipConfig(indexDir) : effectiveConfig(indexDir, ctx.opts);
 
-    // ONE shared opts block for all three actions, carrying the FULL effective
-    // sampling config. `add` keys the member cache on it (config_hash); for
-    // match/search it shapes only the QUERY embedding — the Python side pins
-    // member-cache reads to the persisted index config (config.json) and never
-    // writes the cache at query time, so a one-off override can't re-key or
-    // mutate stored member vectors.
+    // ONE shared opts block for all three actions, carrying the FULL sampling
+    // config (the index config for `add`, effective config for queries). `add`
+    // keys the member cache on it (config_hash); for match/search it shapes only
+    // the QUERY embedding — the Python side pins member-cache reads to the
+    // persisted index config (config.json) and never writes the cache at query
+    // time, so a one-off override can't re-key or mutate stored member vectors.
     const baseOpts = {
       indexId: idx.id!,
       pooling: cfg.pooling,

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -72,21 +72,28 @@ function segmentStarts(rec: OvercastRecord | undefined): number[] {
 }
 
 /** Shot markers for a video: reuse an existing `watch` record's segments; else
- *  invoke the bound watch provider once. Returns [] when none are available (the
- *  caller falls back to uniform sampling). */
-async function shotMarkers(ctx: VerbContext, ref: string): Promise<number[]> {
-  const existing = ctx.case
-    .records()
-    .find((r) => r.verb === "watch" && r.media?.ref === ref && isReady(r));
-  const reused = segmentStarts(existing);
-  if (reused.length) return reused;
+ *  invoke the bound watch provider once and hand the fresh record back so the
+ *  caller RETURNS it (records are persisted by the verb runner — same contract as
+ *  index add's ensureLocalWatchRecord). Any non-error watch evidence (ready OR
+ *  pending) suppresses a new invocation: a pending watch is already paid for, and
+ *  re-running it here would double-bill. Empty markers = uniform fallback. */
+async function shotMarkers(ctx: VerbContext, ref: string): Promise<{ markers: number[]; watched?: OvercastRecord }> {
+  const evidence = ctx.case.records().filter((r) => {
+    if (r.verb !== "watch" || r.media?.ref !== ref) return false;
+    const state = String(r.state ?? "ready");
+    return state !== "error" && state !== "needs_credentials";
+  });
+  if (evidence.length) {
+    return { markers: segmentStarts(evidence.find(isReady)) };
+  }
   // No watch evidence yet — call the bound watch provider (as watchVerb does) to
   // obtain shot boundaries. Reuse-first avoids re-paying for an already-watched clip.
   const binding = providerBinding(ctx, "watch");
   const rec = isCustomBinding(binding)
     ? await runBoundProvider("watch", binding!, ref, { env: providerEnv(ctx.case.mediaDir), timeoutMs: 15 * 60_000, signal: ctx.signal })
     : await runWatch(ref, { run: binding?.run, signal: ctx.signal });
-  return isReady(rec) ? segmentStarts(rec) : [];
+  rec.meta = { ...rec.meta, case: ctx.case.dir, triggered_by: "similar" };
+  return { markers: isReady(rec) ? segmentStarts(rec) : [], watched: rec };
 }
 
 export const similarVerb: VerbSpec = {
@@ -141,20 +148,31 @@ export const similarVerb: VerbSpec = {
     const indexDir = localIndexDir(ctx.case, idx.id!);
     const cfg = effectiveConfig(indexDir, ctx.opts);
 
+    // ONE shared opts block for all three actions. Every op must carry the FULL
+    // effective sampling config: the Python side keys its embedding cache on it
+    // (config_hash), so an op that omitted sampling/window/fps would miss the
+    // cache and silently re-embed members with defaults.
+    const baseOpts = {
+      indexId: idx.id!,
+      pooling: cfg.pooling,
+      granularity: cfg.granularity,
+      sampling: cfg.sampling,
+      window: cfg.window,
+      maxFrames: cfg.maxFrames ?? undefined,
+      fps: cfg.fps ?? undefined,
+      signal: ctx.signal,
+    };
+    const queryOpts = {
+      minSimilarity: ctx.opts["min-similarity"] != null ? Number(ctx.opts["min-similarity"]) : undefined,
+      limit: ctx.opts.limit != null ? Number(ctx.opts.limit) : undefined,
+      offset: ctx.opts.offset != null ? Number(ctx.opts.offset) : undefined,
+    };
+
     // ---- search (text → image) ----
     if (action === "search") {
       const text = ctx.rest.join(" ").trim();
       if (!text) return [err("similar search requires a text query")];
-      const rec = await runLocalClip(ctx.case, text, {
-        indexId: idx.id!,
-        op: "search",
-        minSimilarity: ctx.opts["min-similarity"] != null ? Number(ctx.opts["min-similarity"]) : undefined,
-        limit: ctx.opts.limit != null ? Number(ctx.opts.limit) : undefined,
-        offset: ctx.opts.offset != null ? Number(ctx.opts.offset) : undefined,
-        pooling: cfg.pooling,
-        granularity: cfg.granularity,
-        signal: ctx.signal,
-      });
+      const rec = await runLocalClip(ctx.case, text, { ...baseOpts, ...queryOpts, op: "search" });
       return [rec];
     }
 
@@ -166,48 +184,33 @@ export const similarVerb: VerbSpec = {
     if (!/^https?:\/\//i.test(q.ref!) && !existsSync(q.ref!)) return [err(`similar ${action}: input not found: ${q.ref}`)];
 
     // shot markers only apply to video sampling; resolve them in TS so the local
-    // clip provider stays pure-CLIP (no tinycloud coupling).
+    // clip provider stays pure-CLIP (no tinycloud coupling). A freshly-run watch
+    // record is returned alongside the similar record so it persists as case
+    // evidence (otherwise every later shots-sampled run would re-pay the watch).
     let framesAt: number[] | undefined;
+    let watched: OvercastRecord | undefined;
     if (q.kind === "video" && cfg.sampling === "shots") {
-      const markers = await shotMarkers(ctx, q.ref!);
-      if (markers.length) framesAt = markers;
+      const shots = await shotMarkers(ctx, q.ref!);
+      if (shots.markers.length) framesAt = shots.markers;
+      watched = shots.watched;
     }
 
     if (action === "add") {
-      const entry = findIndex(ctx.case, idx.id!);
-      const already = entry?.members.some((m) => m.ref === q.ref);
       mkdirSync(indexDir, { recursive: true });
-      if (!already) addMember(ctx.case, idx.id!, { ref: q.ref!, recordId: q.recordId });
-      const rec = await runLocalClip(ctx.case, q.ref!, {
-        indexId: idx.id!,
-        op: "add",
-        pooling: cfg.pooling,
-        granularity: cfg.granularity,
-        sampling: cfg.sampling,
-        window: cfg.window,
-        maxFrames: cfg.maxFrames ?? undefined,
-        fps: cfg.fps ?? undefined,
-        framesAt,
-        signal: ctx.signal,
-      });
-      return [rec];
+      const rec = await runLocalClip(ctx.case, q.ref!, { ...baseOpts, op: "add", framesAt });
+      // register the member only after the embed SUCCEEDED (mirrors index add's
+      // accepted() gate) — a failed embed must not leave a vectorless member that
+      // match/search would silently skip.
+      if (isReady(rec)) {
+        const entry = findIndex(ctx.case, idx.id!);
+        if (!entry?.members.some((m) => m.ref === q.ref)) {
+          addMember(ctx.case, idx.id!, { ref: q.ref!, recordId: q.recordId });
+        }
+      }
+      return watched ? [rec, watched] : [rec];
     }
 
-    const rec = await runLocalClip(ctx.case, q.ref!, {
-      indexId: idx.id!,
-      op: "match",
-      minSimilarity: ctx.opts["min-similarity"] != null ? Number(ctx.opts["min-similarity"]) : undefined,
-      limit: ctx.opts.limit != null ? Number(ctx.opts.limit) : undefined,
-      offset: ctx.opts.offset != null ? Number(ctx.opts.offset) : undefined,
-      pooling: cfg.pooling,
-      granularity: cfg.granularity,
-      sampling: cfg.sampling,
-      window: cfg.window,
-      maxFrames: cfg.maxFrames ?? undefined,
-      fps: cfg.fps ?? undefined,
-      framesAt,
-      signal: ctx.signal,
-    });
-    return [rec];
+    const rec = await runLocalClip(ctx.case, q.ref!, { ...baseOpts, ...queryOpts, op: "match", framesAt });
+    return watched ? [rec, watched] : [rec];
   },
 };

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -49,12 +49,14 @@ bash test/e2e/live/run.sh 10 11 70   # just watch, listen, headless
 - **Local detector (`see --detect`)** — `DETECT_PY` = a python with
   `torch`/`transformers`/`scipy`/`pillow` (OWLv2). If unset, the case probes
   `python3`/`python` and skips when the deps are missing.
-- **Visual DBs / DeepFace** — `OC_VISUAL_DB_PY` points at the
-  uv-managed Python from `scripts/visual-db-uv.sh --face`. Optional real-data
-  fixtures: `OC_LOCAL_IMAGE_REF`, `OC_LOCAL_IMAGE_VIDEO_A`,
+- **Visual DBs / DeepFace / CLIP** — `OC_VISUAL_DB_PY` points at the
+  uv-managed Python from `scripts/visual-db-uv.sh --all` (image + face + CLIP).
+  Optional real-data fixtures: `OC_LOCAL_IMAGE_REF`, `OC_LOCAL_IMAGE_VIDEO_A`,
   `OC_LOCAL_IMAGE_VIDEO_B`, `OC_LOCAL_FACE_IMAGE`, `OC_LOCAL_FACE_VIDEO`,
   plus sampling knobs `OC_LOCAL_IMAGE_FPS`, `OC_LOCAL_FACE_FPS`,
-  `OC_LOCAL_IMAGE_MAX_FRAMES`, and `OC_LOCAL_FACE_MAX_FRAMES`.
+  `OC_LOCAL_IMAGE_MAX_FRAMES`, and `OC_LOCAL_FACE_MAX_FRAMES`. For the CLIP
+  (`basic-clip`) DB: `OC_CLIP_IMAGE_REF`, `OC_CLIP_VIDEO`, `OC_CLIP_TEXT`, plus
+  model overrides `OC_CLIP_MODEL`/`OC_CLIP_PRETRAINED`/`OC_CLIP_DEVICE`.
 - **bun** — to compile the binary (`npm run build:bun`). Set `OVERCAST_USE_NODE=1`
   to run `node dist/bin/overcast.js` instead.
 
@@ -65,7 +67,8 @@ bash test/e2e/live/run.sh 10 11 70   # just watch, listen, headless
 `13_enhance_view` · `20_sources` (Tavily/Apify/yt-dlp) · `21_pipeline`
 (source→capture→sense) · `22_monitor` (`--once` diff + bounded `--every`) ·
 `23_index` · `24_case_search` · `16_visual_db` (local image-ransac,
-`face:deepface-local`, and deepface-local with real media) · `30_read`
+`face:deepface-local`, and deepface-local with real media) · `17_clip_db`
+(local basic-clip CLIP DB: `similar add`/`search`/`match` with real media) · `30_read`
 (ask/brief over real records) · `31_visualization` (CSI status/brief/records
 exports with real visual targets and matches) · `32_headless_visualization`
 (headless agent `--mode json` export trace, default CSI HTML theme) ·

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -54,9 +54,12 @@ bash test/e2e/live/run.sh 10 11 70   # just watch, listen, headless
   Optional real-data fixtures: `OC_LOCAL_IMAGE_REF`, `OC_LOCAL_IMAGE_VIDEO_A`,
   `OC_LOCAL_IMAGE_VIDEO_B`, `OC_LOCAL_FACE_IMAGE`, `OC_LOCAL_FACE_VIDEO`,
   plus sampling knobs `OC_LOCAL_IMAGE_FPS`, `OC_LOCAL_FACE_FPS`,
-  `OC_LOCAL_IMAGE_MAX_FRAMES`, and `OC_LOCAL_FACE_MAX_FRAMES`. For the CLIP
-  (`basic-clip`) DB: `OC_CLIP_IMAGE_REF`, `OC_CLIP_VIDEO`, `OC_CLIP_TEXT`, plus
-  model overrides `OC_CLIP_MODEL`/`OC_CLIP_PRETRAINED`/`OC_CLIP_DEVICE`.
+  `OC_LOCAL_IMAGE_MAX_FRAMES`, and `OC_LOCAL_FACE_MAX_FRAMES`. The CLIP
+  (`basic-clip`) case is self-sufficient: it derives its fixtures from
+  `OC_VIDEO_OBJECTS`/`OC_VIDEO_SMALL` (ffmpeg clips + frames) and captions a
+  frame with `see` for the text queries; `OC_CLIP_VIDEO`/`OC_CLIP_IMAGE_REF`/
+  `OC_CLIP_TEXT` override, and `OC_CLIP_MODEL`/`OC_CLIP_PRETRAINED`/
+  `OC_CLIP_DEVICE` pick the model.
 - **bun** — to compile the binary (`npm run build:bun`). Set `OVERCAST_USE_NODE=1`
   to run `node dist/bin/overcast.js` instead.
 
@@ -68,7 +71,10 @@ bash test/e2e/live/run.sh 10 11 70   # just watch, listen, headless
 (source→capture→sense) · `22_monitor` (`--once` diff + bounded `--every`) ·
 `23_index` · `24_case_search` · `16_visual_db` (local image-ransac,
 `face:deepface-local`, and deepface-local with real media) · `17_clip_db`
-(local basic-clip CLIP DB: `similar add`/`search`/`match` with real media) · `30_read`
+(local basic-clip CLIP DB with real media: fixtures derived from real videos,
+caption-driven queries, all four cross-modal modes — text×video, image×video,
+image×image, text×image — a headless-agent `similar search` leg, and a
+self-contained HTML evidence page `clip_db_evidence.html`) · `30_read`
 (ask/brief over real records) · `31_visualization` (CSI status/brief/records
 exports with real visual targets and matches) · `32_headless_visualization`
 (headless agent `--mode json` export trace, default CSI HTML theme) ·

--- a/test/e2e/live/cases/17_clip_db.sh
+++ b/test/e2e/live/cases/17_clip_db.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
-# Real basic-clip (local CLIP) DB checks: create a local basic-clip index, embed
-# an image + a video via `similar add`, then query by text (`search`) and image
-# (`match`). Uses paths from .env and skips cleanly when open_clip is absent.
+# Real basic-clip (local CLIP) DB checks, CLI + headless agent:
+#   • derives fixtures from REAL videos (frames via ffmpeg) when OC_CLIP_* is
+#     unset, and captions a frame with `see` to derive the text queries
+#   • covers all four cross-modal modes — text×video, image×video, image×image,
+#     text×image — and writes a self-contained HTML evidence page
+#     ($SMOKE_DIR/clip_db_evidence.html) with query + match thumbnails/scores
+#   • drives one search through the headless agent (--mode json) and asserts a
+#     `similar` record persisted
+# Skips cleanly when open_clip deps or media are absent.
 LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib.sh
 source "$LIVE/lib.sh"
 C=clip_db
-
-have_media "$CLIP_IMAGE_REF" || { skip "$C.clip" "no OC_CLIP_IMAGE_REF"; exit 0; }
 
 PY="${OC_VISUAL_DB_PY:-${OVERCAST_VISUAL_DB_PY:-python3}}"
 if ! "$PY" - <<'PY' >/dev/null 2>&1
@@ -18,50 +22,160 @@ then
   exit 0
 fi
 
+# --- real fixtures: two distinct-scene videos + frames drawn from them --------
+# VIDEO A (e.g. a work site) is the target for text×video / image×video;
+# VIDEO B (a different scene) provides an IMAGE member for image×image / text×image.
+SRC_A="${CLIP_VIDEO:-$VIDEO_OBJECTS}"
+SRC_B="$VIDEO_SMALL"
+have_media "$SRC_A" || { skip "$C.media" "no OC_CLIP_VIDEO/OC_VIDEO_OBJECTS video"; exit 0; }
+have_media "$SRC_B" || { skip "$C.media" "no OC_VIDEO_SMALL video"; exit 0; }
+
+CLIP_A="$SMOKE_DIR/clipdb_video_a.mp4"; clip_av 20 "$SRC_A" "$CLIP_A"
+CLIP_B="$SMOKE_DIR/clipdb_video_b.mp4"; clip_av 20 "$SRC_B" "$CLIP_B"
+IMG_B_MEMBER="${CLIP_IMAGE_REF:-$SMOKE_DIR/clipdb_member_b.jpg}"
+have_media "$IMG_B_MEMBER" || frame_jpg "$SRC_B" 3 "$IMG_B_MEMBER"
+IMG_A_QUERY="$SMOKE_DIR/clipdb_query_a.jpg"; frame_jpg "$SRC_A" 8 "$IMG_A_QUERY"
+IMG_B_QUERY="$SMOKE_DIR/clipdb_query_b.jpg"; frame_jpg "$SRC_B" 12 "$IMG_B_QUERY"
+for f in "$CLIP_A" "$CLIP_B" "$IMG_B_MEMBER" "$IMG_A_QUERY" "$IMG_B_QUERY"; do
+  have_media "$f" || { skip "$C.media" "could not derive real fixtures (ffmpeg)"; exit 0; }
+done
+
 CASE=$(case_dir clip_db)
 
-cond "index create --type basic-clip --local makes a CLIP DB and similar add embeds a reference image"
-created="$(oc "$CASE" index create scenes --type basic-clip --local --granularity frame --json)"; rc=$?
+# --- build the DB (CLI leg) ---------------------------------------------------
+cond "index create --type basic-clip --local makes a frame-level CLIP DB with a persisted config"
+created="$(oc "$CASE" index create scenes --type basic-clip --local --granularity frame --window 5 --json)"; rc=$?
 assert_eq "$C.create_exit" "0" "$rc" "local basic-clip index create exits 0"
 CLIP_INDEX="$(echo "$created" | jq -r '.payload.index // empty')"
 assert_nonempty "$C.index_id" "$CLIP_INDEX" "local basic-clip index id returned"
 assert_eq "$C.create_config" "frame" "$(echo "$created" | jq -r '.payload.config.granularity // empty')" "config.json granularity persisted"
 
-add_img="$(OC_TIMEOUT=420 oc "$CASE" similar add "$CLIP_IMAGE_REF" --index "$CLIP_INDEX" --json)"
-assert_eq "$C.add_image_state" "ready" "$(echo "$add_img" | jq -r '.state')" "reference image embedded into the CLIP DB"
+cond "similar add embeds two real videos (frame-sampled) and a real image into the CLIP DB"
+add_a="$(OC_TIMEOUT=600 oc "$CASE" similar add "$CLIP_A" --index "$CLIP_INDEX" --json)"
+assert_eq "$C.add_video_a" "ready" "$(echo "$add_a" | jq -r '.state')" "video A embedded"
+vec_a="$(echo "$add_a" | jq -r '.payload.vectors // 0')"
+[ "${vec_a:-0}" -ge 2 ] && ok "$C.add_video_a_vectors" "video A produced $vec_a frame vectors" || fail "$C.add_video_a_vectors" "expected ≥2 frame vectors for video A, got $vec_a"
+add_b="$(OC_TIMEOUT=600 oc "$CASE" similar add "$CLIP_B" --index "$CLIP_INDEX" --json)"
+assert_eq "$C.add_video_b" "ready" "$(echo "$add_b" | jq -r '.state')" "video B embedded"
+add_img="$(OC_TIMEOUT=420 oc "$CASE" similar add "$IMG_B_MEMBER" --index "$CLIP_INDEX" --json)"
+assert_eq "$C.add_image" "ready" "$(echo "$add_img" | jq -r '.state')" "image member embedded"
 
-if have_media "$CLIP_VIDEO"; then
-  add_vid="$(OC_TIMEOUT=600 oc "$CASE" similar add "$CLIP_VIDEO" --index "$CLIP_INDEX" --json)"
-  assert_eq "$C.add_video_state" "ready" "$(echo "$add_vid" | jq -r '.state')" "video embedded (frame-sampled) into the CLIP DB"
-  save_json "clip_db_add_video" "$add_vid" >/dev/null
+# --- caption real frames with `see` to derive the text queries -----------------
+# (falls back to generic phrases when no see backend is available)
+derive_query() { # <frame> <fallback>
+  local out q
+  out="$(OC_TIMEOUT=180 ocrun "$CASE" see "$1" --json 2>/dev/null)"
+  q="$(echo "$out" | jq -r '.payload.caption // empty' 2>/dev/null | grep -v '^#' | grep -v '^[[:space:]]*$' | head -1 | tr -s ' ' | cut -d' ' -f1-14)"
+  [ -n "$q" ] && printf '%s' "$q" || printf '%s' "$2"
+}
+QUERY_A="$(derive_query "$IMG_A_QUERY" "${CLIP_TEXT:-a person working outdoors}")"
+QUERY_B="$(derive_query "$IMG_B_QUERY" "food cooking on a grill")"
+if [ "$QUERY_A" != "${CLIP_TEXT:-a person working outdoors}" ]; then
+  ok "$C.caption_query" "see captioned a real frame into a search query: \"$QUERY_A\""
 else
-  skip "$C.add_video" "no OC_CLIP_VIDEO"
+  skip "$C.caption_query" "see unavailable — using fallback query text"
 fi
 
-cond "similar search ranks members by text->image similarity"
-search="$(OC_TIMEOUT=420 oc "$CASE" similar search "$CLIP_TEXT" --index "$CLIP_INDEX" --limit 5 --json)"
-assert_eq "$C.search_state" "ready" "$(echo "$search" | jq -r '.state')" "text search state ready"
-assert_eq "$C.search_query" "$CLIP_TEXT" "$(echo "$search" | jq -r '.payload.query // empty')" "text query echoed on the record"
-search_count="$(echo "$search" | jq -r '.payload.count // 0')"
-if [ "$search_count" -gt 0 ]; then
-  ok "$C.search_count" "found $search_count semantic match(es) for \"$CLIP_TEXT\""
-else
-  fail "$C.search_count" "expected at least one semantic match for \"$CLIP_TEXT\", got 0"
-fi
-save_json "clip_db_search" "$search" >/dev/null
+# --- the four cross-modal modes -----------------------------------------------
+cond "text×video: a caption-derived text query ranks the right video's moments"
+tv="$(OC_TIMEOUT=420 oc "$CASE" similar search "$QUERY_A" --index "$CLIP_INDEX" --limit 8 --json)"
+assert_eq "$C.text_video_state" "ready" "$(echo "$tv" | jq -r '.state')" "text×video search ready"
+tv_top="$(echo "$tv" | jq -r '.payload.matches[0].ref // empty')"
+assert_eq "$C.text_video_top" "$CLIP_A" "$tv_top" "top text×video match is video A"
+tv_at="$(echo "$tv" | jq -r '.payload.matches[0].at // empty')"
+assert_nonempty "$C.text_video_at" "$tv_at" "text×video match carries a frame moment (at)"
+save_json "clip_db_text_video" "$tv" >/dev/null
 
-cond "similar match ranks members by image->image similarity"
-match="$(OC_TIMEOUT=420 oc "$CASE" similar match "$CLIP_IMAGE_REF" --index "$CLIP_INDEX" --json)"
-assert_eq "$C.match_state" "ready" "$(echo "$match" | jq -r '.state')" "image match state ready"
-match_count="$(echo "$match" | jq -r '.payload.count // 0')"
-if [ "$match_count" -gt 0 ]; then
-  ok "$C.match_count" "found $match_count visual match(es) (the reference itself should rank top)"
-else
-  fail "$C.match_count" "expected at least one visual match (the embedded reference), got 0"
-fi
-save_json "clip_db_match" "$match" >/dev/null
+cond "image×video: a real frame from video A ranks video A's nearest moment first"
+iv="$(OC_TIMEOUT=420 oc "$CASE" similar match "$IMG_A_QUERY" --index "$CLIP_INDEX" --limit 8 --json)"
+assert_eq "$C.image_video_state" "ready" "$(echo "$iv" | jq -r '.state')" "image×video match ready"
+assert_eq "$C.image_video_top" "$CLIP_A" "$(echo "$iv" | jq -r '.payload.matches[0].ref // empty')" "top image×video match is video A"
+iv_sim="$(echo "$iv" | jq -r '.payload.matches[0].similarity // 0')"
+[ "$(echo "$iv_sim >= 60" | bc -l)" = "1" ] && ok "$C.image_video_sim" "same-scene frame similarity is strong ($iv_sim)" || fail "$C.image_video_sim" "expected ≥60 similarity for a same-video frame, got $iv_sim"
+save_json "clip_db_image_video" "$iv" >/dev/null
 
-# the cache should now hold at least one embedding vector on disk
+cond "image×image: a different frame of scene B finds the stored image member"
+ii="$(OC_TIMEOUT=420 oc "$CASE" similar match "$IMG_B_QUERY" --index "$CLIP_INDEX" --limit 8 --json)"
+assert_eq "$C.image_image_state" "ready" "$(echo "$ii" | jq -r '.state')" "image×image match ready"
+ii_top="$(echo "$ii" | jq -r '.payload.matches[0].ref // empty')"
+case "$ii_top" in "$CLIP_B"|"$IMG_B_MEMBER") ok "$C.image_image_top" "top match is scene B ($(basename "$ii_top"))" ;; *) fail "$C.image_image_top" "top match is not scene B: $ii_top" ;; esac
+ii_has_img="$(echo "$ii" | jq --arg r "$IMG_B_MEMBER" '[.payload.matches[].ref] | index($r) != null')"
+assert_eq "$C.image_image_member" "true" "$ii_has_img" "the stored image member appears in the matches"
+save_json "clip_db_image_image" "$ii" >/dev/null
+
+cond "text×image: a caption-derived text query surfaces the stored image member"
+ti="$(OC_TIMEOUT=420 oc "$CASE" similar search "$QUERY_B" --index "$CLIP_INDEX" --limit 8 --json)"
+assert_eq "$C.text_image_state" "ready" "$(echo "$ti" | jq -r '.state')" "text×image search ready"
+ti_has_img="$(echo "$ti" | jq --arg r "$IMG_B_MEMBER" '[.payload.matches[:4][].ref] | index($r) != null')"
+assert_eq "$C.text_image_member" "true" "$ti_has_img" "image member is in the top text×image matches"
+save_json "clip_db_text_image" "$ti" >/dev/null
+
+# --- headless agent leg ---------------------------------------------------------
+cond "the headless agent (--mode json) runs a similar search and persists the record"
+if have_cred CLOUDGLUE_API_KEY; then
+  prompt="Use the overcast similar tool for this case: run similar search \"$QUERY_A\" --index $CLIP_INDEX --limit 3. Reply with JSON only, shaped like {\"index\":\"$CLIP_INDEX\",\"top_ref\":\"...\"}. Do not create notes."
+  hout="$(OC_TIMEOUT=420 oc "$CASE" --mode json "$prompt")"
+  invalid=0; nlines=0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    nlines=$((nlines + 1))
+    printf '%s' "$line" | jq -e . >/dev/null 2>&1 || invalid=$((invalid + 1))
+  done <<<"$hout"
+  assert_eq "$C.headless_json" "0" "$invalid" "headless stream is valid JSONL ($nlines line(s))"
+  if printf '%s' "$hout" | grep -q "$CLIP_INDEX"; then
+    ok "$C.headless_index" "agent stream references the CLIP index"
+  else
+    fail "$C.headless_index" "agent stream did not reference $CLIP_INDEX"
+  fi
+  sim_recs="$(ocrun "$CASE" case records --verb similar --json 2>/dev/null | jq -r '.payload.count // 0')"
+  [ "${sim_recs:-0}" -ge 5 ] && ok "$C.headless_record" "case holds $sim_recs similar records (agent run persisted)" || fail "$C.headless_record" "expected the agent's similar record to persist (count=$sim_recs)"
+else
+  skip "$C.headless" "no CLOUDGLUE_API_KEY — headless agent needs a brain LLM"
+fi
+
+# --- HTML evidence page ---------------------------------------------------------
+EVIDENCE="$SMOKE_DIR/clip_db_evidence.html"
+b64() { base64 <"$1" | tr -d '\n'; }
+thumb_for() { # <ref> <at> <out.jpg> — video ref -> frame at `at`; image ref -> as-is
+  local ref="$1" at="$2" out="$3"
+  case "$ref" in
+    *.jpg|*.jpeg|*.png|*.webp) cp "$ref" "$out" 2>/dev/null ;;
+    *) "$FFMPEG" -y -ss "${at:-0}" -i "$ref" -frames:v 1 -vf "scale=320:-2" -q:v 3 "$out" >/dev/null 2>&1 ;;
+  esac
+  [ -f "$out" ]
+}
+SECTION_N=0
+section() { # <title> <query-html> <matches-json>
+  local title="$1" qhtml="$2" json="$3" i=0
+  SECTION_N=$((SECTION_N + 1))
+  {
+    printf '<section><h2>%s</h2><div class="row"><div class="q">%s</div><div class="arrow">→</div>' "$title" "$qhtml"
+    while IFS=$'\t' read -r ref sim at; do
+      [ -z "$ref" ] && continue
+      i=$((i + 1)); [ "$i" -gt 4 ] && break
+      # tmp name must NOT embed the title — caption-derived titles can contain '/'
+      local t="$SMOKE_DIR/.thumb_$$_${SECTION_N}_$i.jpg"
+      if thumb_for "$ref" "$at" "$t"; then
+        printf '<figure><img src="data:image/jpeg;base64,%s"/><figcaption><b>%s</b> %s%s</figcaption></figure>' \
+          "$(b64 "$t")" "$sim" "$(basename "$ref")" "${at:+ @${at}s}"
+        rm -f "$t"
+      fi
+    done < <(echo "$json" | jq -r '.payload.matches[] | [.ref, .similarity, (.at // "")] | @tsv')
+    printf '</div></section>\n'
+  } >>"$EVIDENCE"
+}
+{
+  printf '<!doctype html><meta charset="utf-8"><title>basic-clip live e2e evidence</title><style>body{font:14px -apple-system,sans-serif;margin:24px;background:#0e1116;color:#e6e6e6}h1{font-size:20px}h2{font-size:15px;margin:18px 0 6px}section{border-bottom:1px solid #333;padding:10px 0}.row{display:flex;gap:12px;align-items:flex-start;flex-wrap:wrap}.q{max-width:340px}.q img{max-width:320px;border-radius:6px}.q .text{background:#1b2330;padding:12px;border-radius:6px;font-style:italic}.arrow{font-size:28px;align-self:center;color:#7aa2f7}figure{margin:0;text-align:center}figure img{width:180px;border-radius:6px}figcaption{font-size:11px;color:#aaa;margin-top:2px}figcaption b{color:#9ece6a}</style>\n'
+  printf '<h1>basic-clip (`similar`) — live e2e evidence · %s</h1>\n' "$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+  printf '<p>Local OpenAI CLIP cross-modal search over real media. Scores are cosine×100. Queries on the left; top matches (with frame moments for videos) on the right.</p>\n'
+} >"$EVIDENCE"
+section "1. text × video — search: &ldquo;${QUERY_A}&rdquo;" "<div class=\"text\">&ldquo;${QUERY_A}&rdquo;</div>" "$tv"
+section "2. image × video — match: $(basename "$IMG_A_QUERY")" "<img src=\"data:image/jpeg;base64,$(b64 "$IMG_A_QUERY")\"/>" "$iv"
+section "3. image × image — match: $(basename "$IMG_B_QUERY")" "<img src=\"data:image/jpeg;base64,$(b64 "$IMG_B_QUERY")\"/>" "$ii"
+section "4. text × image — search: &ldquo;${QUERY_B}&rdquo;" "<div class=\"text\">&ldquo;${QUERY_B}&rdquo;</div>" "$ti"
+if [ -s "$EVIDENCE" ]; then ok "$C.evidence_html" "evidence page written: $EVIDENCE"; else fail "$C.evidence_html" "evidence page not written"; fi
+
+# the cache should hold real embedding vectors on disk
 if ls "$CASE/.overcast/index/$CLIP_INDEX/emb/"*.npy >/dev/null 2>&1; then
   ok "$C.cache" "embedding cache materialized under the index dir"
 else

--- a/test/e2e/live/cases/17_clip_db.sh
+++ b/test/e2e/live/cases/17_clip_db.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Real basic-clip (local CLIP) DB checks: create a local basic-clip index, embed
+# an image + a video via `similar add`, then query by text (`search`) and image
+# (`match`). Uses paths from .env and skips cleanly when open_clip is absent.
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib.sh
+source "$LIVE/lib.sh"
+C=clip_db
+
+have_media "$CLIP_IMAGE_REF" || { skip "$C.clip" "no OC_CLIP_IMAGE_REF"; exit 0; }
+
+PY="${OC_VISUAL_DB_PY:-${OVERCAST_VISUAL_DB_PY:-python3}}"
+if ! "$PY" - <<'PY' >/dev/null 2>&1
+import open_clip, torch, PIL, numpy
+PY
+then
+  skip "$C.clip_deps" "basic-clip deps missing in $PY (run scripts/visual-db-uv.sh --clip)"
+  exit 0
+fi
+
+CASE=$(case_dir clip_db)
+
+cond "index create --type basic-clip --local makes a CLIP DB and similar add embeds a reference image"
+created="$(oc "$CASE" index create scenes --type basic-clip --local --granularity frame --json)"; rc=$?
+assert_eq "$C.create_exit" "0" "$rc" "local basic-clip index create exits 0"
+CLIP_INDEX="$(echo "$created" | jq -r '.payload.index // empty')"
+assert_nonempty "$C.index_id" "$CLIP_INDEX" "local basic-clip index id returned"
+assert_eq "$C.create_config" "frame" "$(echo "$created" | jq -r '.payload.config.granularity // empty')" "config.json granularity persisted"
+
+add_img="$(OC_TIMEOUT=420 oc "$CASE" similar add "$CLIP_IMAGE_REF" --index "$CLIP_INDEX" --json)"
+assert_eq "$C.add_image_state" "ready" "$(echo "$add_img" | jq -r '.state')" "reference image embedded into the CLIP DB"
+
+if have_media "$CLIP_VIDEO"; then
+  add_vid="$(OC_TIMEOUT=600 oc "$CASE" similar add "$CLIP_VIDEO" --index "$CLIP_INDEX" --json)"
+  assert_eq "$C.add_video_state" "ready" "$(echo "$add_vid" | jq -r '.state')" "video embedded (frame-sampled) into the CLIP DB"
+  save_json "clip_db_add_video" "$add_vid" >/dev/null
+else
+  skip "$C.add_video" "no OC_CLIP_VIDEO"
+fi
+
+cond "similar search ranks members by text->image similarity"
+search="$(OC_TIMEOUT=420 oc "$CASE" similar search "$CLIP_TEXT" --index "$CLIP_INDEX" --limit 5 --json)"
+assert_eq "$C.search_state" "ready" "$(echo "$search" | jq -r '.state')" "text search state ready"
+assert_eq "$C.search_query" "$CLIP_TEXT" "$(echo "$search" | jq -r '.payload.query // empty')" "text query echoed on the record"
+search_count="$(echo "$search" | jq -r '.payload.count // 0')"
+if [ "$search_count" -gt 0 ]; then
+  ok "$C.search_count" "found $search_count semantic match(es) for \"$CLIP_TEXT\""
+else
+  fail "$C.search_count" "expected at least one semantic match for \"$CLIP_TEXT\", got 0"
+fi
+save_json "clip_db_search" "$search" >/dev/null
+
+cond "similar match ranks members by image->image similarity"
+match="$(OC_TIMEOUT=420 oc "$CASE" similar match "$CLIP_IMAGE_REF" --index "$CLIP_INDEX" --json)"
+assert_eq "$C.match_state" "ready" "$(echo "$match" | jq -r '.state')" "image match state ready"
+match_count="$(echo "$match" | jq -r '.payload.count // 0')"
+if [ "$match_count" -gt 0 ]; then
+  ok "$C.match_count" "found $match_count visual match(es) (the reference itself should rank top)"
+else
+  fail "$C.match_count" "expected at least one visual match (the embedded reference), got 0"
+fi
+save_json "clip_db_match" "$match" >/dev/null
+
+# the cache should now hold at least one embedding vector on disk
+if ls "$CASE/.overcast/index/$CLIP_INDEX/emb/"*.npy >/dev/null 2>&1; then
+  ok "$C.cache" "embedding cache materialized under the index dir"
+else
+  fail "$C.cache" "expected cached .npy embeddings under .overcast/index/$CLIP_INDEX/emb/"
+fi

--- a/test/e2e/live/lib.sh
+++ b/test/e2e/live/lib.sh
@@ -51,6 +51,12 @@ LOCAL_IMAGE_REF="${OC_LOCAL_IMAGE_REF:-}"       # local image DB: reference logo
 LOCAL_IMAGE_VIDEO_A="${OC_LOCAL_IMAGE_VIDEO_A:-}" # local image DB: candidate video A
 # shellcheck disable=SC2034
 LOCAL_IMAGE_VIDEO_B="${OC_LOCAL_IMAGE_VIDEO_B:-}" # local image DB: candidate video B
+# shellcheck disable=SC2034
+CLIP_IMAGE_REF="${OC_CLIP_IMAGE_REF:-}"          # basic-clip DB: image to embed + image-query
+# shellcheck disable=SC2034
+CLIP_VIDEO="${OC_CLIP_VIDEO:-}"                  # basic-clip DB: video to embed (frames)
+# shellcheck disable=SC2034
+CLIP_TEXT="${OC_CLIP_TEXT:-a person}"            # basic-clip DB: text query for `similar search`
 
 have_media() { [ -f "$1" ]; }
 

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -1,0 +1,201 @@
+// basic-clip (local CLIP DB) + `similar` verb coverage. The uv-managed Python is
+// faked (a bash stub echoing a `similar` record) so the TS verb/arg-mapping,
+// config.json plumbing, and case-setup wizard run offline with NO torch.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { openCase } from "../../src/case.ts";
+import { defaultProfile } from "../../src/profile.ts";
+import { normalizeIndexType, findIndex, addMember, listIndexes } from "../../src/state/index.ts";
+import { indexVerb } from "../../src/verbs/index.ts";
+import { similarVerb } from "../../src/verbs/similar.ts";
+import { caseVerb } from "../../src/verbs/case.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+// A fake OC_VISUAL_DB_PY that echoes back the resolved op + config flags so the
+// test can assert what the verb forwarded (index config ⊕ CLI flags).
+const STUB = `#!/usr/bin/env bash
+op=""; gran=""; pool=""; samp=""; win=""; framesat="no"; input=""
+for ((i=1; i<=$#; i++)); do
+  arg="\${!i}"
+  case "$arg" in
+    --op) j=$((i+1)); op="\${!j}";;
+    --granularity) j=$((i+1)); gran="\${!j}";;
+    --pooling) j=$((i+1)); pool="\${!j}";;
+    --sampling) j=$((i+1)); samp="\${!j}";;
+    --window) j=$((i+1)); win="\${!j}";;
+    --frames-at) framesat="yes";;
+  esac
+  input="$arg"
+done
+printf '{"verb":"similar","format":"json","payload":{"op":"%s","granularity":"%s","pooling":"%s","sampling":"%s","window":"%s","frames_at":"%s","query":"%s","matches":[],"count":0},"state":"ready","meta":{"provider":"fake-clip"}}\\n' "$op" "$gran" "$pool" "$samp" "$win" "$framesat" "$input"
+`;
+
+async function withStub(fn: (dir: string, stub: string) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "oc-clip-"));
+  const stub = join(dir, "fake-clip.sh");
+  writeFileSync(stub, STUB);
+  chmodSync(stub, 0o755);
+  const saved = process.env.OC_VISUAL_DB_PY;
+  process.env.OC_VISUAL_DB_PY = stub;
+  try {
+    await fn(dir, stub);
+  } finally {
+    if (saved === undefined) delete process.env.OC_VISUAL_DB_PY;
+    else process.env.OC_VISUAL_DB_PY = saved;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function mk(dir: string, input: string | undefined, rest: string[] = [], opts: VerbContext["opts"] = {}): VerbContext {
+  const c = openCase(dir);
+  c.ensure();
+  return { input, rest, opts, case: c, profile: defaultProfile() };
+}
+
+test("normalizeIndexType maps clip aliases to basic-clip", () => {
+  for (const a of ["basic-clip", "basic-clip-db", "clip", "clips", "semantic"]) {
+    assert.equal(normalizeIndexType(a), "basic-clip");
+  }
+});
+
+test("index create --type basic-clip --local writes config.json from flags", async () => {
+  await withStub(async (dir) => {
+      const [created] = await indexVerb.run(
+        mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, granularity: "frame", pooling: "mean", sampling: "uniform", window: 5 }),
+      );
+      assert.equal(created.state, "ready");
+      const id = String((created.payload as Record<string, unknown>).index);
+      assert.match(id, /^local_basic_clip_/);
+      assert.equal(findIndex(openCase(dir), id)?.type, "basic-clip");
+      const cfg = JSON.parse(readFileSync(join(dir, ".overcast", "index", id, "config.json"), "utf8"));
+      assert.equal(cfg.granularity, "frame");
+      assert.equal(cfg.pooling, "mean");
+      assert.equal(cfg.window, 5);
+  });
+});
+
+test("index create rejects an invalid basic-clip config value", async () => {
+  await withStub(async (dir) => {
+      const [rec] = await indexVerb.run(mk(dir, "create", ["x"], { type: "basic-clip", local: true, granularity: "bogus" }));
+      assert.equal(rec.state, "error");
+      assert.match(rec.error ?? "", /granularity must be one of/);
+  });
+});
+
+test("similar add embeds via the local provider and registers the member", async () => {
+  await withStub(async (dir) => {
+      const img = join(dir, "photo.jpg");
+      writeFileSync(img, "x");
+      const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, granularity: "frame" }));
+      const id = String((created.payload as Record<string, unknown>).index);
+
+      const [added] = await similarVerb.run(mk(dir, "add", [img], { index: id }));
+      assert.equal(added.state, "ready");
+      const p = added.payload as Record<string, unknown>;
+      assert.equal(p.op, "add");
+      assert.equal(p.granularity, "frame"); // index config.json flowed through
+      assert.equal(findIndex(openCase(dir), id)?.members.length, 1);
+  });
+});
+
+test("similar search forwards the text query as the positional input", async () => {
+  await withStub(async (dir) => {
+      const img = join(dir, "photo.jpg");
+      writeFileSync(img, "x");
+      const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true }));
+      const id = String((created.payload as Record<string, unknown>).index);
+      addMember(openCase(dir), id, { ref: img });
+
+      const [rec] = await similarVerb.run(mk(dir, "search", ["a", "red", "car"], { index: id }));
+      assert.equal(rec.state, "ready");
+      const p = rec.payload as Record<string, unknown>;
+      assert.equal(p.op, "search");
+      assert.equal(p.query, "a red car"); // joined + passed as the last positional
+  });
+});
+
+test("similar match rejects an out-of-range --min-similarity", async () => {
+  await withStub(async (dir) => {
+      const img = join(dir, "q.jpg");
+      writeFileSync(img, "x");
+      const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true }));
+      const id = String((created.payload as Record<string, unknown>).index);
+      const [rec] = await similarVerb.run(mk(dir, "match", [img], { index: id, "min-similarity": 150 }));
+      assert.equal(rec.state, "error");
+      assert.match(rec.error ?? "", /min-similarity/);
+  });
+});
+
+test("similar rejects a non-basic-clip index", async () => {
+  await withStub(async (dir) => {
+      const c = openCase(dir);
+      c.ensure();
+      const [created] = await indexVerb.run(mk(dir, "create", ["logos"], { type: "image-ransac", local: true }));
+      const id = String((created.payload as Record<string, unknown>).index);
+      const img = join(dir, "q.jpg");
+      writeFileSync(img, "x");
+      const [rec] = await similarVerb.run(mk(dir, "match", [img], { index: id }));
+      assert.equal(rec.state, "error");
+      assert.match(rec.error ?? "", /not basic-clip/);
+  });
+});
+
+test("index add --to a basic-clip index points at `similar add`", async () => {
+  await withStub(async (dir) => {
+      const img = join(dir, "photo.jpg");
+      writeFileSync(img, "x");
+      const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true }));
+      const id = String((created.payload as Record<string, unknown>).index);
+      const [rec] = await indexVerb.run(mk(dir, "add", [img], { to: id }));
+      assert.equal(rec.state, "error");
+      assert.match(rec.error ?? "", /similar add/);
+  });
+});
+
+test("index remove from a basic-clip index accepts a video member", async () => {
+  await withStub(async (dir) => {
+      const video = join(dir, "clip.mp4");
+      writeFileSync(video, "x");
+      const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true }));
+      const id = String((created.payload as Record<string, unknown>).index);
+      addMember(openCase(dir), id, { ref: video });
+      const [rec] = await indexVerb.run(mk(dir, "remove", [video], { from: id }));
+      assert.equal(rec.state, "ready");
+      assert.equal((rec.payload as Record<string, unknown>).removed, true);
+      assert.equal(findIndex(openCase(dir), id)?.members.length, 0);
+  });
+});
+
+test("case setup --index stands up two basic-clip indexes with distinct configs", async () => {
+  await withStub(async (dir) => {
+      const c = openCase(dir);
+      c.ensure();
+      const [rec] = await caseVerb.run({
+        input: "setup",
+        rest: [],
+        opts: {
+          yes: true,
+          index: "moments:basic-clip@granularity=frame;window=5,another:basic-clip@granularity=video;pooling=mean",
+        },
+        case: c,
+        profile: defaultProfile(),
+        home: dir,
+        profileName: "default",
+      });
+      assert.notEqual(rec.state, "error");
+      const clip = listIndexes(openCase(dir)).filter((i) => i.type === "basic-clip");
+      assert.equal(clip.length, 2, "two basic-clip indexes created");
+      const byName = Object.fromEntries(clip.map((i) => [i.name, i.id]));
+      const cfgOf = (id: string) => JSON.parse(readFileSync(join(dir, ".overcast", "index", id, "config.json"), "utf8"));
+      assert.equal(cfgOf(byName["moments"]).granularity, "frame");
+      assert.equal(cfgOf(byName["moments"]).window, 5);
+      assert.equal(cfgOf(byName["another"]).granularity, "video");
+      assert.equal(cfgOf(byName["another"]).pooling, "mean");
+      assert.ok(existsSync(join(dir, ".overcast", "index", byName["another"], "config.json")));
+  });
+});

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -400,6 +400,59 @@ test("clip_match.py queries never re-key or persist member embeddings (#B4-1)", 
   assert.match(src, /if persist:\n\s+npy\.parent\.mkdir/);
 });
 
+test("similar add rejects per-add config overrides (#B5-1)", async () => {
+  await withStub(async (dir) => {
+    const img = join(dir, "photo.jpg");
+    writeFileSync(img, "x");
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    const [rec] = await similarVerb.run(mk(dir, "add", [img], { index: id, granularity: "frame" }));
+    assert.equal(rec.state, "error");
+    assert.match(rec.error ?? "", /doesn't apply per-add.*index create/);
+    assert.equal(findIndex(openCase(dir), id)?.members.length, 0);
+  });
+});
+
+test("clip_match.py add embeds with the persisted index config, like queries (#B5-1)", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
+  // add and query must key the member cache identically, or add persists a
+  // config_hash searches never reuse.
+  assert.match(src, /build_member\(ref, member_args, args\.index_dir, frames_at=frames_at\)/);
+});
+
+test("clip_match.py stops reusing shot markers once the config says uniform (#B5-2)", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
+  assert.match(src, /frames_at is None and args\.sampling == "shots"/);
+});
+
+test("case setup 'index add' signal also embeds into basic-clip routes (#B5-3)", async () => {
+  await withStub(async (dir) => {
+    const video = join(dir, "clip.mp4");
+    writeFileSync(video, "x");
+    const c = openCase(dir);
+    c.ensure();
+    // a watch record pre-exists so no watch provider is needed for the route
+    const recs = await caseVerb.run({
+      input: "setup",
+      rest: [],
+      opts: { yes: true, index: "scenes:basic-clip", video, signals: "index add" },
+      case: c,
+      profile: defaultProfile(),
+      home: dir,
+      profileName: "default",
+    });
+    const setupRec = recs.find((r) => {
+      const p = r.payload as Record<string, unknown> | undefined;
+      return p && typeof p === "object" && Array.isArray(p.applied_operations);
+    });
+    assert.ok(setupRec, "setup record with applied_operations");
+    const ops = (setupRec!.payload as Record<string, unknown>).applied_operations as string[];
+    assert.ok(ops.some((o) => o.startsWith("indexing started") && o.includes(video)), `expected an embed op in ${JSON.stringify(ops)}`);
+    const clipIndex = listIndexes(openCase(dir)).find((i) => i.type === "basic-clip");
+    assert.equal(clipIndex?.members.length, 1, "the routed video was embedded and registered");
+  });
+});
+
 test("clip_match.py does not anchor the query record on a matched member's timestamp (#B3-2)", () => {
   const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
   // a member's `at` lives in payload.matches[]; media anchors the QUERY only.

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -6,15 +6,19 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { openCase } from "../../src/case.ts";
-import { defaultProfile } from "../../src/profile.ts";
+import { defaultProfile, type Profile } from "../../src/profile.ts";
+import { makeRecord } from "../../src/record.ts";
 import { normalizeIndexType, findIndex, addMember, listIndexes } from "../../src/state/index.ts";
 import { indexVerb } from "../../src/verbs/index.ts";
 import { similarVerb } from "../../src/verbs/similar.ts";
 import { caseVerb } from "../../src/verbs/case.ts";
 import type { VerbContext } from "../../src/registry/types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 // A fake OC_VISUAL_DB_PY that echoes back the resolved op + config flags so the
 // test can assert what the verb forwarded (index config ⊕ CLI flags).
@@ -51,10 +55,10 @@ async function withStub(fn: (dir: string, stub: string) => Promise<void>): Promi
   }
 }
 
-function mk(dir: string, input: string | undefined, rest: string[] = [], opts: VerbContext["opts"] = {}): VerbContext {
+function mk(dir: string, input: string | undefined, rest: string[] = [], opts: VerbContext["opts"] = {}, profile?: Profile): VerbContext {
   const c = openCase(dir);
   c.ensure();
-  return { input, rest, opts, case: c, profile: defaultProfile() };
+  return { input, rest, opts, case: c, profile: profile ?? defaultProfile() };
 }
 
 test("normalizeIndexType maps clip aliases to basic-clip", () => {
@@ -198,4 +202,127 @@ test("case setup --index stands up two basic-clip indexes with distinct configs"
       assert.equal(cfgOf(byName["another"]).pooling, "mean");
       assert.ok(existsSync(join(dir, ".overcast", "index", byName["another"], "config.json")));
   });
+});
+
+// ---- Bugbot round-1 regressions ---------------------------------------------
+
+test("similar search forwards the full sampling config (cache-key parity with add) (#B1-1)", async () => {
+  await withStub(async (dir) => {
+    const img = join(dir, "photo.jpg");
+    writeFileSync(img, "x");
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, sampling: "uniform", window: 7, pooling: "mean" }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    addMember(openCase(dir), id, { ref: img });
+
+    const [rec] = await similarVerb.run(mk(dir, "search", ["red", "car"], { index: id }));
+    assert.equal(rec.state, "ready");
+    const p = rec.payload as Record<string, unknown>;
+    // the stub echoes the flags it received — search must carry the same config
+    // add uses, or a query-time cache miss re-embeds members with defaults.
+    assert.equal(p.sampling, "uniform");
+    assert.equal(p.window, "7");
+    assert.equal(p.pooling, "mean");
+  });
+});
+
+test("similar add does NOT register the member when the embed fails (#B1-3)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-clip-fail-"));
+  const bad = join(dir, "fail-clip.sh");
+  writeFileSync(bad, `#!/usr/bin/env bash
+printf '{"verb":"similar","format":"json","payload":{"op":"add","matches":[],"count":0},"error":"basic-clip deps missing","state":"error"}\\n'
+`);
+  chmodSync(bad, 0o755);
+  const saved = process.env.OC_VISUAL_DB_PY;
+  process.env.OC_VISUAL_DB_PY = bad;
+  try {
+    const img = join(dir, "photo.jpg");
+    writeFileSync(img, "x");
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    const [rec] = await similarVerb.run(mk(dir, "add", [img], { index: id }));
+    assert.equal(rec.state, "error");
+    assert.equal(findIndex(openCase(dir), id)?.members.length, 0, "failed embed must not leave a vectorless member");
+  } finally {
+    if (saved === undefined) delete process.env.OC_VISUAL_DB_PY;
+    else process.env.OC_VISUAL_DB_PY = saved;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("similar add with sampling=shots persists the fresh watch record (#B1-4)", async () => {
+  await withStub(async (dir) => {
+    const video = join(dir, "clip.mp4");
+    writeFileSync(video, "x");
+    const fakeWatch = join(dir, "fake-watch.sh");
+    writeFileSync(fakeWatch, `#!/usr/bin/env bash
+printf '{"verb":"watch","format":"json","payload":{"content":"x","transcript":"","detailed":{"segments":[{"start_seconds":0},{"start_seconds":12.5}]}},"state":"ready"}\\n'
+`);
+    chmodSync(fakeWatch, 0o755);
+    const profile = defaultProfile();
+    profile.providers = { ...profile.providers, watch: { type: "exec", run: `bash ${fakeWatch} {{input}}` } };
+
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, sampling: "shots" }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }, profile));
+    assert.equal(recs.length, 2, "similar record + the fresh watch record");
+    assert.equal(recs[0].verb, "similar");
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "yes", "shot markers forwarded to the embedder");
+    assert.equal(recs[1].verb, "watch");
+    assert.equal(recs[1].media?.ref, video);
+    assert.equal(recs[1].meta?.triggered_by, "similar");
+  });
+});
+
+test("similar add with sampling=shots reuses ready watch evidence (no re-watch) (#B1-4)", async () => {
+  await withStub(async (dir) => {
+    const video = join(dir, "clip.mp4");
+    writeFileSync(video, "x");
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({
+      verb: "watch",
+      format: "json",
+      payload: { content: "x", detailed: { segments: [{ start_seconds: 3 }, { start_seconds: 9 }] } },
+      media: { ref: video },
+      state: "ready",
+    }));
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, sampling: "shots" }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    // no watch provider bound: a re-invocation would fail loudly, so a ready
+    // result with frames_at=yes proves the existing record was reused.
+    const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }));
+    assert.equal(recs.length, 1, "no duplicate watch record");
+    assert.equal(recs[0].state, "ready");
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "yes");
+  });
+});
+
+test("similar add with sampling=shots does not re-watch while evidence is pending (#B1-4)", async () => {
+  await withStub(async (dir) => {
+    const video = join(dir, "clip.mp4");
+    writeFileSync(video, "x");
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({
+      verb: "watch",
+      format: "json",
+      payload: { content: "" },
+      media: { ref: video },
+      state: "pending",
+    }));
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, sampling: "shots" }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }));
+    assert.equal(recs.length, 1, "pending watch evidence must suppress a new (double-billed) watch");
+    assert.equal(recs[0].state, "ready");
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "no", "uniform fallback while shots are pending");
+  });
+});
+
+test("clip_match.py persists + reuses shot markers across cache rebuilds (#B1-2)", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
+  // the sidecar must record the markers a member was embedded with…
+  assert.match(src, /"frames_at":\s*frames_at/);
+  // …and a stale query-time rebuild must reuse them instead of a uniform grid.
+  assert.match(src, /meta\.get\("frames_at"\)/);
 });

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -389,6 +389,17 @@ test("visual-db scripts recognize every video extension the TS intake gate accep
   }
 });
 
+test("clip_match.py queries never re-key or persist member embeddings (#B4-1)", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
+  // member-side rebuilds during a query must use the PERSISTED index config
+  // (config.json), not the per-query CLI flags…
+  assert.match(src, /member_args = index_config_args\(args\)/);
+  assert.match(src, /build_member\(mem\["ref"\], member_args, args\.index_dir, persist=False\)/);
+  // …and a query-time rebuild must stay in memory — reads never write the cache.
+  assert.match(src, /def build_member\(ref, args, index_dir, frames_at=None, persist=True\)/);
+  assert.match(src, /if persist:\n\s+npy\.parent\.mkdir/);
+});
+
 test("clip_match.py does not anchor the query record on a matched member's timestamp (#B3-2)", () => {
   const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
   // a member's `at` lives in payload.matches[]; media anchors the QUERY only.

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -23,7 +23,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // A fake OC_VISUAL_DB_PY that echoes back the resolved op + config flags so the
 // test can assert what the verb forwarded (index config ⊕ CLI flags).
 const STUB = `#!/usr/bin/env bash
-op=""; gran=""; pool=""; samp=""; win=""; framesat="no"; input=""
+op=""; gran=""; pool=""; samp=""; win=""; framesat=""; input=""
 for ((i=1; i<=$#; i++)); do
   arg="\${!i}"
   case "$arg" in
@@ -32,7 +32,7 @@ for ((i=1; i<=$#; i++)); do
     --pooling) j=$((i+1)); pool="\${!j}";;
     --sampling) j=$((i+1)); samp="\${!j}";;
     --window) j=$((i+1)); win="\${!j}";;
-    --frames-at) framesat="yes";;
+    --frames-at) j=$((i+1)); framesat="\${!j}";;
   esac
   input="$arg"
 done
@@ -266,7 +266,7 @@ printf '{"verb":"watch","format":"json","payload":{"content":"x","transcript":""
     const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }, profile));
     assert.equal(recs.length, 2, "similar record + the fresh watch record");
     assert.equal(recs[0].verb, "similar");
-    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "yes", "shot markers forwarded to the embedder");
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "0,12.5", "shot markers forwarded to the embedder");
     assert.equal(recs[1].verb, "watch");
     assert.equal(recs[1].media?.ref, video);
     assert.equal(recs[1].meta?.triggered_by, "similar");
@@ -289,11 +289,11 @@ test("similar add with sampling=shots reuses ready watch evidence (no re-watch) 
     const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, sampling: "shots" }));
     const id = String((created.payload as Record<string, unknown>).index);
     // no watch provider bound: a re-invocation would fail loudly, so a ready
-    // result with frames_at=yes proves the existing record was reused.
+    // result carrying the record's markers proves the existing record was reused.
     const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }));
     assert.equal(recs.length, 1, "no duplicate watch record");
     assert.equal(recs[0].state, "ready");
-    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "yes");
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "3,9");
   });
 });
 
@@ -315,8 +315,65 @@ test("similar add with sampling=shots does not re-watch while evidence is pendin
     const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }));
     assert.equal(recs.length, 1, "pending watch evidence must suppress a new (double-billed) watch");
     assert.equal(recs[0].state, "ready");
-    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "no", "uniform fallback while shots are pending");
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "", "uniform fallback while shots are pending");
   });
+});
+
+test("shots reuse prefers the NEWEST ready watch with segments (#B2-2)", async () => {
+  await withStub(async (dir) => {
+    const video = join(dir, "clip.mp4");
+    writeFileSync(video, "x");
+    const c = openCase(dir);
+    c.ensure();
+    // older watch has stale segments; a later re-watch produced better ones.
+    c.writeRecord(makeRecord({
+      verb: "watch", format: "json",
+      payload: { content: "x", detailed: { segments: [{ start_seconds: 3 }, { start_seconds: 9 }] } },
+      media: { ref: video }, state: "ready",
+    }));
+    c.writeRecord(makeRecord({
+      verb: "watch", format: "json",
+      payload: { content: "x", detailed: { segments: [{ start_seconds: 5 }, { start_seconds: 20 }] } },
+      media: { ref: video }, state: "ready",
+    }));
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, sampling: "shots" }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }));
+    assert.equal(recs.length, 1);
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "5,20", "the newest ready watch's segments win");
+  });
+});
+
+test("shots reuse skips a segmentless ready watch in favor of one with segments (#B2-2)", async () => {
+  await withStub(async (dir) => {
+    const video = join(dir, "clip.mp4");
+    writeFileSync(video, "x");
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({
+      verb: "watch", format: "json",
+      payload: { content: "x", detailed: { segments: [{ start_seconds: 3 }, { start_seconds: 9 }] } },
+      media: { ref: video }, state: "ready",
+    }));
+    // a later speech-only watch with no segments must not mask the earlier one
+    c.writeRecord(makeRecord({
+      verb: "watch", format: "json",
+      payload: { content: "x", transcript: "hi", detailed: {} },
+      media: { ref: video }, state: "ready",
+    }));
+    const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true, sampling: "shots" }));
+    const id = String((created.payload as Record<string, unknown>).index);
+    const recs = await similarVerb.run(mk(dir, "add", [video], { index: id }));
+    assert.equal(recs.length, 1);
+    assert.equal((recs[0].payload as Record<string, unknown>).frames_at, "3,9");
+  });
+});
+
+test("clip_match.py invalidates a cached member when explicit frames_at changed (#B2-1)", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
+  // frames_at is not part of config_hash, so the freshness check must compare
+  // an explicit marker list against the sidecar's recorded markers.
+  assert.match(src, /frames_at is not None and meta\.get\("frames_at"\) != frames_at/);
 });
 
 test("clip_match.py persists + reuses shot markers across cache rebuilds (#B1-2)", () => {

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -376,6 +376,71 @@ test("clip_match.py invalidates a cached member when explicit frames_at changed 
   assert.match(src, /frames_at is not None and meta\.get\("frames_at"\) != frames_at/);
 });
 
+test("visual-db scripts recognize every video extension the TS intake gate accepts (#B3-1)", () => {
+  // media-ref.ts AV_RE's video subset — a clip the verb accepts as video must not
+  // be misrouted to a script's image path because its VIDEO_EXTS tuple is narrower.
+  const avVideoExts = ["mp4", "m4v", "mov", "webm", "mkv", "avi", "mpeg", "mpg", "m2ts", "mts", "ts", "wmv", "flv", "3gp", "3g2", "ogv", "mxf"];
+  for (const script of ["clip_match.py", "image_match.py", "face_match.py"]) {
+    const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", script), "utf8");
+    const tuple = src.match(/VIDEO_EXTS = \(([^)]*)\)/)?.[1] ?? "";
+    for (const ext of avVideoExts) {
+      assert.ok(tuple.includes(`".${ext}"`), `${script} VIDEO_EXTS is missing .${ext}`);
+    }
+  }
+});
+
+test("clip_match.py does not anchor the query record on a matched member's timestamp (#B3-2)", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
+  // a member's `at` lives in payload.matches[]; media anchors the QUERY only.
+  assert.doesNotMatch(src, /media\["at"\]\s*=\s*results/);
+});
+
+test("case setup labels a failed basic-clip embed 'attempted' even when shots watch succeeds (#B3-3)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-clip-setuplabel-"));
+  const bad = join(dir, "fail-clip.sh");
+  writeFileSync(bad, `#!/usr/bin/env bash
+printf '{"verb":"similar","format":"json","payload":{"op":"add","matches":[],"count":0},"error":"basic-clip deps missing","state":"error"}\\n'
+`);
+  chmodSync(bad, 0o755);
+  const fakeWatch = join(dir, "fake-watch.sh");
+  writeFileSync(fakeWatch, `#!/usr/bin/env bash
+printf '{"verb":"watch","format":"json","payload":{"content":"x","detailed":{"segments":[{"start_seconds":0}]}},"state":"ready"}\\n'
+`);
+  chmodSync(fakeWatch, 0o755);
+  const saved = process.env.OC_VISUAL_DB_PY;
+  process.env.OC_VISUAL_DB_PY = bad;
+  try {
+    const video = join(dir, "clip.mp4");
+    writeFileSync(video, "x");
+    const c = openCase(dir);
+    c.ensure();
+    const profile = defaultProfile();
+    profile.providers = { ...profile.providers, watch: { type: "exec", run: `bash ${fakeWatch} {{input}}` } };
+    const recs = await caseVerb.run({
+      input: "setup",
+      rest: [],
+      opts: { yes: true, index: "scenes:basic-clip@sampling=shots", video, signals: "similar add" },
+      case: c,
+      profile,
+      home: dir,
+      profileName: "default",
+    });
+    const setupRec = recs.find((r) => {
+      const p = r.payload as Record<string, unknown> | undefined;
+      return p && typeof p === "object" && Array.isArray(p.applied_operations);
+    });
+    assert.ok(setupRec, "setup record with applied_operations");
+    const ops = (setupRec!.payload as Record<string, unknown>).applied_operations as string[];
+    const indexing = ops.filter((o) => o.includes(video));
+    assert.ok(indexing.some((o) => o.startsWith("indexing attempted")), `expected 'indexing attempted' in ${JSON.stringify(indexing)}`);
+    assert.ok(!indexing.some((o) => o.startsWith("indexing started")), "a ready auxiliary watch record must not mask the failed embed");
+  } finally {
+    if (saved === undefined) delete process.env.OC_VISUAL_DB_PY;
+    else process.env.OC_VISUAL_DB_PY = saved;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("clip_match.py persists + reuses shot markers across cache rebuilds (#B1-2)", () => {
   const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
   // the sidecar must record the markers a member was embedded with…

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -453,6 +453,25 @@ test("case setup 'index add' signal also embeds into basic-clip routes (#B5-3)",
   });
 });
 
+test("case status counts similar records as evidence (#B6-1)", async () => {
+  await withStub(async (dir) => {
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({
+      verb: "similar",
+      format: "json",
+      payload: { op: "search", summary: "2 semantic matches", query: "a red car", matches: [], count: 2 },
+      media: { ref: "a red car" },
+      state: "ready",
+    }));
+    const [status] = await caseVerb.run(mk(dir, "status"));
+    const tldr = (status.payload as Record<string, unknown>).tldr as Record<string, unknown>;
+    const findings = (tldr.findings as string[]).join("\n");
+    assert.match(findings, /Evidence present:.*similar 1/, "similar counted in the evidence summary");
+    assert.match(findings, /similar: 2 semantic matches/, "similar record surfaces in recent evidence");
+  });
+});
+
 test("clip_match.py does not anchor the query record on a matched member's timestamp (#B3-2)", () => {
   const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "visual-db", "clip_match.py"), "utf8");
   // a member's `at` lives in payload.matches[]; media anchors the QUERY only.


### PR DESCRIPTION
## What

Adds a third **local visual DB** type, **`basic-clip`**, backed by OpenAI CLIP (`open_clip`, ViT-B/32), alongside `image-ransac` and `deepface-local`. It gives an agent general **cross-modal semantic similarity** over case media — find images/video moments that resemble a photo (image→image) or a phrase (text→image) — queried through a new **`similar`** verb.

## Surface

- `similar add <image|video> --index <id>` — embed + cache a member (videos frame-sampled and pooled; per-frame with `--granularity frame` so matches carry `at`)
- `similar match <image|video> --index <id>` — image→image
- `similar search "<text>" --index <id>` — text→image

Scores are cosine×100 (0–100), consistent with `face`.

## Design

- **Precompute + cache on `add`** (CLIP model load is heavy): embeddings persist as `.npy` + JSON sidecar under `.overcast/index/<id>/emb/`, keyed by `(ref, mtime, config)` so the cache self-heals. Queries only embed the query and do a cosine top-K.
- **Per-index config** (`pooling` max/mean · `granularity` video/frame · `sampling` uniform/shots · `window`) written to `config.json` at create; query flags override.
- **Shots sampling** reuses an existing `watch` record's shot boundaries, or invokes the bound `watch` provider once (reuse-first avoids re-paying tinycloud); falls back to uniform when unavailable.
- Follows the existing local-DB machinery exactly (index registry + `.overcast/index/<id>/` store + uv-managed Python bridge). Model/weights overridable via `OC_CLIP_MODEL` / `OC_CLIP_PRETRAINED` / `OC_CLIP_DEVICE`.

## Case setup wizard

`basic-clip` is a selectable local DB in `case setup`, with an optional per-index config suffix (pairs separated by `;`, since `--index` is comma-separated). Stand up multiple indexes at once — e.g. a frame-level and a video-level index:

```
overcast case setup --index "moments:basic-clip@granularity=frame,clips:basic-clip@granularity=video" --yes
```

## Also

- `scripts/visual-db-uv.sh --clip` installs the CLIP stack (`open-clip-torch` + `torch` + `pillow`); `--all` installs face + CLIP.
- Provider catalog choice + preset (`provider setup` / `doctor` discoverability).
- Compact `similar` memory field policy (summary/query/matched refs only — never vectors).
- Docs: `CLAUDE.md`, `docs/providers.md`, `docs/flows.md`; regenerated skill reference.

## Testing

- `npm run typecheck` clean · `npm run build` clean · `npm test` **435 pass / 0 fail** (10 new offline tests via a fake provider stub, no torch) · `npm run test:e2e` **144/144** · `shellcheck -S warning` clean.
- New live e2e case `test/e2e/live/cases/17_clip_db.sh` (gates on `open_clip` + `.env` clips, skips cleanly otherwise).
- Python script verified: compiles, argparse works, dep-gap emits a clean error record. Real torch inference is only exercised by the live suite (not run in CI without the CLIP venv).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New verb and local embedding pipeline touch index lifecycle, case setup automation, and optional watch side-effects for shot sampling; core auth paths unchanged but incorrect cache/config handling could yield silent search skew.
> 
> **Overview**
> Introduces a third local visual DB type, **`basic-clip`**, and a new **`similar`** sense verb for **cross-modal semantic search** (text→image and image→image, including video moments) over case media via OpenAI CLIP (`open_clip`).
> 
> **`similar add`** embeds and caches members under `.overcast/index/<id>/emb/`; **`similar match`** / **`similar search`** rank by cosine similarity (0–100). Per-index **`config.json`** at `index create` controls pooling, frame vs video granularity, and uniform vs shot-based sampling; member embeddings always follow that config, while query-time flags only affect the query. Shot sampling reuses existing `watch` evidence or triggers one watch run and persists it as case evidence.
> 
> Wiring mirrors existing local visual DBs: `index create --type basic-clip --local`, provider catalog preset **`similar:basic-clip`**, `runLocalClip` + **`clip_match.py`**, `scripts/visual-db-uv.sh --clip` / `--all`, compact memory indexing for `similar` records, and **`case setup --index`** with optional `@k=v;k=v` suffixes for multiple CLIP indexes. **`index add`** on basic-clip indexes is redirected to **`similar add`**; removal clears cached embeddings.
> 
> Docs/skills/README/`.env.example` are updated; live e2e **`17_clip_db.sh`** and extensive offline tests (stubbed Python) cover the new paths. Visual DB Python scripts gain aligned **`VIDEO_EXTS`** (e.g. `.3gp`, `.mxf`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a832a7769060aaccf4bea314bf2530871ef0b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->