### PR TITLE
see: default to the brain LLM for image description (switchable)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
    a pi **package/extension**; net-new code is the verbs + providers + record store.
 2. **BYO LLM.** Never hardcode the brain provider. Keep the *brain provider*
    (pi-ai) and the *sense providers* (tinycloud / VLM / STT) separate everywhere.
+   *One deliberate, opt-out bridge:* `see` defaults to the **brain LLM** for image
+   description when it's image-capable (`src/providers/brain/vision.ts`) — it
+   resolves whatever brain the profile/env already points at (BYO, never a
+   hardcoded one) and is one switch away from the classic sense provider
+   (`setup provider see builtin:hf` / `OVERCAST_SEE_BRAIN=off`). Don't extend this
+   pattern to other verbs without the same "resolved-not-hardcoded + opt-out" bar.
 3. **The record is loose.** Output contract = `{ id, verb, format (json|md|txt),
    payload, media?{ref,at}, meta?, error?, state? }` and nothing more. Map provider
    output to the record at the exec boundary; never reintroduce a rigid envelope.
@@ -54,8 +60,10 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
    (`watch/listen/see/face/enhance`), **source** (`scan/capture/monitor`; youtube,
    tiktok, web), and **memory** (`ask/brief`; local-grep, optional qmd). Bindings live in the profile;
    transports are `exec` (default), `http`, `in-proc`. Default sense binding =
-   tinycloud (exec); `face:deepface-local` is the local DeepFace profile provider for
-   face detection/matching.
+   tinycloud (exec) — except `see`, whose default is the in-proc brain-vision
+   backend (invariant #2), falling back to the HF exec captioner;
+   `face:deepface-local` is the local DeepFace profile provider for face
+   detection/matching.
 7. **ffmpeg is internal**, not a pluggable provider — `enhance`, `crop`, `view`,
    and frame extraction shell out to the **system** `ffmpeg`/`ffprobe` (PATH or
    `OVERCAST_FFMPEG`/`OVERCAST_FFPROBE`); `overcast doctor` checks it's installed.
@@ -79,8 +87,11 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
 - **Senses** — `watch` (shot-detect + all-modality describe → `content` /
   `transcript` / `detailed`), `listen` (speech transcript; `--describe` for the
   full audio-scene, `--diarize`, `--lang`), `see` (caption / OCR / open-vocab
-  `--detect` — turnkey Hugging Face, bindable fal, local OWLv2 via
-  `examples/providers/detect`), `face` (tinycloud ≥ 0.3.4 by default, or
+  `--detect` — **default: the brain LLM** when image-capable, i.e. a direct
+  "describe this image" call; falls back to the Hugging Face captioner,
+  `builtin:hf`/`builtin:brain` + `OVERCAST_SEE_BRAIN=off` to switch; bindable fal
+  / local OWLv2 via `examples/providers/detect` for detection), `face`
+  (tinycloud ≥ 0.3.4 by default, or
   `face:deepface-local` locally: detect faces, `--match <jpeg|png>` to find/rank a
   person in a clip, or `--index` to search a face-analysis / deepface-local index),
   `image` (local OpenCV RANSAC image/video-frame matching against

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ surface + env vars.)
 |---|---|
 | `watch` | analyze a video → `content` / `transcript` / `detailed` (default: Cloudglue) |
 | `listen` | transcribe audio / a video's audio; `--describe` for the full audio-scene |
-| `see` | caption / OCR / detect on an image or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM) |
+| `see` | caption / OCR / detect on an image, image URL, or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM) |
 | `face` | detect faces in a video, `--match <img>` to find a person, or search a face-analysis index |
 | `image` | match images/video frames against a local OpenCV RANSAC image index |
 | `enhance` | denoise / normalize / upscale via bundled ffmpeg, or a bound model provider |

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ surface + env vars.)
 |---|---|
 | `watch` | analyze a video → `content` / `transcript` / `detailed` (default: Cloudglue) |
 | `listen` | transcribe audio / a video's audio; `--describe` for the full audio-scene |
-| `see` | caption / OCR / detect on an image or video frame (turnkey HF, or bind a VLM) |
+| `see` | caption / OCR / detect on an image or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM) |
 | `face` | detect faces in a video, `--match <img>` to find a person, or search a face-analysis index |
 | `image` | match images/video frames against a local OpenCV RANSAC image index |
 | `enhance` | denoise / normalize / upscale via bundled ffmpeg, or a bound model provider |
@@ -366,7 +366,7 @@ for cadence, and add `--max-frames` when you want a hard cap.
 
 | class | verbs | shipped providers |
 |---|---|---|
-| **sense** | watch / listen / see / face / enhance | Cloudglue (default), Hugging Face, fal.ai, ElevenLabs, ffmpeg |
+| **sense** | watch / listen / see / face / enhance | Cloudglue (default), the brain LLM (default `see`), Hugging Face, fal.ai, ElevenLabs, ffmpeg |
 | **source** | scan / capture / monitor | youtube (yt-dlp), tiktok (Apify), web (Tavily/Brave) |
 | **memory** | ask / brief | `local-grep` case search (always on); optional lifecycle-managed qmd semantic search; typed tinycloud media indexes via `ask --index` |
 
@@ -420,7 +420,7 @@ bash examples/profiles/install-profiles.sh   # then: overcast <verb> … --profi
 - `OVERCAST_QMD_CMD`, `OVERCAST_QMD_MODEL` — optional qmd case-search command/model (`embeddinggemma-300M-Q8_0` by default; install with `npm install -g @tobilu/qmd`, then rebuild before querying qmd)
 
 **Opt-in sense providers** (bind via `setup provider <verb> <spec>`)
-- `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` — turnkey `see` + `enhance`; `HF_SEE_MODEL` (default `google/gemma-3-27b-it`), `HF_ENHANCE_IMAGE_MODEL` / `HF_ENHANCE_AUDIO_MODEL` / `HF_ENHANCE_ENDPOINT`
+- `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` — fallback `see` captioner (when the brain LLM has no vision) + `enhance`; `HF_SEE_MODEL` (default `google/gemma-3-27b-it`), `HF_ENHANCE_IMAGE_MODEL` / `HF_ENHANCE_AUDIO_MODEL` / `HF_ENHANCE_ENDPOINT`. `see` defaults to the brain LLM when it's image-capable — `OVERCAST_SEE_BRAIN=off` (or `setup provider see builtin:hf`) forces this HF captioner instead.
 - `FAL_KEY` (or `FAL_API_KEY`) — `see` (florence-2), `enhance` image (esrgan) / audio (deepfilternet3); `FAL_SEE_MODEL`, `FAL_ENHANCE_IMAGE_MODEL`, `FAL_ENHANCE_AUDIO_MODEL`
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`) — `listen` (Scribe STT) + `enhance` audio (voice isolation); `ELEVENLABS_STT_MODEL` (default `scribe_v1`)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -42,7 +42,7 @@ OVERCAST_SOURCE_TIKTOK_CMD="bash examples/providers/sources/tiktok.sh" \
 
 Bindings live in the active profile (`~/.overcast/profiles/<name>.json`), so they
 travel with `--profile`. **Rebinding a verb requires no overcast code changes** —
-the default tinycloud `watch`/`listen` and the `see` placeholder are just the
+the default tinycloud `watch`/`listen` and the default `see` backend are just the
 out-of-the-box descriptors.
 
 ## Provider setup wizard and non-interactive profiles
@@ -117,12 +117,39 @@ credential-blocked, or failed. Refless hits are explicit processing errors in
 both commands. Monitor records hard failures once and marks them seen; pending
 or credential-blocked items are left retryable for the next pass.
 
-## Hugging Face providers (turnkey when `HF_TOKEN` is set)
+## `see` — the brain LLM by default
 
-overcast ships Hugging Face Inference API providers so `see` and model-based
-`enhance` work out of the box once `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) is set:
+`see` defaults to the **brain LLM** whenever it accepts image input: overcast
+sends the image plus a "describe this image in detail" instruction directly to
+whatever brain the profile/env already resolves (BYO — the turnkey Cloudglue brain
+out of the box, or any image-capable `setup llm <provider> <model>`), and maps the
+reply to the `see` record (`payload.caption`; `--ocr` also fills `payload.ocr`).
+No extra key is needed beyond the brain you already use.
 
-- **`see`** — auto-defaults to a HF vision-LLM captioner ([`examples/providers/hf/see.sh`](../examples/providers/hf/see.sh)) when `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) is present (else the placeholder). Override the model with `HF_SEE_MODEL` (default `google/gemma-3-27b-it`). Forwards `--ocr` / `--detect` / `--prompt`.
+Precedence when you run `see`:
+
+1. an explicit provider binding (`setup provider see <exec|http|inproc spec>`) — e.g. the OWLv2 detector;
+2. the **brain LLM** when it's image-capable (the default);
+3. the Hugging Face captioner when `HF_TOKEN` is set;
+4. a `needs_credentials` placeholder with guidance.
+
+Switch the built-in backend without editing the profile by hand:
+
+```bash
+overcast setup provider see builtin:hf      # force the classic Hugging Face captioner
+overcast setup provider see builtin:brain   # force the brain LLM (errors if it has no vision)
+OVERCAST_SEE_BRAIN=off overcast see shot.jpg # one-off: skip the brain default (→ HF / placeholder)
+```
+
+`--detect` still needs a detection provider (the brain path produces a description,
+not bounding boxes) — bind one, e.g. `setup provider see "exec:python3 examples/providers/detect/detect.py"`.
+
+## Hugging Face providers (`see` fallback + model-based `enhance`)
+
+overcast ships Hugging Face Inference API providers so the `see` captioner and
+model-based `enhance` work once `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) is set:
+
+- **`see`** — the fallback captioner ([`examples/providers/hf/see.sh`](../examples/providers/hf/see.sh)), used when the brain LLM has no vision (or when forced via `setup provider see builtin:hf` / `OVERCAST_SEE_BRAIN=off`). Override the model with `HF_SEE_MODEL` (default `google/gemma-3-27b-it`). Forwards `--ocr` / `--detect` / `--prompt`.
 - **`enhance` (image)** — opt-in HF model ops ([`examples/providers/hf/enhance.py`](../examples/providers/hf/enhance.py), needs `huggingface_hub` + `pillow`). Image **upscale/unblur/restore works** via the **fal-ai** provider, routed through your `HF_TOKEN` (the HF way — billed to your HF account, no fal key needed; uses the free monthly credit then pay-as-you-go). The **default stays the internal ffmpeg toolkit**; bind to opt in:
   ```bash
   overcast setup provider enhance "exec:python3 examples/providers/hf/enhance.py {{input}}"

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -144,6 +144,12 @@ OVERCAST_SEE_BRAIN=off overcast see shot.jpg # one-off: skip the brain default (
 `--detect` still needs a detection provider (the brain path produces a description,
 not bounding boxes) — bind one, e.g. `setup provider see "exec:python3 examples/providers/detect/detect.py"`.
 
+`see` also takes an **http(s) image URL** directly: the image is downloaded into
+the case media dir first (evidence, like `capture` — the record's `media.ref` is
+the local artifact, `meta.source_url` the origin), so every backend reads a local
+file. A URL that resolves to video/audio is redirected to `watch`/`listen`, and a
+non-image response (login wall, expired signed URL returning HTML) errors clearly.
+
 ## Hugging Face providers (`see` fallback + model-based `enhance`)
 
 overcast ships Hugging Face Inference API providers so the `see` captioner and

--- a/examples/profiles/install-profiles.sh
+++ b/examples/profiles/install-profiles.sh
@@ -23,9 +23,9 @@ bind() { # <profile> <verb> <script-relpath> [interpreter=bash]
 
 echo "Building profiles in ${2:-~/.overcast}:"
 
-# 1. cloudglue — the baseline (tinycloud watch/listen, ffmpeg enhance, see placeholder).
+# 1. cloudglue — the baseline (tinycloud watch/listen, ffmpeg enhance, see=brain LLM).
 $OC setup llm cloudglue tinycloud:advanced --profile cloudglue "${HOME_ARG[@]}" >/dev/null
-echo "  cloudglue: defaults (watch/listen=tinycloud, enhance=ffmpeg, see=placeholder)"
+echo "  cloudglue: defaults (watch/listen=tinycloud, enhance=ffmpeg, see=brain LLM)"
 
 # 2. fal — fal.ai everything pluggable.
 bind fal see     fal/see.sh

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -54,17 +54,17 @@ Emits `audio.analysis` records.
 
 ### `overcast see`
 
-Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or `builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; --detect needs a detection provider. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.
+Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or `builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; --detect needs a detection provider. Accepts frame://rec@sec (resolved via the internal ffmpeg toolkit) and http(s) image URLs, fetched into the case media dir first (meta.source_url keeps the origin).
 
 ```
 overcast see <input> [options]
 
   Understand an image or a single video frame (caption, OCR, detections).
 
-  Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or `builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; --detect needs a detection provider. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.
+  Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or `builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; --detect needs a detection provider. Accepts frame://rec@sec (resolved via the internal ffmpeg toolkit) and http(s) image URLs, fetched into the case media dir first (meta.source_url keeps the origin).
 
 Arguments:
-  input            Image path, video frame, or frame://rec@sec
+  input            Image path, http(s) image URL, video frame, or frame://rec@sec
 
 Options:
   --format <string>      Output surface: json | md | txt

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -54,14 +54,14 @@ Emits `audio.analysis` records.
 
 ### `overcast see`
 
-Defaults to a Hugging Face image captioner when HF_TOKEN is set (override with HF_SEE_MODEL); otherwise a placeholder (needs_credentials) until a VLM is bound via `setup provider see`. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.
+Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or `builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; --detect needs a detection provider. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.
 
 ```
 overcast see <input> [options]
 
   Understand an image or a single video frame (caption, OCR, detections).
 
-  Defaults to a Hugging Face image captioner when HF_TOKEN is set (override with HF_SEE_MODEL); otherwise a placeholder (needs_credentials) until a VLM is bound via `setup provider see`. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.
+  Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or `builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; --detect needs a detection provider. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.
 
 Arguments:
   input            Image path, video frame, or frame://rec@sec

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,7 @@ const ENV_GROUPS: Array<{ title: string; vars: Array<[string, string]> }> = [
   {
     title: "overcast — opt-in sense providers (bind via `setup provider <verb> <spec>`)",
     vars: [
-      ["HF_TOKEN / HUGGING_FACE_HUB_TOKEN", "Hugging Face token — turnkey `see` (vision-LLM caption/OCR) + `enhance` (image upscale)"],
+      ["HF_TOKEN / HUGGING_FACE_HUB_TOKEN", "Hugging Face token — fallback `see` captioner (when the brain has no vision) + `enhance` (image upscale)"],
       ["HF_SEE_MODEL", "HF see model (default google/gemma-3-27b-it)"],
       ["HF_ENHANCE_IMAGE_MODEL / HF_ENHANCE_AUDIO_MODEL / HF_ENHANCE_ENDPOINT", "HF enhance model + router endpoint overrides"],
       ["FAL_KEY / FAL_API_KEY", "fal.ai key — see (florence-2), enhance image (esrgan) + audio (deepfilternet3)"],
@@ -129,6 +129,7 @@ const ENV_GROUPS: Array<{ title: string; vars: Array<[string, string]> }> = [
       ["OVERCAST_PROFILE", "active profile for the session (set by the launcher from --profile)"],
       ["OVERCAST_MEDIA_DIR", "(set by overcast) the media output dir passed to exec providers"],
       ["OVERCAST_NO_DOTENV", "Set 1 to disable automatic .env loading for isolated tests/runs"],
+      ["OVERCAST_SEE_BRAIN", "Set off/0 to disable the default brain-LLM `see` backend (fall back to Hugging Face / placeholder)"],
       ["OVERCAST_PI_ONLINE", "Set 1 to re-enable pi's startup update-check"],
       ["OVERCAST_MONITOR_MAX_PASSES", "cap on monitor --every passes (testing/scheduling)"],
       ["OVERCAST_E2E_LIVE", "Set 1 to run the gated live-Cloudglue e2e cases"],

--- a/src/extension/overcast.ts
+++ b/src/extension/overcast.ts
@@ -17,6 +17,7 @@ import { toAgentTool } from "../registry/to-agent-tool.js";
 import { openCase } from "../case.js";
 import { loadProfile, resolveCloudglue, resolveHome } from "../profile.js";
 import { loadSetup } from "../state/setup.js";
+import { CLOUDGLUE_MODEL_ID } from "../providers/brain/vision.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { OvercastHeader, OvercastFooter, workingIndicator, opLabel, idleLabel } from "./branding.js";
 import { registerSlashCommands } from "./slash.js";
@@ -39,7 +40,7 @@ function setupHintLabel(cwd: string): string | undefined {
   return setup?.completed ? undefined : "case not set up";
 }
 
-const CLOUDGLUE_MODEL_ID = "tinycloud:advanced";
+// CLOUDGLUE_MODEL_ID is imported from providers/brain/vision.js (single source of truth).
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // Built file lives at dist/extension/overcast.js → package root is two up,

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -1,0 +1,137 @@
+// Fetch remote media into the case store. ONE download path for verbs that need
+// a LOCAL file from an http(s) ref — `see` uses it so a pasted image URL "just
+// works" for every backend (the brain LLM, the HF captioner, exec detectors all
+// read local files). The artifact lands in the case media dir (evidence, like
+// `capture`), named by a hash of the URL so repeat calls reuse the same file.
+//
+// Extension resolution (so ffmpeg/senses can classify the artifact):
+//   URL path ext (if a known media ext) → Content-Type → magic-byte sniff.
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { OVERCAST_VERSION } from "../version.js";
+
+export const isHttpUrl = (ref: string): boolean => /^https?:\/\//i.test(ref);
+
+const CT_EXT: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/bmp": ".bmp",
+  "image/tiff": ".tiff",
+  "image/avif": ".avif",
+  "image/heic": ".heic",
+  "video/mp4": ".mp4",
+  "video/webm": ".webm",
+  "video/quicktime": ".mov",
+  "video/mpeg": ".mpg",
+  "audio/mpeg": ".mp3",
+  "audio/mp4": ".m4a",
+  "audio/wav": ".wav",
+  "audio/x-wav": ".wav",
+  "audio/ogg": ".ogg",
+  "audio/flac": ".flac",
+};
+
+// Known media extensions a URL path can assert directly (query/fragment ignored).
+const URL_EXT_RE =
+  /\.(jpe?g|png|webp|gif|bmp|tiff?|avif|heic|mp4|m4v|mov|webm|mkv|avi|mpe?g|mp3|m4a|wav|flac|ogg|opus|aac)$/i;
+
+/** Best-effort media extension from leading magic bytes (so downloaded/piped
+ *  bytes land with a sensible extension the senses/ffmpeg can classify). */
+export function sniffExt(b: Buffer): string {
+  const at = (off: number, s: string) => b.length >= off + s.length && b.slice(off, off + s.length).toString("latin1") === s;
+  if (at(4, "ftyp")) return ".mp4"; // ISO-BMFF: mp4/mov/m4a
+  if (at(0, "RIFF") && at(8, "WEBP")) return ".webp";
+  if (at(0, "RIFF") && at(8, "WAVE")) return ".wav";
+  if (at(0, "RIFF") && at(8, "AVI ")) return ".avi";
+  if (b[0] === 0x89 && at(1, "PNG")) return ".png";
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return ".jpg";
+  if (at(0, "GIF8")) return ".gif";
+  if (at(0, "OggS")) return ".ogg";
+  if (at(0, "fLaC")) return ".flac";
+  if (at(0, "ID3") || (b[0] === 0xff && (b[1] & 0xe0) === 0xe0)) return ".mp3";
+  if (b[0] === 0x1a && b[1] === 0x45 && b[2] === 0xdf && b[3] === 0xa3) return ".webm";
+  return ".bin";
+}
+
+export type MediaKind = "image" | "av" | "other";
+
+/** Classify a resolved extension for caller routing (see wants images; a video
+ *  URL should be redirected to watch/listen instead of sent to a VLM). */
+export function kindForExt(ext: string): MediaKind {
+  if (/^\.(jpe?g|png|webp|gif|bmp|tiff?|avif|heic)$/i.test(ext)) return "image";
+  if (/^\.(mp4|m4v|mov|webm|mkv|avi|mpe?g|mpg|mp3|m4a|wav|flac|ogg|opus|aac)$/i.test(ext)) return "av";
+  return "other";
+}
+
+export interface FetchedMedia {
+  /** local path of the downloaded artifact (inside the case media dir) */
+  path: string;
+  /** response Content-Type (main value only), when the server sent one */
+  contentType?: string;
+  /** resolved extension, e.g. ".jpg" (".bin" when nothing could classify it) */
+  ext: string;
+  bytes: number;
+}
+
+export interface FetchMediaOpts {
+  timeoutMs?: number;
+  /** hard cap on the downloaded size (default 64 MB) */
+  maxBytes?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Download an http(s) media URL into `mediaDir` and return the local artifact.
+ * Throws with a clear message on HTTP errors, timeout, abort, or size overrun.
+ * When the URL path carries a known media extension the artifact name is
+ * deterministic up front and an existing file is reused without re-downloading.
+ */
+export async function fetchMediaToCase(
+  url: string,
+  mediaDir: string,
+  opts: FetchMediaOpts = {},
+): Promise<FetchedMedia> {
+  const { timeoutMs = 60_000, maxBytes = 64 * 1024 * 1024 } = opts;
+  mkdirSync(mediaDir, { recursive: true });
+  const hash = createHash("sha256").update(url).digest("hex").slice(0, 12);
+
+  // A URL-path extension makes the name deterministic pre-fetch → cache hit.
+  let pathname = "";
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    throw new Error(`invalid URL: ${url}`);
+  }
+  const urlExt = pathname.match(URL_EXT_RE)?.[0]?.toLowerCase();
+  if (urlExt) {
+    const out = join(mediaDir, `url-${hash}${urlExt}`);
+    if (existsSync(out)) return { path: out, ext: urlExt, bytes: 0 };
+  }
+
+  const timeout = AbortSignal.timeout(timeoutMs);
+  const signal = opts.signal ? AbortSignal.any([opts.signal, timeout]) : timeout;
+  let res: Response;
+  try {
+    // Node's fetch sends no User-Agent; several CDNs (e.g. Wikimedia) reject
+    // UA-less clients outright, so identify ourselves.
+    res = await fetch(url, { signal, headers: { "user-agent": `overcast/${OVERCAST_VERSION}` } });
+  } catch (e) {
+    if (timeout.aborted) throw new Error(`download timed out after ${timeoutMs}ms: ${url}`);
+    throw new Error(`download failed: ${(e as Error).message}`);
+  }
+  if (!res.ok) throw new Error(`download failed ${res.status} ${res.statusText}: ${url}`);
+  const len = Number(res.headers.get("content-length") ?? 0);
+  if (len > maxBytes) throw new Error(`remote media is ${len} bytes (cap ${maxBytes}): ${url}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.byteLength > maxBytes) throw new Error(`remote media is ${buf.byteLength} bytes (cap ${maxBytes}): ${url}`);
+
+  const contentType = (res.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase() || undefined;
+  const ext = urlExt ?? (contentType && CT_EXT[contentType]) ?? sniffExt(buf);
+  const out = join(mediaDir, `url-${hash}${ext}`);
+  writeFileSync(out, buf);
+  return { path: out, contentType, ext, bytes: buf.byteLength };
+}

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -106,7 +106,11 @@ export async function fetchMediaToCase(
   } catch {
     throw new Error(`invalid URL: ${url}`);
   }
-  const urlExt = pathname.match(URL_EXT_RE)?.[0]?.toLowerCase();
+  // Normalized so the cache name matches what a Content-Type/sniff resolution
+  // of the same media would produce. NOTE: this pre-fetch cache hit is safe
+  // because artifacts are always NAMED by the resolved (response-truth) ext —
+  // an HTML body never lands as url-<hash>.jpg, so a .jpg hit is a real image.
+  const urlExt = pathname.match(URL_EXT_RE)?.[0]?.toLowerCase().replace(/^\.jpeg$/, ".jpg").replace(/^\.tif$/, ".tiff");
   if (urlExt) {
     const out = join(mediaDir, `url-${hash}${urlExt}`);
     if (existsSync(out)) return { path: out, ext: urlExt, bytes: 0 };
@@ -130,7 +134,15 @@ export async function fetchMediaToCase(
   if (buf.byteLength > maxBytes) throw new Error(`remote media is ${buf.byteLength} bytes (cap ${maxBytes}): ${url}`);
 
   const contentType = (res.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase() || undefined;
-  const ext = urlExt ?? (contentType && CT_EXT[contentType]) ?? sniffExt(buf);
+  // Response truth wins over the URL's claimed extension: an expired signed URL
+  // or login wall answers 200 text/html — that must NOT ride a ".jpg" path into
+  // the image pipeline. Content-Type map → magic bytes → the URL ext only when
+  // the response is uninformative (no/generic content-type, unsniffable bytes).
+  const ctExt = contentType ? CT_EXT[contentType] : undefined;
+  const sniffed = sniffExt(buf);
+  const uninformative =
+    !contentType || contentType === "application/octet-stream" || contentType === "binary/octet-stream";
+  const ext = ctExt ?? (sniffed !== ".bin" ? sniffed : uninformative ? urlExt ?? ".bin" : ".bin");
   const out = join(mediaDir, `url-${hash}${ext}`);
   writeFileSync(out, buf);
   return { path: out, contentType, ext, bytes: buf.byteLength };

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -40,10 +40,18 @@ const URL_EXT_RE =
   /\.(jpe?g|png|webp|gif|bmp|tiff?|avif|heic|mp4|m4v|mov|webm|mkv|avi|mpe?g|mp3|m4a|wav|flac|ogg|opus|aac)$/i;
 
 /** Best-effort media extension from leading magic bytes (so downloaded/piped
- *  bytes land with a sensible extension the senses/ffmpeg can classify). */
+ *  bytes land with a sensible extension the senses/ffmpeg can classify).
+ *  Also detects definitely-TEXT bodies (".html"/".txt") — an HTML login wall or
+ *  error page behind a lying/missing Content-Type must never classify as media
+ *  (every real media format below carries binary magic). */
 export function sniffExt(b: Buffer): string {
   const at = (off: number, s: string) => b.length >= off + s.length && b.slice(off, off + s.length).toString("latin1") === s;
-  if (at(4, "ftyp")) return ".mp4"; // ISO-BMFF: mp4/mov/m4a
+  if (at(4, "ftyp")) {
+    // ISO-BMFF brand: avif/heic are IMAGES riding the mp4 container magic.
+    if (at(8, "avif") || at(8, "avis")) return ".avif";
+    if (at(8, "heic") || at(8, "heix") || at(8, "mif1") || at(8, "msf1")) return ".heic";
+    return ".mp4"; // mp4/mov/m4a
+  }
   if (at(0, "RIFF") && at(8, "WEBP")) return ".webp";
   if (at(0, "RIFF") && at(8, "WAVE")) return ".wav";
   if (at(0, "RIFF") && at(8, "AVI ")) return ".avi";
@@ -54,6 +62,13 @@ export function sniffExt(b: Buffer): string {
   if (at(0, "fLaC")) return ".flac";
   if (at(0, "ID3") || (b[0] === 0xff && (b[1] & 0xe0) === 0xe0)) return ".mp3";
   if (b[0] === 0x1a && b[1] === 0x45 && b[2] === 0xdf && b[3] === 0xa3) return ".webm";
+  // text detection: strip a UTF-8 BOM + leading whitespace, then look for markup;
+  // else call an all-printable-ASCII head plain text (JSON/plain error bodies).
+  const start = b[0] === 0xef && b[1] === 0xbb && b[2] === 0xbf ? 3 : 0;
+  const head = b.subarray(start, start + 256).toString("latin1").trimStart();
+  if (/^<(!doctype|html|head|body|\?xml|svg)/i.test(head)) return ".html";
+  const probe = b.subarray(start, start + Math.min(64, b.length - start));
+  if (probe.length > 0 && probe.every((c) => c === 9 || c === 10 || c === 13 || (c >= 32 && c <= 126))) return ".txt";
   return ".bin";
 }
 
@@ -136,13 +151,19 @@ export async function fetchMediaToCase(
   const contentType = (res.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase() || undefined;
   // Response truth wins over the URL's claimed extension: an expired signed URL
   // or login wall answers 200 text/html — that must NOT ride a ".jpg" path into
-  // the image pipeline. Content-Type map → magic bytes → the URL ext only when
-  // the response is uninformative (no/generic content-type, unsniffable bytes).
+  // the image pipeline. A definitely-text BODY (per sniff) vetoes everything,
+  // including a lying `image/jpeg` Content-Type — no real media is printable
+  // text. Otherwise: Content-Type map (it disambiguates ISO-BMFF images) →
+  // magic bytes → the URL ext only when the response is uninformative
+  // (no/generic content-type, unsniffable bytes).
   const ctExt = contentType ? CT_EXT[contentType] : undefined;
   const sniffed = sniffExt(buf);
+  const textish = sniffed === ".html" || sniffed === ".txt";
   const uninformative =
     !contentType || contentType === "application/octet-stream" || contentType === "binary/octet-stream";
-  const ext = ctExt ?? (sniffed !== ".bin" ? sniffed : uninformative ? urlExt ?? ".bin" : ".bin");
+  const ext = textish
+    ? sniffed
+    : ctExt ?? (sniffed !== ".bin" ? sniffed : uninformative ? urlExt ?? ".bin" : ".bin");
   const out = join(mediaDir, `url-${hash}${ext}`);
   writeFileSync(out, buf);
   return { path: out, contentType, ext, bytes: buf.byteLength };

--- a/src/providers/brain/vision.ts
+++ b/src/providers/brain/vision.ts
@@ -1,0 +1,270 @@
+// Brain-vision `see` backend — the NEW default for `see`. When the configured
+// BRAIN LLM supports image input, we describe the image with a single direct LLM
+// call ("describe what you see, in detail") instead of a separate vision
+// provider. It resolves whatever brain the profile/env already points at (BYO),
+// so no specific brain is forced.
+//
+// This is a DELIBERATE, opt-out bridge across CLAUDE.md invariant #2 (keep brain
+// vs. sense providers separate): the brain is still resolved the BYO way, and the
+// classic Hugging Face captioner stays one switch away —
+//   `setup provider see builtin:hf`  or  OVERCAST_SEE_BRAIN=off
+// — so we never hardcode or force a brain onto a sense.
+
+import { readFileSync } from "node:fs";
+import { extname } from "node:path";
+
+import {
+  createProvider,
+  envApiKeyAuth,
+  type Api,
+  type Context,
+  type Model,
+  type MutableModels,
+  type Provider,
+} from "@earendil-works/pi-ai";
+
+import { makeRecord, type OvercastRecord } from "../../record.js";
+import { resolveCloudglue, type Profile } from "../../profile.js";
+
+/** The turnkey Cloudglue brain: a custom (non-builtin) pi-ai provider speaking
+ *  the anthropic-messages API. Shared with the pi extension so the CLI see-path
+ *  and the TUI brain agree on the id. */
+export const CLOUDGLUE_PROVIDER_ID = "cloudglue";
+export const CLOUDGLUE_MODEL_ID = "tinycloud:advanced";
+
+/** The Cloudglue brain model descriptor (image-capable). One source of truth for
+ *  both the see-path (here) and the extension's `pi.setModel`. */
+export function cloudglueBrainModel(baseUrl: string): Model<"anthropic-messages"> {
+  return {
+    id: CLOUDGLUE_MODEL_ID,
+    name: "TinyCloud Advanced",
+    api: "anthropic-messages",
+    provider: CLOUDGLUE_PROVIDER_ID,
+    baseUrl,
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: 32_000,
+  };
+}
+
+/** OVERCAST_SEE_BRAIN=off|0|false|no hard-disables the brain default (falls back
+ *  to the HF captioner / placeholder). The switch tests + CI use to stay
+ *  deterministic regardless of an ambient Cloudglue key. */
+export function brainSeeDisabled(): boolean {
+  const v = (process.env.OVERCAST_SEE_BRAIN ?? "").trim().toLowerCase();
+  return v === "off" || v === "0" || v === "false" || v === "no";
+}
+
+/** Which brain the see verb should use, mirroring the extension's turnkey rule:
+ *  an explicit `profile.llm` wins; else the turnkey Cloudglue key (env or
+ *  ~/.tinycloud/config.json). undefined = no brain configured. */
+export function resolveBrainChoice(profile: Profile): { provider: string; model?: string } | undefined {
+  if (profile.llm?.provider) {
+    return { provider: profile.llm.provider, model: profile.llm.model };
+  }
+  if (resolveCloudglue().apiKey) {
+    return { provider: CLOUDGLUE_PROVIDER_ID, model: CLOUDGLUE_MODEL_ID };
+  }
+  return undefined;
+}
+
+/** Result of a brain-see attempt: either a finished record (success OR a clean
+ *  error record), or "unavailable" so the caller can fall back to HF/placeholder. */
+export type BrainSeeResult =
+  | { kind: "record"; record: OvercastRecord }
+  | { kind: "unavailable"; reason: string };
+
+export interface BrainSeeCtx {
+  profile: Profile;
+  caseDir: string;
+  /** --prompt: focus the description */
+  prompt?: string;
+  /** --ocr: also transcribe on-image text */
+  ocr?: boolean;
+  signal?: AbortSignal;
+}
+
+/** Describe an image with the configured brain LLM. `imageRef` must be a local
+ *  file path (frame:// refs are already resolved by the caller). */
+export async function seeWithBrain(imageRef: string, ctx: BrainSeeCtx): Promise<BrainSeeResult> {
+  const resolved = await resolveVisionModel(ctx.profile, ctx.signal);
+  if (resolved.kind !== "model") return { kind: "unavailable", reason: resolved.reason };
+  const { models, model } = resolved;
+
+  let data: string;
+  try {
+    data = readFileSync(imageRef).toString("base64");
+  } catch (e) {
+    return { kind: "record", record: brainRecord(model, ctx.caseDir, imageRef, { error: `image not found: ${imageRef} (${(e as Error).message})` }) };
+  }
+
+  const wantOcr = ctx.ocr === true;
+  const context: Context = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: buildSeePrompt(ctx.prompt, wantOcr) },
+          { type: "image", data, mimeType: mimeForImage(imageRef) },
+        ],
+        timestamp: Date.now(),
+      },
+    ],
+  };
+
+  try {
+    const res = await models.completeSimple(model, context, {
+      signal: ctx.signal,
+      // A detailed description is generous but bounded; cap well under the model's
+      // window so a chatty model can't run away.
+      maxTokens: Math.min(model.maxTokens || 4096, 4096),
+    });
+    const text = res.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+    if (res.stopReason === "error" || res.stopReason === "aborted" || !text) {
+      return {
+        kind: "record",
+        record: brainRecord(model, ctx.caseDir, imageRef, {
+          error: res.errorMessage || `brain returned no description (stopReason=${res.stopReason})`,
+        }),
+      };
+    }
+    const { caption, ocr } = wantOcr ? splitDescriptionOcr(text) : { caption: text, ocr: "" };
+    return { kind: "record", record: brainRecord(model, ctx.caseDir, imageRef, { caption, ocr }) };
+  } catch (e) {
+    return { kind: "record", record: brainRecord(model, ctx.caseDir, imageRef, { error: (e as Error).message }) };
+  }
+}
+
+// --- internals --------------------------------------------------------------
+
+type ResolveResult =
+  | { kind: "model"; models: MutableModels; model: Model<Api> }
+  | { kind: "unavailable"; reason: string };
+
+/** Build a pi-ai Models with the builtin providers (auth auto-resolved from env)
+ *  plus the turnkey Cloudglue provider, then resolve the chosen brain model and
+ *  confirm it accepts image input. */
+async function resolveVisionModel(profile: Profile, _signal?: AbortSignal): Promise<ResolveResult> {
+  const choice = resolveBrainChoice(profile);
+  if (!choice) return { kind: "unavailable", reason: "no brain LLM is configured (set one with `setup llm`, or provide a Cloudglue key)" };
+
+  // Heavy imports (the full builtin catalog + the anthropic-messages transport)
+  // stay off the hot path: only loaded when the brain see-path actually runs.
+  const { builtinModels } = await import("@earendil-works/pi-ai/providers/all");
+  const models = builtinModels();
+
+  // Register the turnkey Cloudglue provider (custom; anthropic-messages). Its
+  // auth reads CLOUDGLUE_API_KEY, so surface the resolved key into the env when it
+  // only lives in ~/.tinycloud/config.json (mirrors the CLI/TUI launcher).
+  const cg = resolveCloudglue();
+  if (cg.apiKey) {
+    if (!process.env.CLOUDGLUE_API_KEY) process.env.CLOUDGLUE_API_KEY = cg.apiKey;
+    try {
+      const { anthropicMessagesApi } = await import("@earendil-works/pi-ai/api/anthropic-messages.lazy");
+      const cgProvider = createProvider({
+        id: CLOUDGLUE_PROVIDER_ID,
+        name: "Cloudglue",
+        baseUrl: cg.baseUrl,
+        auth: { apiKey: envApiKeyAuth("Cloudglue API key", ["CLOUDGLUE_API_KEY"]) },
+        models: [cloudglueBrainModel(cg.baseUrl)],
+        api: anthropicMessagesApi(),
+      });
+      models.setProvider(cgProvider as unknown as Provider);
+    } catch {
+      /* best-effort; builtin providers remain available for a BYO brain */
+    }
+  }
+
+  // Resolve the model. Static providers (e.g. anthropic, cloudglue) resolve sync;
+  // dynamic providers may need a one-off refresh to populate their list.
+  let model = choice.model ? models.getModel(choice.provider, choice.model) : undefined;
+  if (!model) {
+    await models.refresh(choice.provider).catch(() => {});
+    model = choice.model
+      ? models.getModel(choice.provider, choice.model)
+      : models.getModels(choice.provider).find((m) => supportsImage(m));
+  }
+  if (!model) {
+    return {
+      kind: "unavailable",
+      reason: `brain model ${choice.provider}${choice.model ? `/${choice.model}` : ""} not found (check \`setup llm\` / provider credentials)`,
+    };
+  }
+  if (!supportsImage(model)) {
+    return { kind: "unavailable", reason: `brain model ${model.provider}/${model.id} has no image input` };
+  }
+  return { kind: "model", models, model };
+}
+
+function supportsImage(m: Model<Api>): boolean {
+  return Array.isArray(m.input) && m.input.includes("image");
+}
+
+/** Build the see instruction. Investigator-flavored, factual, image-only. */
+export function buildSeePrompt(focus?: string, ocr?: boolean): string {
+  let p =
+    "Describe this image in detail. Cover the setting, people, objects, actions, and anything " +
+    "notable an investigator would care about. Be specific and factual — describe only what is " +
+    "visible, and do not speculate beyond the image.";
+  if (focus) p += `\n\nPay particular attention to: ${focus}`;
+  if (ocr) {
+    p +=
+      "\n\nAlso transcribe any text that appears in the image, verbatim. Format your reply exactly as:\n" +
+      "DESCRIPTION: <the detailed description>\n" +
+      "TEXT: <verbatim transcription of on-image text, or 'none'>";
+  }
+  return p;
+}
+
+/** Split a DESCRIPTION:/TEXT: reply (see --ocr) into caption + ocr. Falls back to
+ *  putting the whole reply in the caption if the model didn't follow the format. */
+export function splitDescriptionOcr(text: string): { caption: string; ocr: string } {
+  const desc = text.match(/DESCRIPTION:\s*([\s\S]*?)(?:\n\s*TEXT:|$)/i);
+  if (!desc) return { caption: text, ocr: "" };
+  const textPart = text.match(/\n\s*TEXT:\s*([\s\S]*)$/i);
+  const ocr = (textPart?.[1] ?? "").trim();
+  return { caption: desc[1].trim(), ocr: /^none\.?$/i.test(ocr) ? "" : ocr };
+}
+
+/** Map file extension → image mime type (default jpeg). */
+export function mimeForImage(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case ".png":
+      return "image/png";
+    case ".webp":
+      return "image/webp";
+    case ".gif":
+      return "image/gif";
+    case ".bmp":
+      return "image/bmp";
+    case ".heic":
+    case ".heif":
+      return "image/heic";
+    default:
+      return "image/jpeg";
+  }
+}
+
+/** A see record in the shape existing consumers expect (caption/ocr/detections). */
+function brainRecord(
+  model: Model<Api>,
+  caseDir: string,
+  imageRef: string,
+  fields: { caption?: string; ocr?: string; error?: string },
+): OvercastRecord {
+  return makeRecord({
+    verb: "see",
+    format: "json",
+    payload: { caption: fields.caption ?? "", ocr: fields.ocr ?? "", detections: [] },
+    media: { ref: imageRef },
+    meta: { case: caseDir, provider: `brain:${model.provider}`, model: model.id },
+    error: fields.error,
+    state: fields.error ? "error" : "ready",
+  });
+}

--- a/src/providers/brain/vision.ts
+++ b/src/providers/brain/vision.ts
@@ -243,6 +243,11 @@ export function mimeForImage(path: string): string {
       return "image/gif";
     case ".bmp":
       return "image/bmp";
+    case ".avif":
+      return "image/avif";
+    case ".tif":
+    case ".tiff":
+      return "image/tiff";
     case ".heic":
     case ".heif":
       return "image/heic";

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -6,6 +6,7 @@ import { join, basename, dirname } from "node:path";
 import { copyFileSync, existsSync, appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { makeRecord, type OvercastRecord } from "../record.js";
+import { sniffExt } from "../media/fetch.js";
 import {
   builtinDescriptor,
   enumerateSource,
@@ -810,23 +811,8 @@ async function runDefaultWatchWithPolicy(ctx: VerbContext, caller: string, ref: 
   return out;
 }
 
-/** Best-effort media extension from leading magic bytes (so a piped clip lands
- *  with a sensible extension the senses/ffmpeg can classify). */
-function sniffExt(b: Buffer): string {
-  const at = (off: number, s: string) => b.length >= off + s.length && b.slice(off, off + s.length).toString("latin1") === s;
-  if (at(4, "ftyp")) return ".mp4"; // ISO-BMFF: mp4/mov/m4a
-  if (at(0, "RIFF") && at(8, "WEBP")) return ".webp";
-  if (at(0, "RIFF") && at(8, "WAVE")) return ".wav";
-  if (at(0, "RIFF") && at(8, "AVI ")) return ".avi";
-  if (b[0] === 0x89 && at(1, "PNG")) return ".png";
-  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return ".jpg";
-  if (at(0, "GIF8")) return ".gif";
-  if (at(0, "OggS")) return ".ogg";
-  if (at(0, "fLaC")) return ".flac";
-  if (at(0, "ID3") || (b[0] === 0xff && (b[1] & 0xe0) === 0xe0)) return ".mp3";
-  if (b[0] === 0x1a && b[1] === 0x45 && b[2] === 0xdf && b[3] === 0xa3) return ".webm";
-  return ".bin";
-}
+// sniffExt (magic-byte extension) lives in media/fetch.ts — shared with the
+// see URL-download path so piped and downloaded bytes classify identically.
 
 /** `capture -` — ingest bytes piped on stdin into the case as a capture record. */
 async function captureStdin(ctx: VerbContext, out?: string): Promise<OvercastRecord> {

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -10,6 +10,7 @@ import { runListen } from "../providers/tinycloud/listen.js";
 import { isCustomBinding, runBoundProvider, runExecProvider } from "../providers/run.js";
 import { providerBinding } from "../providers/bindings.js";
 import { seeWithBrain, brainSeeDisabled } from "../providers/brain/vision.js";
+import { fetchMediaToCase, isHttpUrl, kindForExt } from "../media/fetch.js";
 import { execCapture, parseFirstJson } from "../providers/exec.js";
 import { tokenizeCommand } from "../providers/sources/index.js";
 import { resolveVideoArg } from "./media-ref.js";
@@ -99,8 +100,10 @@ export const seeVerb: VerbSpec = {
     "Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder " +
     "until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or " +
     "`builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; " +
-    "--detect needs a detection provider. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.",
-  args: [{ name: "input", summary: "Image path, video frame, or frame://rec@sec", required: true }],
+    "--detect needs a detection provider. Accepts frame://rec@sec (resolved via the internal ffmpeg " +
+    "toolkit) and http(s) image URLs, fetched into the case media dir first (meta.source_url keeps " +
+    "the origin).",
+  args: [{ name: "input", summary: "Image path, http(s) image URL, video frame, or frame://rec@sec", required: true }],
   flags: [
     { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
@@ -131,6 +134,46 @@ export const seeVerb: VerbSpec = {
         return [errorRecord("see", `frame extraction failed for ${ctx.input}: ${(e as Error).message}`)];
       }
     }
+
+    // An http(s) URL is fetched into the case media dir first (evidence, like
+    // capture) so every backend — the brain LLM, the HF captioner, exec
+    // detectors — reads a local file instead of choking on the URL. The record
+    // keeps the origin in meta.source_url; media.ref is the local artifact.
+    let sourceUrl: string | undefined;
+    if (isHttpUrl(resolvedRef)) {
+      sourceUrl = resolvedRef;
+      let dl;
+      try {
+        dl = await fetchMediaToCase(resolvedRef, ctx.case.mediaDir, { signal: ctx.signal });
+      } catch (e) {
+        return [errorRecord("see", `could not fetch ${resolvedRef}: ${(e as Error).message}`)];
+      }
+      const kind = kindForExt(dl.ext);
+      if (kind === "av") {
+        return [
+          errorRecord(
+            "see",
+            `${resolvedRef} resolved to ${dl.ext.slice(1)} media (saved to ${dl.path}) — see analyzes still ` +
+              "images; run `watch`/`listen` on it, or `see frame://<record>@<sec>` for a single frame",
+          ),
+        ];
+      }
+      if (kind === "other") {
+        return [
+          errorRecord(
+            "see",
+            `${resolvedRef} did not return an image (content-type ${dl.contentType ?? "unknown"}) — ` +
+              "check the link (login walls and expired signed URLs commonly return HTML)",
+          ),
+        ];
+      }
+      resolvedRef = dl.path;
+    }
+    /** Stamp the case (+ URL provenance) on an outgoing see record. */
+    const stamp = (rec: OvercastRecord): OvercastRecord[] => {
+      rec.meta = { ...rec.meta, case: ctx.case.dir, ...(sourceUrl ? { source_url: sourceUrl } : {}) };
+      return [rec];
+    };
 
     // Provider resolution for see:
     //  0. a built-in backend selector — `setup provider see builtin:brain|builtin:hf`
@@ -189,8 +232,7 @@ export const seeVerb: VerbSpec = {
         extraArgs,
         signal: ctx.signal,
       });
-      rec.meta = { ...rec.meta, case: ctx.case.dir };
-      return [rec];
+      return stamp(rec);
     }
     // --detect needs a detection provider. The turnkey HF captioner / placeholder
     // below can't detect, so fail clearly instead of passing the label list to a
@@ -221,7 +263,7 @@ export const seeVerb: VerbSpec = {
         ocr: ctx.opts.ocr === true,
         signal: ctx.signal,
       });
-      if (res.kind === "record") return [res.record];
+      if (res.kind === "record") return stamp(res.record);
       if (forceBrain) {
         return [
           errorRecord(
@@ -247,15 +289,14 @@ export const seeVerb: VerbSpec = {
           extraArgs,
           signal: ctx.signal,
         });
-        rec.meta = { ...rec.meta, case: ctx.case.dir };
-        return [rec];
+        return stamp(rec);
       }
       if (forceHf) {
         return [errorRecord("see", "the Hugging Face see provider script isn't available in this build")];
       }
     }
 
-    return [
+    return stamp(
       makeRecord({
         verb: "see",
         format: "json",
@@ -269,10 +310,10 @@ export const seeVerb: VerbSpec = {
             "a VLM with `setup provider see <spec>`.",
         },
         media: { ref: resolvedRef },
-        meta: { provider: "placeholder", case: ctx.case.dir },
+        meta: { provider: "placeholder" },
         state: "needs_credentials",
       }),
-    ];
+    );
   },
 };
 

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -9,6 +9,7 @@ import { makeRecord, type OvercastRecord } from "../record.js";
 import { runListen } from "../providers/tinycloud/listen.js";
 import { isCustomBinding, runBoundProvider, runExecProvider } from "../providers/run.js";
 import { providerBinding } from "../providers/bindings.js";
+import { seeWithBrain, brainSeeDisabled } from "../providers/brain/vision.js";
 import { execCapture, parseFirstJson } from "../providers/exec.js";
 import { tokenizeCommand } from "../providers/sources/index.js";
 import { resolveVideoArg } from "./media-ref.js";
@@ -93,9 +94,12 @@ export const seeVerb: VerbSpec = {
   group: "sense",
   summary: "Understand an image or a single video frame (caption, OCR, detections).",
   description:
-    "Defaults to a Hugging Face image captioner when HF_TOKEN is set (override with " +
-    "HF_SEE_MODEL); otherwise a placeholder (needs_credentials) until a VLM is bound via " +
-    "`setup provider see`. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.",
+    "Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' " +
+    "call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a " +
+    "Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder " +
+    "until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or " +
+    "`builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; " +
+    "--detect needs a detection provider. Accepts frame://rec@sec, resolved to a frame via the internal ffmpeg toolkit.",
   args: [{ name: "input", summary: "Image path, video frame, or frame://rec@sec", required: true }],
   flags: [
     { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },
@@ -129,18 +133,29 @@ export const seeVerb: VerbSpec = {
     }
 
     // Provider resolution for see:
+    //  0. a built-in backend selector — `setup provider see builtin:brain|builtin:hf`
+    //     forces one path (see below), else
     //  1. an explicit profile binding (exec runs it; http/inproc → explicit
     //     error rather than being silently ignored), else
-    //  2. the shipped Hugging Face captioner when HF_TOKEN is set (turnkey), else
-    //  3. the placeholder (needs_credentials + guidance).
+    //  2. the BRAIN LLM when it supports images (the new turnkey default), else
+    //  3. the shipped Hugging Face captioner when HF_TOKEN is set, else
+    //  4. the placeholder (needs_credentials + guidance).
     const binding = providerBinding(ctx, "see");
+    const builtin = binding?.module?.startsWith("builtin:") ? binding.module.slice("builtin:".length) : undefined;
+    if (builtin && builtin !== "brain" && builtin !== "hf") {
+      return [errorRecord("see", `unknown built-in see backend 'builtin:${builtin}' (expected builtin:brain or builtin:hf)`)];
+    }
+    const forceBrain = builtin === "brain";
+    const forceHf = builtin === "hf";
     const seeEnv = providerEnv(ctx.case.mediaDir);
     // forward the declared see flags to whichever provider runs (custom or HF).
     const extraArgs: string[] = [];
     if (ctx.opts.ocr === true) extraArgs.push("--ocr");
     if (ctx.opts.detect) extraArgs.push("--detect", String(ctx.opts.detect));
     if (ctx.opts.prompt) extraArgs.push("--prompt", String(ctx.opts.prompt));
-    if (isCustomBinding(binding)) {
+    // A real custom binding (exec/http/inproc) wins — but NOT a `builtin:` selector,
+    // which is handled by the brain/HF branches below.
+    if (isCustomBinding(binding) && !builtin) {
       // --detect needs a detection-capable provider. If the bound provider's
       // `describe` clearly declares no detection (no "detections" payload / detect
       // task), fail fast instead of handing --detect to a captioner that ignores
@@ -194,7 +209,35 @@ export const seeVerb: VerbSpec = {
         }),
       ];
     }
-    if (hfToken()) {
+    // New default: describe with the BRAIN LLM when it supports images (BYO).
+    // Forced on with `builtin:brain`; skipped for `builtin:hf` or when disabled
+    // via OVERCAST_SEE_BRAIN=off. On "unavailable" (no image-capable brain) we
+    // fall through to HF/placeholder — unless the brain was explicitly forced.
+    if (!forceHf && (forceBrain || !brainSeeDisabled())) {
+      const res = await seeWithBrain(resolvedRef, {
+        profile: ctx.profile,
+        caseDir: ctx.case.dir,
+        prompt: ctx.opts.prompt ? String(ctx.opts.prompt) : undefined,
+        ocr: ctx.opts.ocr === true,
+        signal: ctx.signal,
+      });
+      if (res.kind === "record") return [res.record];
+      if (forceBrain) {
+        return [
+          errorRecord(
+            "see",
+            `see (brain) can't run: ${res.reason}. Configure an image-capable brain (\`setup llm\`), ` +
+              "or switch backends with `overcast setup provider see builtin:hf` / `setup provider see <spec>`.",
+          ),
+        ];
+      }
+      // else: no image-capable brain — fall through to the HF captioner / placeholder.
+    }
+
+    // Classic Hugging Face captioner: the fallback default, and the switchable
+    // "old implementation" (`builtin:hf` runs it even when a brain is available;
+    // with no HF_TOKEN it self-reports needs_credentials).
+    if (hfToken() || forceHf) {
       const hf = shippedPath("examples", "providers", "hf", "see.sh");
       if (hf) {
         // pass --input explicitly (like execDescriptor) so the media path is never
@@ -207,6 +250,9 @@ export const seeVerb: VerbSpec = {
         rec.meta = { ...rec.meta, case: ctx.case.dir };
         return [rec];
       }
+      if (forceHf) {
+        return [errorRecord("see", "the Hugging Face see provider script isn't available in this build")];
+      }
     }
 
     return [
@@ -218,7 +264,9 @@ export const seeVerb: VerbSpec = {
           ocr: "",
           detections: [],
           guidance:
-            "see has no default provider yet. Bind a VLM: `overcast setup provider see <http|module>`.",
+            "see has no image-capable brain and no VLM bound. Configure a brain (`setup llm`, or a " +
+            "Cloudglue key for the turnkey brain), set HF_TOKEN for the Hugging Face captioner, or bind " +
+            "a VLM with `setup provider see <spec>`.",
         },
         media: { ref: resolvedRef },
         meta: { provider: "placeholder", case: ctx.case.dir },

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -117,6 +117,15 @@ export const seeVerb: VerbSpec = {
   run: async (ctx) => {
     if (!ctx.input) return [errorRecord("see", "see requires an image input")];
 
+    // Stamp the case (+ URL provenance, once known) on EVERY outgoing see
+    // record — successes and failures alike, so an error on a URL input still
+    // carries meta.source_url.
+    let sourceUrl: string | undefined;
+    const stamp = (rec: OvercastRecord): OvercastRecord[] => {
+      rec.meta = { ...rec.meta, case: ctx.case.dir, ...(sourceUrl ? { source_url: sourceUrl } : {}) };
+      return [rec];
+    };
+
     // resolve a frame:// reference to an extracted frame (still needs a VLM to analyze)
     let resolvedRef = ctx.input;
     const fr = parseFrameRef(ctx.input);
@@ -126,12 +135,12 @@ export const seeVerb: VerbSpec = {
       // "image not found: frame://…").
       const src = ctx.case.recordById(fr.recordId)?.media?.ref;
       if (!src || !existsSync(src)) {
-        return [errorRecord("see", `cannot resolve ${ctx.input}: record ${fr.recordId} has no media on disk`)];
+        return stamp(errorRecord("see", `cannot resolve ${ctx.input}: record ${fr.recordId} has no media on disk`));
       }
       try {
         resolvedRef = await extractFrame(src, fr.second, ctx.case.mediaDir);
       } catch (e) {
-        return [errorRecord("see", `frame extraction failed for ${ctx.input}: ${(e as Error).message}`)];
+        return stamp(errorRecord("see", `frame extraction failed for ${ctx.input}: ${(e as Error).message}`));
       }
     }
 
@@ -139,41 +148,36 @@ export const seeVerb: VerbSpec = {
     // capture) so every backend — the brain LLM, the HF captioner, exec
     // detectors — reads a local file instead of choking on the URL. The record
     // keeps the origin in meta.source_url; media.ref is the local artifact.
-    let sourceUrl: string | undefined;
     if (isHttpUrl(resolvedRef)) {
       sourceUrl = resolvedRef;
       let dl;
       try {
         dl = await fetchMediaToCase(resolvedRef, ctx.case.mediaDir, { signal: ctx.signal });
       } catch (e) {
-        return [errorRecord("see", `could not fetch ${resolvedRef}: ${(e as Error).message}`)];
+        return stamp(errorRecord("see", `could not fetch ${resolvedRef}: ${(e as Error).message}`));
       }
       const kind = kindForExt(dl.ext);
       if (kind === "av") {
-        return [
+        return stamp(
           errorRecord(
             "see",
             `${resolvedRef} resolved to ${dl.ext.slice(1)} media (saved to ${dl.path}) — see analyzes still ` +
               "images; run `watch`/`listen` on it, or `see frame://<record>@<sec>` for a single frame",
           ),
-        ];
+        );
       }
       if (kind === "other") {
-        return [
+        const bodyNote = dl.ext === ".html" ? ", body is HTML" : dl.ext === ".txt" ? ", body is text" : "";
+        return stamp(
           errorRecord(
             "see",
-            `${resolvedRef} did not return an image (content-type ${dl.contentType ?? "unknown"}) — ` +
+            `${resolvedRef} did not return an image (content-type ${dl.contentType ?? "unknown"}${bodyNote}) — ` +
               "check the link (login walls and expired signed URLs commonly return HTML)",
           ),
-        ];
+        );
       }
       resolvedRef = dl.path;
     }
-    /** Stamp the case (+ URL provenance) on an outgoing see record. */
-    const stamp = (rec: OvercastRecord): OvercastRecord[] => {
-      rec.meta = { ...rec.meta, case: ctx.case.dir, ...(sourceUrl ? { source_url: sourceUrl } : {}) };
-      return [rec];
-    };
 
     // Provider resolution for see:
     //  0. a built-in backend selector — `setup provider see builtin:brain|builtin:hf`
@@ -186,7 +190,7 @@ export const seeVerb: VerbSpec = {
     const binding = providerBinding(ctx, "see");
     const builtin = binding?.module?.startsWith("builtin:") ? binding.module.slice("builtin:".length) : undefined;
     if (builtin && builtin !== "brain" && builtin !== "hf") {
-      return [errorRecord("see", `unknown built-in see backend 'builtin:${builtin}' (expected builtin:brain or builtin:hf)`)];
+      return stamp(errorRecord("see", `unknown built-in see backend 'builtin:${builtin}' (expected builtin:brain or builtin:hf)`));
     }
     const forceBrain = builtin === "brain";
     const forceHf = builtin === "hf";
@@ -212,7 +216,7 @@ export const seeVerb: VerbSpec = {
           const payload = d && Array.isArray(d.payload) ? (d.payload as unknown[]) : [];
           const task = d && typeof d.task === "string" ? d.task : "";
           if (!payload.includes("detections") && !/detect/i.test(task)) {
-            return [
+            return stamp(
               makeRecord({
                 verb: "see",
                 format: "json",
@@ -221,9 +225,8 @@ export const seeVerb: VerbSpec = {
                   "the bound see provider doesn't support --detect (its describe declares no detections); " +
                   "bind a detector, e.g. `overcast setup provider see \"exec:python3 examples/providers/detect/detect.py\"`.",
                 state: "error",
-                meta: { case: ctx.case.dir },
               }),
-            ];
+            );
           }
         }
       }
@@ -238,7 +241,7 @@ export const seeVerb: VerbSpec = {
     // below can't detect, so fail clearly instead of passing the label list to a
     // captioner (which would mistake it for the image path).
     if (ctx.opts.detect) {
-      return [
+      return stamp(
         makeRecord({
           verb: "see",
           format: "json",
@@ -247,9 +250,8 @@ export const seeVerb: VerbSpec = {
             "see --detect needs a detection provider; bind one, e.g. " +
             "`overcast setup provider see \"exec:python3 examples/providers/detect/detect.py\"` (OWLv2).",
           state: "error",
-          meta: { case: ctx.case.dir },
         }),
-      ];
+      );
     }
     // New default: describe with the BRAIN LLM when it supports images (BYO).
     // Forced on with `builtin:brain`; skipped for `builtin:hf` or when disabled
@@ -265,13 +267,13 @@ export const seeVerb: VerbSpec = {
       });
       if (res.kind === "record") return stamp(res.record);
       if (forceBrain) {
-        return [
+        return stamp(
           errorRecord(
             "see",
             `see (brain) can't run: ${res.reason}. Configure an image-capable brain (\`setup llm\`), ` +
               "or switch backends with `overcast setup provider see builtin:hf` / `setup provider see <spec>`.",
           ),
-        ];
+        );
       }
       // else: no image-capable brain — fall through to the HF captioner / placeholder.
     }
@@ -292,7 +294,7 @@ export const seeVerb: VerbSpec = {
         return stamp(rec);
       }
       if (forceHf) {
-        return [errorRecord("see", "the Hugging Face see provider script isn't available in this build")];
+        return stamp(errorRecord("see", "the Hugging Face see provider script isn't available in this build"));
       }
     }
 

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -84,10 +84,16 @@ function semverLt(a: [number, number, number], b: [number, number, number]): boo
   return false;
 }
 
-/** Parse a provider spec into a descriptor. Forms: exec:<cmd> | http(s)://… | inproc:<module>. */
+/** Parse a provider spec into a descriptor. Forms: builtin:<name> | exec:<cmd> |
+ *  http(s)://… | inproc:<module>. `builtin:<name>` selects a shipped in-process
+ *  backend (currently `see`: builtin:brain | builtin:hf); the module keeps its
+ *  `builtin:` prefix so the verb recognizes it. */
 export function parseProviderSpec(spec: string): ProviderDescriptor {
   if (spec.startsWith("http://") || spec.startsWith("https://")) {
     return { type: "http", endpoint: spec };
+  }
+  if (spec.startsWith("builtin:")) {
+    return { type: "inproc", module: spec };
   }
   if (spec.startsWith("inproc:")) {
     return { type: "inproc", module: spec.slice("inproc:".length) };

--- a/test/e2e/cases/phase2_senses.sh
+++ b/test/e2e/cases/phase2_senses.sh
@@ -61,8 +61,10 @@ assert_eq "crop.state" "ready" "$(jq -r '.state' <<<"$cout")" "crop ready"
 crop_path="$(jq -r '.media.ref' <<<"$cout")"
 if [ -f "$crop_path" ]; then ok "crop.output_exists" "crop image written"; else fail "crop.output_exists" "no crop at $crop_path"; fi
 
-# see: with NO provider configured (HF token unset), it's the placeholder.
-# (When HF_TOKEN/a binding is present, see routes to that provider instead.)
-sout="$(env -u HF_TOKEN -u HUGGING_FACE_HUB_TOKEN OVERCAST_NO_DOTENV=1 $OVERCAST see "./missing.jpg" --json --case "$casedir" 2>/dev/null)"
+# see: with NO brain, NO HF token, and no binding, it's the placeholder.
+# (A brain / HF_TOKEN / a binding routes see to that backend instead.) Both the
+# brain default (OVERCAST_SEE_BRAIN=off) and .env auto-load (OVERCAST_NO_DOTENV=1)
+# are disabled so this stays deterministic even with an ambient Cloudglue key.
+sout="$(env -u HF_TOKEN -u HUGGING_FACE_HUB_TOKEN OVERCAST_NO_DOTENV=1 OVERCAST_SEE_BRAIN=off $OVERCAST see "./missing.jpg" --json --case "$casedir" 2>/dev/null)"
 save_json "phase2_see" "$sout" >/dev/null
 assert_eq "see.state" "needs_credentials" "$(jq -r '.state' <<<"$sout")" "see placeholder state (no provider)"

--- a/test/e2e/live/cases/12_see.sh
+++ b/test/e2e/live/cases/12_see.sh
@@ -14,6 +14,23 @@ elif have_media "$VIDEO_VISUAL"; then
 fi
 [ -n "${FRAME:-}" ] && [ -f "$FRAME" ] || { skip "$C" "no image (set OC_IMAGE or OC_VIDEO_OBJECTS/VISUAL)"; exit 0; }
 
+# --- brain LLM (the DEFAULT see backend): no binding, image-capable brain
+#     describes the frame directly. Turnkey with the Cloudglue brain. ---
+if require_cred "$C.brain" CLOUDGLUE_API_KEY "skipping"; then
+  CASE=$(case_dir see_brain)   # fresh case → default profile (no see binding) → brain default
+  cond "see (default brain LLM) describes a real frame → ready record with a caption"
+  out="$(OC_TIMEOUT=180 oc "$CASE" see "$FRAME" --json)"
+  save_json "12_see_brain" "$out" >/dev/null
+  st="$(echo "$out" | jq -r '.state')"
+  prov="$(echo "$out" | jq -r '.meta.provider // empty')"
+  if [ "$st" = "ready" ]; then
+    assert_nonempty "$C.brain.caption" "$(echo "$out"|jq -r '.payload.caption')" "brain caption non-empty"
+    case "$prov" in brain:*) ok "$C.brain.provider" "routed to $prov" ;; *) fail "$C.brain.provider" "expected brain:* provider, got '$prov'" ;; esac
+  else
+    fail "$C.brain.state" "state=$st err=$(echo "$out"|jq -r '.error // empty' | head -c 80)"
+  fi
+fi
+
 # --- HF captioner (bound explicitly with an absolute path: the bun binary can't
 #     auto-resolve the shipped examples/ from its virtual FS) ---
 if require_cred "$C.hf" HF_TOKEN "skipping"; then

--- a/test/unit/see-brain.test.ts
+++ b/test/unit/see-brain.test.ts
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  brainSeeDisabled,
+  resolveBrainChoice,
+  buildSeePrompt,
+  splitDescriptionOcr,
+  mimeForImage,
+} from "../../src/providers/brain/vision.ts";
+import { parseProviderSpec } from "../../src/verbs/setup.ts";
+import { seeVerb } from "../../src/verbs/senses.ts";
+import { openCase } from "../../src/case.ts";
+import { defaultProfile } from "../../src/profile.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+test("parseProviderSpec maps builtin:<name> to an inproc selector (prefix kept)", () => {
+  assert.deepEqual(parseProviderSpec("builtin:brain"), { type: "inproc", module: "builtin:brain" });
+  assert.deepEqual(parseProviderSpec("builtin:hf"), { type: "inproc", module: "builtin:hf" });
+});
+
+test("brainSeeDisabled honors off/0/false/no; anything else = enabled", () => {
+  const saved = process.env.OVERCAST_SEE_BRAIN;
+  try {
+    for (const v of ["off", "0", "false", "no", "OFF", " No "]) {
+      process.env.OVERCAST_SEE_BRAIN = v;
+      assert.equal(brainSeeDisabled(), true, `expected disabled for ${JSON.stringify(v)}`);
+    }
+    for (const v of ["", "auto", "1", "on", "yes"]) {
+      process.env.OVERCAST_SEE_BRAIN = v;
+      assert.equal(brainSeeDisabled(), false, `expected enabled for ${JSON.stringify(v)}`);
+    }
+    delete process.env.OVERCAST_SEE_BRAIN;
+    assert.equal(brainSeeDisabled(), false);
+  } finally {
+    if (saved === undefined) delete process.env.OVERCAST_SEE_BRAIN;
+    else process.env.OVERCAST_SEE_BRAIN = saved;
+  }
+});
+
+test("resolveBrainChoice prefers an explicit profile.llm", () => {
+  const p = defaultProfile();
+  p.llm = { provider: "anthropic", model: "claude-opus-4-8" };
+  assert.deepEqual(resolveBrainChoice(p), { provider: "anthropic", model: "claude-opus-4-8" });
+});
+
+test("buildSeePrompt: base is a detailed description; --prompt focuses; --ocr adds a TEXT format", () => {
+  const base = buildSeePrompt();
+  assert.match(base, /describe this image in detail/i);
+  assert.match(buildSeePrompt("the license plate"), /the license plate/);
+  const withOcr = buildSeePrompt(undefined, true);
+  assert.match(withOcr, /DESCRIPTION:/);
+  assert.match(withOcr, /TEXT:/);
+});
+
+test("splitDescriptionOcr parses the DESCRIPTION/TEXT format and 'none'", () => {
+  assert.deepEqual(splitDescriptionOcr("DESCRIPTION: a red van\nTEXT: ACME CORP"), {
+    caption: "a red van",
+    ocr: "ACME CORP",
+  });
+  assert.deepEqual(splitDescriptionOcr("DESCRIPTION: a quiet street\nTEXT: none"), {
+    caption: "a quiet street",
+    ocr: "",
+  });
+  // no format → whole reply is the caption
+  assert.deepEqual(splitDescriptionOcr("just a plain description"), {
+    caption: "just a plain description",
+    ocr: "",
+  });
+});
+
+test("mimeForImage maps extensions (default jpeg)", () => {
+  assert.equal(mimeForImage("/x/a.png"), "image/png");
+  assert.equal(mimeForImage("/x/a.JPG"), "image/jpeg");
+  assert.equal(mimeForImage("/x/a.webp"), "image/webp");
+  assert.equal(mimeForImage("/x/a.unknown"), "image/jpeg");
+});
+
+test("see builtin:brain forced with an unresolvable brain → clean error record (no fallback)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-seebrain-"));
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    const p = defaultProfile();
+    // A provider id that no builtin catalog knows → resolution fails locally
+    // (no network), so the forced brain path returns an error record.
+    p.llm = { provider: "no-such-provider", model: "no-such-model" };
+    p.providers = { ...p.providers, see: { type: "inproc", module: "builtin:brain" } };
+    const ctx: VerbContext = { input: join(dir, "shot.jpg"), rest: [], opts: {}, case: c, profile: p };
+    const [rec] = await seeVerb.run(ctx);
+    assert.equal(rec.verb, "see");
+    assert.equal(rec.state, "error");
+    assert.match(rec.error ?? "", /brain/i);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("see rejects an unknown builtin selector", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-seebad-"));
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    const p = defaultProfile();
+    p.providers = { ...p.providers, see: { type: "inproc", module: "builtin:bogus" } };
+    const ctx: VerbContext = { input: join(dir, "shot.jpg"), rest: [], opts: {}, case: c, profile: p };
+    const [rec] = await seeVerb.run(ctx);
+    assert.equal(rec.state, "error");
+    assert.match(rec.error ?? "", /builtin:bogus/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/unit/see-brain.test.ts
+++ b/test/unit/see-brain.test.ts
@@ -76,6 +76,10 @@ test("mimeForImage maps extensions (default jpeg)", () => {
   assert.equal(mimeForImage("/x/a.png"), "image/png");
   assert.equal(mimeForImage("/x/a.JPG"), "image/jpeg");
   assert.equal(mimeForImage("/x/a.webp"), "image/webp");
+  // every image ext kindForExt admits must map to its real MIME (Bugbot: avif/tiff went out as image/jpeg)
+  assert.equal(mimeForImage("/x/a.avif"), "image/avif");
+  assert.equal(mimeForImage("/x/a.tif"), "image/tiff");
+  assert.equal(mimeForImage("/x/a.tiff"), "image/tiff");
   assert.equal(mimeForImage("/x/a.unknown"), "image/jpeg");
 });
 

--- a/test/unit/see-url.test.ts
+++ b/test/unit/see-url.test.ts
@@ -1,0 +1,147 @@
+// see with an http(s) URL: the image is fetched into the case media dir first
+// (media/fetch.ts), so every backend reads a local file — plus clear errors for
+// non-image URLs. Fully offline: a local node http server plays the remote host.
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, basename } from "node:path";
+
+import { fetchMediaToCase, kindForExt, isHttpUrl, sniffExt } from "../../src/media/fetch.ts";
+import { seeVerb } from "../../src/verbs/senses.ts";
+import { openCase } from "../../src/case.ts";
+import { defaultProfile } from "../../src/profile.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+const PNG = Buffer.concat([Buffer.from([0x89]), Buffer.from("PNG\r\n\x1a\n", "latin1"), Buffer.alloc(64)]);
+const JPG = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.alloc(64)]);
+const MP4 = Buffer.concat([Buffer.alloc(4), Buffer.from("ftypisom", "latin1"), Buffer.alloc(64)]);
+
+let dir: string;
+let server: Server;
+let base: string;
+let hits: Record<string, number>;
+
+before(async () => {
+  dir = mkdtempSync(join(tmpdir(), "oc-seeurl-"));
+  hits = {};
+  server = createServer((req, res) => {
+    const path = (req.url ?? "/").split("?")[0];
+    hits[path] = (hits[path] ?? 0) + 1;
+    if (path === "/img.png") {
+      res.writeHead(200, { "content-type": "image/png" });
+      res.end(PNG);
+    } else if (path === "/photo.jpg") {
+      // signed-URL style: extension in the path, query noise, no content-type
+      res.writeHead(200);
+      res.end(JPG);
+    } else if (path === "/noext") {
+      // no URL ext, no content-type → magic-byte sniff decides
+      res.writeHead(200);
+      res.end(PNG);
+    } else if (path === "/clip") {
+      res.writeHead(200, { "content-type": "video/mp4" });
+      res.end(MP4);
+    } else if (path === "/page") {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end("<html>login required</html>");
+    } else {
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("nope");
+    }
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const addr = server.address() as { port: number };
+  base = `http://127.0.0.1:${addr.port}`;
+});
+after(async () => {
+  await new Promise((r) => server.close(r));
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function ctx(input: string, profile = defaultProfile()): VerbContext {
+  const c = openCase(dir);
+  c.ensure();
+  return { input, rest: [], opts: {}, case: c, profile };
+}
+
+test("isHttpUrl / kindForExt / sniffExt basics", () => {
+  assert.equal(isHttpUrl("https://x.test/a.jpg"), true);
+  assert.equal(isHttpUrl("/local/a.jpg"), false);
+  assert.equal(kindForExt(".png"), "image");
+  assert.equal(kindForExt(".mp4"), "av");
+  assert.equal(kindForExt(".bin"), "other");
+  assert.equal(sniffExt(PNG), ".png");
+  assert.equal(sniffExt(MP4), ".mp4");
+});
+
+test("fetchMediaToCase: content-type → extension; artifact lands in mediaDir", async () => {
+  const media = join(dir, "media");
+  const got = await fetchMediaToCase(`${base}/img.png`, media);
+  assert.equal(got.ext, ".png");
+  assert.equal(got.contentType, "image/png");
+  assert.ok(got.path.startsWith(media));
+  assert.deepEqual(readFileSync(got.path).subarray(0, 4), PNG.subarray(0, 4));
+});
+
+test("fetchMediaToCase: URL ext survives query noise; repeat call reuses the artifact", async () => {
+  const media = join(dir, "media");
+  const url = `${base}/photo.jpg?Expires=123&Signature=abc~def`;
+  const a = await fetchMediaToCase(url, media);
+  assert.equal(a.ext, ".jpg");
+  const before = hits["/photo.jpg"];
+  const b = await fetchMediaToCase(url, media);
+  assert.equal(b.path, a.path);
+  assert.equal(hits["/photo.jpg"], before); // cache hit — no second download
+});
+
+test("fetchMediaToCase: no ext + no content-type → magic-byte sniff", async () => {
+  const got = await fetchMediaToCase(`${base}/noext`, join(dir, "media"));
+  assert.equal(got.ext, ".png");
+});
+
+test("fetchMediaToCase: HTTP error status throws with the status line", async () => {
+  await assert.rejects(fetchMediaToCase(`${base}/missing.png`, join(dir, "media")), /404/);
+});
+
+test("see with an image URL: provider receives a LOCAL path; meta.source_url keeps the origin", async () => {
+  // fake exec provider that echoes the --input path back in the payload
+  const prov = join(dir, "echo-see.sh");
+  writeFileSync(
+    prov,
+    '#!/usr/bin/env bash\nwhile [ $# -gt 0 ]; do if [ "$1" = "--input" ]; then inp="$2"; fi; shift; done\n' +
+      'echo "{\\"verb\\":\\"see\\",\\"payload\\":{\\"caption\\":\\"ok\\",\\"got\\":\\"$inp\\"},\\"state\\":\\"ready\\"}"\n',
+  );
+  chmodSync(prov, 0o755);
+  const p = defaultProfile();
+  p.providers = { ...p.providers, see: { type: "exec", run: `bash ${prov} --input {{input}}` } };
+  const url = `${base}/img.png`;
+  const [rec] = await seeVerb.run(ctx(url, p));
+  assert.equal(rec.state, "ready");
+  const got = (rec.payload as Record<string, unknown>).got as string;
+  assert.ok(!isHttpUrl(got), `provider must get a local path, got ${got}`);
+  assert.ok(basename(got).startsWith("url-"), `artifact is case media: ${got}`);
+  assert.equal(rec.meta?.source_url, url);
+});
+
+test("see with a video URL: clear error pointing at watch/frame://, no ENOENT spew", async () => {
+  const [rec] = await seeVerb.run(ctx(`${base}/clip`));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /watch/);
+  assert.doesNotMatch(rec.error ?? "", /ENOENT/);
+});
+
+test("see with an HTML URL (login wall / expired signature): clear non-image error", async () => {
+  const [rec] = await seeVerb.run(ctx(`${base}/page`));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /did not return an image/);
+  assert.match(rec.error ?? "", /text\/html/);
+});
+
+test("see with an unreachable URL: clean fetch error record", async () => {
+  const [rec] = await seeVerb.run(ctx("http://127.0.0.1:9/img.png")); // port 9: discard, nothing listens
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /could not fetch/);
+});

--- a/test/unit/see-url.test.ts
+++ b/test/unit/see-url.test.ts
@@ -51,6 +51,10 @@ before(async () => {
       // expired signed URL: .jpg path, but the body is an HTML error page
       res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
       res.end("<html>URL signature expired</html>");
+    } else if (path === "/liar.jpg") {
+      // lying Content-Type: claims image/jpeg, body is an HTML login page
+      res.writeHead(200, { "content-type": "image/jpeg" });
+      res.end("<!DOCTYPE html><html>please log in</html>");
     } else {
       res.writeHead(404, { "content-type": "text/plain" });
       res.end("nope");
@@ -151,12 +155,43 @@ test("see with an unreachable URL: clean fetch error record", async () => {
 });
 
 test("a .jpg URL whose body is HTML is NOT masked by the URL extension (Bugbot: expired signed URL)", async () => {
-  // response truth (content-type text/html) must beat the path's .jpg claim
+  // response truth (content-type text/html + HTML body) must beat the path's .jpg claim
   const got = await fetchMediaToCase(`${base}/expired.jpg?Expires=0&Signature=stale`, join(dir, "media"));
-  assert.equal(got.ext, ".bin");
+  assert.equal(got.ext, ".html");
   assert.equal(kindForExt(got.ext), "other");
   const [rec] = await seeVerb.run(ctx(`${base}/expired.jpg?Expires=0&Signature=stale`));
   assert.equal(rec.state, "error");
   assert.match(rec.error ?? "", /did not return an image/);
   assert.match(rec.error ?? "", /text\/html/);
+});
+
+test("a LYING image/jpeg Content-Type on an HTML body is vetoed by the byte sniff (Bugbot)", async () => {
+  const got = await fetchMediaToCase(`${base}/liar.jpg`, join(dir, "media"));
+  assert.equal(got.ext, ".html"); // body truth beats both the CT claim and the URL ext
+  const [rec] = await seeVerb.run(ctx(`${base}/liar.jpg`));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /did not return an image/);
+  assert.match(rec.error ?? "", /body is HTML/);
+});
+
+test("sniffExt: ISO-BMFF image brands (avif/heic) don't classify as mp4; text bodies detect", () => {
+  const bmff = (brand: string) =>
+    Buffer.concat([Buffer.alloc(4), Buffer.from(`ftyp${brand}`, "latin1"), Buffer.alloc(32)]);
+  assert.equal(sniffExt(bmff("avif")), ".avif");
+  assert.equal(sniffExt(bmff("heic")), ".heic");
+  assert.equal(sniffExt(bmff("isom")), ".mp4");
+  assert.equal(sniffExt(Buffer.from("  <!DOCTYPE html><html></html>")), ".html");
+  assert.equal(sniffExt(Buffer.from('{"error":"expired"}')), ".txt");
+});
+
+test("URL failure records still carry meta.source_url + meta.case (Bugbot)", async () => {
+  const videoUrl = `${base}/clip`;
+  const [avRec] = await seeVerb.run(ctx(videoUrl));
+  assert.equal(avRec.state, "error");
+  assert.equal(avRec.meta?.source_url, videoUrl);
+  assert.ok(avRec.meta?.case, "error record carries the case");
+  const deadUrl = "http://127.0.0.1:9/img.png";
+  const [fetchRec] = await seeVerb.run(ctx(deadUrl));
+  assert.equal(fetchRec.state, "error");
+  assert.equal(fetchRec.meta?.source_url, deadUrl);
 });

--- a/test/unit/see-url.test.ts
+++ b/test/unit/see-url.test.ts
@@ -47,6 +47,10 @@ before(async () => {
     } else if (path === "/page") {
       res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
       res.end("<html>login required</html>");
+    } else if (path === "/expired.jpg") {
+      // expired signed URL: .jpg path, but the body is an HTML error page
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end("<html>URL signature expired</html>");
     } else {
       res.writeHead(404, { "content-type": "text/plain" });
       res.end("nope");
@@ -144,4 +148,15 @@ test("see with an unreachable URL: clean fetch error record", async () => {
   const [rec] = await seeVerb.run(ctx("http://127.0.0.1:9/img.png")); // port 9: discard, nothing listens
   assert.equal(rec.state, "error");
   assert.match(rec.error ?? "", /could not fetch/);
+});
+
+test("a .jpg URL whose body is HTML is NOT masked by the URL extension (Bugbot: expired signed URL)", async () => {
+  // response truth (content-type text/html) must beat the path's .jpg claim
+  const got = await fetchMediaToCase(`${base}/expired.jpg?Expires=0&Signature=stale`, join(dir, "media"));
+  assert.equal(got.ext, ".bin");
+  assert.equal(kindForExt(got.ext), "other");
+  const [rec] = await seeVerb.run(ctx(`${base}/expired.jpg?Expires=0&Signature=stale`));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /did not return an image/);
+  assert.match(rec.error ?? "", /text\/html/);
 });

--- a/test/unit/senses.test.ts
+++ b/test/unit/senses.test.ts
@@ -52,10 +52,13 @@ test("runListen maps a speech envelope to audio.analysis (via fixture provider)"
   assert.deepEqual(segs[0].at, [0, 3]);
 });
 
-test("see is a placeholder (needs_credentials) when no HF token + no binding", async () => {
-  const saved = { a: process.env.HF_TOKEN, b: process.env.HUGGING_FACE_HUB_TOKEN };
+test("see is a placeholder (needs_credentials) when no brain + no HF token + no binding", async () => {
+  const saved = { a: process.env.HF_TOKEN, b: process.env.HUGGING_FACE_HUB_TOKEN, c: process.env.OVERCAST_SEE_BRAIN };
   delete process.env.HF_TOKEN;
   delete process.env.HUGGING_FACE_HUB_TOKEN;
+  // Disable the brain default so this is deterministic even on a machine with an
+  // ambient Cloudglue key (env or ~/.tinycloud/config.json).
+  process.env.OVERCAST_SEE_BRAIN = "off";
   try {
     const [rec] = await seeVerb.run(ctx("./suspect.jpg"));
     assert.equal(rec.verb, "see");
@@ -64,6 +67,8 @@ test("see is a placeholder (needs_credentials) when no HF token + no binding", a
   } finally {
     if (saved.a) process.env.HF_TOKEN = saved.a;
     if (saved.b) process.env.HUGGING_FACE_HUB_TOKEN = saved.b;
+    if (saved.c === undefined) delete process.env.OVERCAST_SEE_BRAIN;
+    else process.env.OVERCAST_SEE_BRAIN = saved.c;
   }
 });
 


### PR DESCRIPTION
## What

`see` now describes an image by calling the configured **brain LLM** directly
("describe this image in detail") whenever the brain accepts image input — resolving
whatever brain the profile/env already points at (BYO, never hardcoded). The classic
Hugging Face captioner stays one switch away, so the old behavior is fully retained.

**Resolution order:** explicit provider binding → **brain (new default)** → HF captioner (`HF_TOKEN`) → `needs_credentials` placeholder.

**Switch backends:**
- `overcast setup provider see builtin:hf` — force the classic HF captioner
- `overcast setup provider see builtin:brain` — force the brain path
- `OVERCAST_SEE_BRAIN=off` — ephemeral escape hatch (also keeps offline tests deterministic)

## Why

The turnkey Cloudglue brain (and most BYO brains) are image-capable, so `see` can produce a rich, investigator-flavored description out of the box with no extra provider/key — instead of the previous `needs_credentials` placeholder unless `HF_TOKEN` was set.

## How

- New `src/providers/brain/vision.ts` — resolves the brain via pi-ai (`builtinModels()` + a constructed Cloudglue provider), verifies `model.input` includes `image`, runs `completeSimple` with the image, maps to the `see` record. Shares the Cloudglue model id with the extension (single source of truth).
- `see` routing + a generic `builtin:` provider-spec selector (`senses.ts`, `setup.ts`), composed with main's `providerBinding()`.
- Docs: `CLAUDE.md` (invariants #2/#6 + verb surface — documents this as the one deliberate, opt-out bridge across the brain/sense separation), `README`, `docs/providers.md`, CLI env help, regenerated skill reference, example profiles.
- Tests: unit (`see-brain`), offline-e2e determinism guard, and a live-e2e brain case.

## Verification

- `typecheck` clean · **433 unit tests** pass · **144 offline e2e** pass · shellcheck clean · bun `--compile` binary builds & loads.
- **Live e2e on a real image** (`12_see`): `see.brain.provider → routed to brain:cloudglue` and both brain + HF captions non-empty (PASS).
- Binding order proven end-to-end via the CLI and a **headless agent** (`--mode json`): default profile → persisted record `provider=brain:cloudglue`; `builtin:hf` → `provider=hf:google/gemma-3-27b-it`.

## Note on invariant #2 (BYO LLM)

This is a deliberate, opt-out bridge across "keep brain and sense providers separate": the brain is still resolved the BYO way (never a hardcoded provider) and is one switch from the classic sense provider. `CLAUDE.md` is updated to set the bar for any future such bridge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default `see` behavior and outbound LLM calls (cost/credentials) for any image-capable brain, plus new URL fetch handling; fallbacks and opt-out env/profile switches limit blast radius.
> 
> **Overview**
> **`see` now defaults to the configured brain LLM** when that model accepts images: a direct “describe this image in detail” call via pi-ai (`src/providers/brain/vision.ts`), using whatever brain the profile/env already resolves (BYO / Cloudglue), with records tagged `meta.provider=brain:*`. Resolution order is **explicit binding → brain → HF captioner (`HF_TOKEN`) → `needs_credentials`**. Opt out with `setup provider see builtin:hf`, `builtin:brain`, or `OVERCAST_SEE_BRAIN=off`.
> 
> **http(s) image URLs** are downloaded into the case media dir first (`src/media/fetch.ts`), with `meta.source_url` on records; non-image responses (video/audio, HTML login walls, lying content-types) get explicit errors instead of hitting VLMs. **`sniffExt` is centralized** in `fetch.ts` (OSINT stdin capture reuses it).
> 
> **`builtin:brain` / `builtin:hf`** are new profile spec forms (`parseProviderSpec` in `setup.ts`). The pi extension imports **`CLOUDGLUE_MODEL_ID` from vision.ts** as the single source of truth. Docs, CLI env help, skills reference, and tests (unit + live brain `see`) are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eed3fbe4659911f18d84b4b71dacf111b3f508ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->