### PR TITLE
wall --infinite: endless repeat-to-fill monitor wall (+ grid row overlap fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,8 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `--square`), `wall` (control-room monitor wall: case videos muted + looping at
   their evidence moments — open finding > face hit > record anchor — with
   coverage badges and scan/monitor/brief freshness overlaid; `--limit`,
-  `--source`/`--since`, `--refresh`, `--theme plain|csi`, `--no-open`).
+  `--source`/`--since`, `--refresh`, `--infinite` endless repeat-to-fill wall,
+  `--theme plain|csi`, `--no-open`).
 - **OSINT** — `scan` / `capture` / `monitor` (sources: youtube / tiktok / x / web /
   lens reverse-image;
   `--since` recency; `--pull`/`--pipe` to capture+sense; `monitor --once/--every`).

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -534,11 +534,15 @@ overcast wall                                # wall the case (opens the browser)
 overcast wall --theme csi --limit 16         # bigger neon wall
 overcast wall --source youtube --since 24h   # only fresh youtube pulls
 overcast wall --refresh 60 --no-open         # re-snapshot while monitor runs
+overcast wall --infinite                     # endless wall: feeds repeat to fill the screen
 ```
 
 The wall references local media by `file://` URL (nothing is embedded), so it
 plays whatever is still on disk; missing or browser-hostile containers render
 NO SIGNAL / STILL tiles (with an ffmpeg poster frame when extractable).
+`--infinite` turns a small case into a full monitor bank: the real feeds repeat
+to cover the viewport and the grid keeps extending as it scrolls (rows that
+scroll far out of view are recycled, so it stays cheap forever).
 
 ## Command matrix
 

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -288,14 +288,14 @@ Emits `media.crop` records.
 
 ### `overcast wall`
 
-Generates a self-contained HTML wall of muted, looping video tiles — each anchored to its best evidence moment (open finding > face hit > record anchor) — overlaid with case state: sense-coverage badges, findings, per-source scan / monitor / brief freshness. Local media is referenced by file:// URL (not embedded); missing or browser-hostile media renders a NO SIGNAL / STILL tile (with an ffmpeg poster frame when extractable). Click a tile to open the media at its anchor; hover for the intel card. --no-open writes the wall and emits a record with its path instead of launching.
+Generates a self-contained HTML wall of muted, looping video tiles — each anchored to its best evidence moment (open finding > face hit > record anchor) — overlaid with case state: sense-coverage badges, findings, per-source scan / monitor / brief freshness. Local media is referenced by file:// URL (not embedded); missing or browser-hostile media renders a NO SIGNAL / STILL tile (with an ffmpeg poster frame when extractable). Click a tile to open the media at its anchor; hover for the intel card. --infinite repeats the real feeds to fill the screen and keeps extending the grid as it scrolls — an endless monitor bank even from a handful of feeds. --no-open writes the wall and emits a record with its path instead of launching.
 
 ```
 overcast wall  [options]
 
   Open a control-room monitor wall: case videos looping at their evidence moments.
 
-  Generates a self-contained HTML wall of muted, looping video tiles — each anchored to its best evidence moment (open finding > face hit > record anchor) — overlaid with case state: sense-coverage badges, findings, per-source scan / monitor / brief freshness. Local media is referenced by file:// URL (not embedded); missing or browser-hostile media renders a NO SIGNAL / STILL tile (with an ffmpeg poster frame when extractable). Click a tile to open the media at its anchor; hover for the intel card. --no-open writes the wall and emits a record with its path instead of launching.
+  Generates a self-contained HTML wall of muted, looping video tiles — each anchored to its best evidence moment (open finding > face hit > record anchor) — overlaid with case state: sense-coverage badges, findings, per-source scan / monitor / brief freshness. Local media is referenced by file:// URL (not embedded); missing or browser-hostile media renders a NO SIGNAL / STILL tile (with an ffmpeg poster frame when extractable). Click a tile to open the media at its anchor; hover for the intel card. --infinite repeats the real feeds to fill the screen and keeps extending the grid as it scrolls — an endless monitor bank even from a handful of feeds. --no-open writes the wall and emits a record with its path instead of launching.
 
 Options:
   --limit <number>       Max tiles, most evidentiary/recent first (~25 is a practical decode ceiling) (default: 12)
@@ -303,6 +303,7 @@ Options:
   --since <string>       Only media with records since (e.g. 24h, 7d, 2026-06-01)
   --export <string>      Wall HTML path (default: .overcast/media/wall.html)
   --refresh <number>     Auto-reload the wall every N seconds (restarts the feeds)
+  --infinite             Endless wall: repeat feeds to fill the screen and keep extending on scroll
   --no-open              Write the wall but don't launch it
   --theme <string>       HTML theme: plain | csi (default: plain)
   --format <string>      Output surface: json | md | txt

--- a/src/report/wall.ts
+++ b/src/report/wall.ts
@@ -61,6 +61,8 @@ export interface WallHud {
   monitor: { time: string; ageSeconds: number; newItems: number } | null;
   briefAgeSeconds: number | null;
   refreshSeconds: number | null;
+  /** endless wall: repeat feeds to fill the screen, extend the grid on scroll */
+  infinite: boolean;
 }
 
 export interface WallModel {
@@ -78,6 +80,8 @@ export interface BuildWallOptions {
   /** epoch-ms cutoff (pre-parsed via parseSince); undated tiles are kept */
   sinceCutoff?: number;
   refreshSeconds?: number;
+  /** repeat feeds to fill the screen; the wall keeps extending on scroll */
+  infinite?: boolean;
   /** injectable clock/fs for tests */
   now?: number;
   fileExists?: (path: string) => boolean;
@@ -141,6 +145,7 @@ export function buildWallModel(records: OvercastRecord[], opts: BuildWallOptions
       tilesShown: shown.length,
       openFindings: openRootFindings.length,
       refreshSeconds: opts.refreshSeconds,
+      infinite: opts.infinite,
     }),
     tiles: shown,
   };
@@ -372,6 +377,7 @@ interface HudOptions {
   tilesShown: number;
   openFindings: number;
   refreshSeconds?: number;
+  infinite?: boolean;
 }
 
 function buildHud(records: OvercastRecord[], o: HudOptions): WallHud {
@@ -423,6 +429,7 @@ function buildHud(records: OvercastRecord[], o: HudOptions): WallHud {
       : null,
     briefAgeSeconds: briefLatest ? Math.max(0, (o.now - briefLatest.t) / 1000) : null,
     refreshSeconds: o.refreshSeconds ?? null,
+    infinite: o.infinite ?? false,
   };
 }
 
@@ -501,12 +508,15 @@ export function renderWallHtml(model: WallModel, theme: HtmlTheme): string {
   const tiles = model.tiles.map((t, i) => renderTile(t, i)).join("\n");
   // sqrt grid: a wall of 16/9 tiles on a 16/9 screen self-fills the viewport
   // (5 tiles → 3-wide, 12 → 4-wide) instead of leaving one short row of minis.
-  const cols = Math.max(1, Math.min(6, Math.ceil(Math.sqrt(model.tiles.length || 1))));
+  // An infinite wall floors at 3-wide: with repeats available, one or two real
+  // feeds should read as a bank of monitors, not a pair of billboards.
+  const sqrtCols = Math.ceil(Math.sqrt(model.tiles.length || 1));
+  const cols = Math.max(1, Math.min(6, model.hud.infinite ? Math.max(3, sqrtCols) : sqrtCols));
   return `<!doctype html><html><head><meta charset="utf-8">${refreshTag}<title>${escapeHtml(title)}</title>
 <style>${WALL_BASE_CSS}
 ${csi ? CSI_SKIN : PLAIN_SKIN}</style></head><body${csi ? ' data-overcast-theme="csi"' : ""}>
 ${renderHud(model.hud)}
-<main class="wall" style="--cols:${cols}"${csi ? ' data-csi-wall="true"' : ""}>
+<main class="wall" style="--cols:${cols}"${model.hud.infinite ? ' data-infinite="true"' : ""}${csi ? ' data-csi-wall="true"' : ""}>
 ${tiles || `<div class="empty">NO FEEDS — filters matched no case videos</div>`}
 </main>
 <div class="start" id="start">▶ CLICK TO START FEEDS</div>
@@ -596,8 +606,12 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-monospace,SF
 .chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border:1px solid var(--line);border-radius:999px;color:var(--green);background:var(--bg);white-space:nowrap}
 .chip.bad{color:var(--bad)}.chip.amber{color:var(--amber)}.chip.cyan{color:var(--cyan)}.chip.magenta{color:var(--magenta)}
 .clock{margin-left:auto;color:var(--amber)}
-.wall{flex:1;overflow-y:auto;display:grid;grid-template-columns:repeat(var(--cols,4),minmax(0,1fr));gap:10px;padding:10px;align-content:start}
-.tile{position:relative;margin:0;aspect-ratio:16/9;background:#000;border:1px solid var(--line);border-radius:6px;overflow:hidden}
+.wall{flex:1;overflow-y:auto;overflow-anchor:none;display:grid;grid-template-columns:repeat(var(--cols,4),minmax(0,1fr));gap:10px;padding:10px;align-content:start}
+/* 16/9 via padding-top, NOT aspect-ratio: with a definite-height scroll grid,
+   Chrome collapses implicit rows of aspect-ratio items to a share of the
+   container (tiles overlap once the wall scrolls); %-padding resolves against
+   the track width and sizes the rows correctly. */
+.tile{position:relative;margin:0;padding-top:56.25%;background:#000;border:1px solid var(--line);border-radius:6px;overflow:hidden}
 .tile[data-open]{cursor:pointer}
 .tile video,.tile img.poster{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;background:#000}
 .tile-top{position:absolute;top:0;left:0;right:0;display:flex;gap:8px;padding:6px 8px;font-size:10px;color:var(--cyan);background:linear-gradient(180deg,rgba(0,0,0,.7),transparent)}
@@ -638,12 +652,25 @@ const PLAIN_SKIN = `:root{color-scheme:dark;--bg:#101214;--panel:#16191c;--panel
 
 // Inline player logic (no template interpolation — keep this plain JS).
 const WALL_JS = `(function(){
-var tiles = Array.prototype.slice.call(document.querySelectorAll(".tile"));
+var wall = document.querySelector(".wall");
+var infinite = !!(wall && wall.hasAttribute("data-infinite"));
 var vids = [];
 function markStalled(){ document.body.classList.add("stalled"); }
-tiles.forEach(function(tile, i){
+var io = null;
+if ("IntersectionObserver" in window) {
+  io = new IntersectionObserver(function(entries){
+    entries.forEach(function(e){
+      var v = e.target.querySelector("video");
+      if (!v || !v.src) return;
+      if (e.intersectionRatio >= 0.25) { if (!document.body.classList.contains("stalled")) v.play().catch(function(){}); }
+      else v.pause();
+    });
+  }, { threshold: [0, 0.25] });
+}
+function setupTile(tile, delay){
   var open = tile.getAttribute("data-open");
   if (open) tile.addEventListener("click", function(){ window.open(open); });
+  if (io) io.observe(tile);
   var v = tile.querySelector("video");
   if (!v) return;
   vids.push(v);
@@ -668,23 +695,18 @@ tiles.forEach(function(tile, i){
     try { v.currentTime = start; } catch (e) {}
   });
   v.addEventListener("error", function(){ tile.classList.add("err"); });
-  // staggered attach avoids a simultaneous decode burst across the grid
+  // staggered attach avoids a simultaneous decode burst across the grid.
+  // Only a real autoplay block (NotAllowedError) shows the START button — a
+  // play() aborted because the observer paused an offscreen tile is normal.
   setTimeout(function(){
     v.src = v.getAttribute("data-src");
-    v.play().catch(markStalled);
-  }, i * 150);
-});
-if ("IntersectionObserver" in window) {
-  var io = new IntersectionObserver(function(entries){
-    entries.forEach(function(e){
-      var v = e.target.querySelector("video");
-      if (!v || !v.src) return;
-      if (e.intersectionRatio >= 0.25) { if (!document.body.classList.contains("stalled")) v.play().catch(function(){}); }
-      else v.pause();
-    });
-  }, { threshold: [0, 0.25] });
-  tiles.forEach(function(t){ io.observe(t); });
+    v.play().catch(function(err){ if (err && err.name === "NotAllowedError") markStalled(); });
+  }, delay);
 }
+var tiles = Array.prototype.slice.call(document.querySelectorAll(".tile"));
+// pristine copies taken BEFORE wiring — a clone must never inherit a live src
+var templates = infinite ? tiles.map(function(t){ return t.cloneNode(true); }) : [];
+tiles.forEach(function(tile, i){ setupTile(tile, i * 150); });
 var startBtn = document.getElementById("start");
 if (startBtn) startBtn.addEventListener("click", function(){
   document.body.classList.remove("stalled");
@@ -692,4 +714,60 @@ if (startBtn) startBtn.addEventListener("click", function(){
 });
 var clock = document.getElementById("clock");
 if (clock) { var tick = function(){ clock.textContent = new Date().toLocaleTimeString(); }; tick(); setInterval(tick, 1000); }
+if (!infinite || !templates.length || !wall) return;
+// --- infinite wall: repeat the real feeds to fill the screen, keep appending
+// as the wall scrolls, and recycle rows far above the viewport so the DOM (and
+// the decoder pool) stays bounded no matter how far the operator scrolls.
+var cols = parseInt(getComputedStyle(wall).getPropertyValue("--cols"), 10) || 1;
+var cam = tiles.length, cycle = 0, cloneCount = 0;
+var chunks = []; // whole-row clone batches — removable without reflowing what follows
+var MAX_CLONES = 60;
+function makeClone(){
+  var el = templates[cycle++ % templates.length].cloneNode(true);
+  cam++; // repeats keep counting up — an endless bank of monitors, not a loop
+  var camEl = el.querySelector(".tile-top span");
+  if (camEl) camEl.textContent = "CAM " + (cam < 10 ? "0" + cam : cam);
+  return el;
+}
+function append(count){
+  var els = [];
+  for (var k = 0; k < count; k++) { var el = makeClone(); els.push(el); wall.appendChild(el); }
+  els.forEach(function(el, j){ setupTile(el, j * 150); });
+  cloneCount += count;
+  return els;
+}
+function recycle(){
+  while (chunks.length > 1 && cloneCount > MAX_CLONES) {
+    var oldest = chunks[0];
+    // only drop a chunk already well past the top of the viewport
+    if (oldest[oldest.length - 1].getBoundingClientRect().bottom > -100) break;
+    // whole rows removed → everything below shifts up by exactly this height;
+    // compensate scrollTop by hand (.wall sets overflow-anchor:none so the
+    // browser's scroll anchoring can't compensate a second time)
+    var h = chunks[1][0].offsetTop - oldest[0].offsetTop;
+    oldest.forEach(function(el){
+      var v = el.querySelector("video");
+      if (v) { v.pause(); v.removeAttribute("src"); try { v.load(); } catch (e) {} var vi = vids.indexOf(v); if (vi >= 0) vids.splice(vi, 1); }
+      if (io) io.unobserve(el);
+      if (el.parentNode) el.parentNode.removeChild(el);
+    });
+    chunks.shift();
+    cloneCount -= oldest.length;
+    wall.scrollTop -= h;
+  }
+}
+function appendChunk(){ chunks.push(append(cols * 2)); recycle(); }
+// complete the last real row once (never recycled) so every later chunk starts
+// row-aligned — removing one must not reflow the rows that remain
+var pad = (cols - (tiles.length % cols)) % cols;
+if (pad) append(pad);
+function fill(){
+  var guard = 0;
+  while (wall.scrollHeight < wall.clientHeight * 1.5 && guard++ < 24) appendChunk();
+}
+fill();
+window.addEventListener("resize", fill);
+wall.addEventListener("scroll", function(){
+  if (wall.scrollTop + wall.clientHeight * 2 >= wall.scrollHeight) appendChunk();
+});
 })();`;

--- a/src/verbs/wall.ts
+++ b/src/verbs/wall.ts
@@ -34,8 +34,10 @@ export const wallVerb: VerbSpec = {
     "sense-coverage badges, findings, per-source scan / monitor / brief freshness. Local media is " +
     "referenced by file:// URL (not embedded); missing or browser-hostile media renders a NO " +
     "SIGNAL / STILL tile (with an ffmpeg poster frame when extractable). Click a tile to open the " +
-    "media at its anchor; hover for the intel card. --no-open writes the wall and emits a record " +
-    "with its path instead of launching.",
+    "media at its anchor; hover for the intel card. --infinite repeats the real feeds to fill the " +
+    "screen and keeps extending the grid as it scrolls — an endless monitor bank even from a " +
+    "handful of feeds. --no-open writes the wall and emits a record with its path instead of " +
+    "launching.",
   args: [],
   flags: [
     { name: "limit", summary: "Max tiles, most evidentiary/recent first (~25 is a practical decode ceiling)", type: "number", default: 12 },
@@ -43,6 +45,7 @@ export const wallVerb: VerbSpec = {
     { name: "since", summary: "Only media with records since (e.g. 24h, 7d, 2026-06-01)", type: "string" },
     { name: "export", summary: "Wall HTML path", type: "string", default: WALL_DEFAULT_EXPORT },
     { name: "refresh", summary: "Auto-reload the wall every N seconds (restarts the feeds)", type: "number" },
+    { name: "infinite", summary: "Endless wall: repeat feeds to fill the screen and keep extending on scroll", type: "boolean" },
     { name: "no-open", summary: "Write the wall but don't launch it", type: "boolean" },
     { name: "theme", summary: "HTML theme: plain | csi", type: "string", choices: ["plain", "csi"], default: "plain" },
     { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },
@@ -71,6 +74,7 @@ export const wallVerb: VerbSpec = {
       if (!Number.isFinite(n) || n <= 0) return [err(`invalid --refresh: ${ctx.opts.refresh} (expected seconds > 0)`)];
       refresh = Math.round(n);
     }
+    const infinite = ctx.opts.infinite === true;
     const source = ctx.opts.source != null ? String(ctx.opts.source).trim() : undefined;
     if (ctx.opts.source != null && !source) {
       return [err("--source requires a value (youtube | tiktok | web | local)")];
@@ -86,6 +90,7 @@ export const wallVerb: VerbSpec = {
       source,
       sinceCutoff,
       refreshSeconds: refresh,
+      infinite,
     });
 
     // nothing to wall → transient pending guidance, no artifact (brief precedent)
@@ -136,6 +141,7 @@ export const wallVerb: VerbSpec = {
           stills: model.tiles.filter((t) => t.mode === "still").length,
           open_findings: model.hud.openFindings,
           refresh: refresh ?? null,
+          infinite,
           tile_refs: model.tiles.map((t) => ({
             ref: t.ref,
             at: t.anchor.at,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -86,7 +86,8 @@ self-contained HTML evidence page `clip_db_evidence.html`) · `30_read`
 exports with real visual targets and matches) · `32_headless_visualization`
 (headless agent `--mode json` export trace, default CSI HTML theme) · `33_wall`
 (control-room wall over real watch/face evidence: finding-anchored loop window,
-FND chip, CSI markers) · `40_profiles` · `50_piping` (jq / chaining) · `60_dist`
+FND chip, CSI markers, plus the `--infinite` endless wall from the same case) ·
+`40_profiles` · `50_piping` (jq / chaining) · `60_dist`
 (binary as artifact) · `70_headless` (agent `--mode json` event stream + `-p`
 tool use + watch/persist).
 
@@ -94,7 +95,7 @@ The offline suite also covers setup management (`phase4_setup`): `case setup
 plan`, apply with target/note/source, `show`, `edit`, saved `.overcast/setup.json`,
 and exclusion of setup history records from memory — plus the control-room wall
 (`phase6_wall`): empty-case pending guidance, then a themed wall over seeded
-case media.
+case media and the `--infinite` endless-wall record + page marker.
 
 ### Output
 

--- a/test/e2e/cases/phase6_wall.sh
+++ b/test/e2e/cases/phase6_wall.sh
@@ -65,3 +65,13 @@ if grep -q 'data-start=' "$whtml" && grep -q 'data-src="file://' "$whtml"; then
 else
   fail "wall.tile_loop" "no looping video tile in wall html"
 fi
+
+# --infinite: endless wall marker in the record and the page
+iout="$($OVERCAST wall --infinite --no-open --json --case "$casedir" 2>/dev/null)"
+save_json "phase6_wall_infinite" "$iout" >/dev/null
+assert_eq "wall.infinite_payload" "true" "$(jq -r '.payload.infinite' <<<"$iout")" "--infinite recorded in payload"
+if grep -q 'data-infinite="true"' "$(jq -r '.payload.viewer' <<<"$iout")"; then
+  ok "wall.infinite_marker" "wall html carries data-infinite"
+else
+  fail "wall.infinite_marker" "data-infinite missing from --infinite wall html"
+fi

--- a/test/e2e/live/cases/33_wall.sh
+++ b/test/e2e/live/cases/33_wall.sh
@@ -71,3 +71,25 @@ if grep -q 'FND 1' "$WHTML"; then
 else
   fail "$C.fnd_chip" "FND chip missing"
 fi
+
+cond "the same case renders as an endless wall (--infinite) without changing the evidence model"
+IHTML="$SMOKE_DIR/33_wall_infinite.html"
+wi="$(oc "$CASE" wall --infinite --export "$IHTML" --theme csi --no-open --json)"
+save_json "33_wall_infinite" "$wi" >/dev/null
+assert_eq "$C.inf.state" "ready" "$(echo "$wi" | jq -r '.state')" "infinite wall ready"
+assert_eq "$C.inf.flag" "true" "$(echo "$wi" | jq -r '.payload.infinite')" "payload carries infinite=true"
+assert_eq "$C.plain_flag" "false" "$(echo "$w" | jq -r '.payload.infinite')" "normal wall records infinite=false"
+# --infinite is presentation-only: same tiles, same finding-anchored top tile
+assert_eq "$C.inf.tiles" "$tiles" "$(echo "$wi" | jq -r '.payload.tiles')" "same tile model as the normal wall"
+assert_eq "$C.inf.anchor" "4" "$(echo "$wi" | jq -r '.payload.tile_refs[0].at')" "finding anchor survives --infinite"
+if [ -f "$IHTML" ] && grep -q 'data-infinite="true"' "$IHTML"; then
+  ok "$C.inf.marker" "endless wall marker present: $IHTML"
+else
+  fail "$C.inf.marker" "data-infinite missing from infinite wall html"
+fi
+# 1-2 real feeds floor at a 3-wide monitor bank (clone rows fill the screen)
+if grep -q -- '--cols:3' "$IHTML"; then
+  ok "$C.inf.cols" "3-wide monitor-bank floor applied"
+else
+  fail "$C.inf.cols" "expected --cols:3 floor on a small infinite wall"
+fi

--- a/test/unit/wall.test.ts
+++ b/test/unit/wall.test.ts
@@ -289,6 +289,31 @@ test("csi render: theme markers, tiles with loop windows, NO SIGNAL, refresh met
   assert.ok(!noRefresh.includes("http-equiv"), "refresh meta present without --refresh");
 });
 
+test("--infinite: hud flag, data-infinite marker, and the 3-col floor for tiny walls", () => {
+  const on = buildWallModel([watchRec(A)], opts({ infinite: true }));
+  assert.equal(on.hud.infinite, true);
+  const html = renderWallHtml(on, "csi");
+  assert.match(html, /data-infinite="true"/);
+  // one real feed still lays out as a monitor bank, not a full-width billboard
+  assert.match(html, /--cols:3/);
+  // the page script carries the repeat/extend machinery + manual scroll
+  // compensation (native anchoring is disabled so it can't double-apply)
+  assert.match(html, /appendChunk/);
+  assert.match(html, /overflow-anchor:none/);
+
+  const off = buildWallModel([watchRec(A)], opts());
+  assert.equal(off.hud.infinite, false);
+  const offHtml = renderWallHtml(off, "plain");
+  // the attribute form specifically — the shared player script always mentions
+  // the data-infinite name, but only --infinite sets it on the grid
+  assert.ok(!offHtml.includes('data-infinite="true"'), "default wall must not carry the infinite marker");
+  assert.match(offHtml, /--cols:1/); // sqrt grid unchanged when off
+
+  // the floor never shrinks a wall the sqrt rule already made wider
+  const many = Array.from({ length: 12 }, (_, i) => watchRec(`/media/m${i}.mp4`));
+  assert.match(renderWallHtml(buildWallModel(many, opts({ infinite: true })), "plain"), /--cols:4/);
+});
+
 test("plain render: same grid + player script, no csi marker", () => {
   const model = buildWallModel([watchRec(A)], opts());
   const html = renderWallHtml(model, "plain");
@@ -360,6 +385,18 @@ test("wall escapes a media path with quotes/specials (no HTML/attr breakage)", a
   } finally {
     rmSync(nastyDir, { recursive: true, force: true });
   }
+});
+
+test("wall --infinite threads to the record payload and the page", async () => {
+  const vc = ctx(dir, { "no-open": true, infinite: true });
+  const [rec] = await wallVerb.run(vc);
+  assert.equal(rec.state, "ready");
+  const p = rec.payload as Record<string, unknown>;
+  assert.equal(p.infinite, true);
+  assert.match(readFileSync(p.viewer as string, "utf8"), /data-infinite="true"/);
+
+  const [plain] = await wallVerb.run(ctx(dir, { "no-open": true }));
+  assert.equal((plain.payload as Record<string, unknown>).infinite, false);
 });
 
 test("empty case → transient pending record, no wall.html written", async () => {


### PR DESCRIPTION
## What

New `wall` option: `overcast wall --infinite` turns a small case into an endless control-room monitor bank — the real feeds repeat to fill the screen, and the grid keeps extending as it scrolls.

- **One flag, three surfaces**: `--infinite` is declared once on the wall verb spec; CLI, pi tool, and skill reference pick it up. `infinite` lands in the record payload/hud and the page marks the grid `data-infinite="true"`.
- **3-column floor when infinite**: one or two real feeds lay out as a bank of monitors instead of full-width billboards (the sqrt grid is unchanged otherwise, and the floor never shrinks a wider wall).
- **Bounded forever**: clones are stamped from pristine templates captured before wiring (never inherit a live `src`), appended in whole-row chunks on scroll, and rows far above the viewport are recycled — pause, detach src, remove, manual `scrollTop` compensation (`overflow-anchor:none` so the browser can't compensate a second time). CAM numbers keep counting up; presentation only, the evidence model is untouched.

## Bugs found while verifying (headless Chrome over CDP)

1. **Latent stock-wall layout bug**: `aspect-ratio:16/9` grid tiles inside a definite-height scroll container make Chrome collapse the implicit rows to a share of the container height — tiles overlap whenever the wall scrolls (reproducible on main with `--limit 25`). Fixed with the grid-safe `padding-top:56.25%` ratio hack; rows now size to the tiles in both modes.
2. **Spurious “CLICK TO START FEEDS”**: a `play()` aborted because the IntersectionObserver paused an offscreen tile was treated like an autoplay block. Only a genuine `NotAllowedError` shows the START button now.

## Verification

- `npm run typecheck` clean; **539/539** unit tests (new: hud flag, marker, 3-col floor + no-shrink, payload threading, off-by-default).
- Offline e2e **164/164** (`phase6_wall` now asserts the `--infinite` record + page marker).
- Live e2e (`33_wall`) **22/22**: the same real-footage case renders both ways and asserts `--infinite` is presentation-only — identical tile model, finding-anchored 4–9s loop window survives.
- Behavioral check in headless Chrome via CDP: from 2 feeds, load fills a 1600×900 viewport (15 tiles, 3-wide); 120 hard scrolls-to-bottom extended to CAM 1413 while the DOM stayed bounded at 57 tiles; visible tiles play, offscreen tiles pause, no stall flag.

Docs: flows §17, CLAUDE.md verb map, regenerated skill reference, e2e READMEs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inspect-only HTML/JS presentation for the wall verb; no auth, data, or evidence-model changes, with unit and e2e coverage for the new flag and scroll behavior.
> 
> **Overview**
> Adds **`overcast wall --infinite`**, a presentation-only mode that turns a small set of real feeds into a full monitor bank: feeds **repeat to fill the viewport**, the grid **grows on scroll**, and rows far above the viewport are **recycled** so DOM and decoders stay bounded. The flag is on the wall verb spec (CLI/tool/skills); **`infinite`** is recorded in the wall payload/HUD and the page sets **`data-infinite="true"`** on the grid.
> 
> When infinite is on, column layout **floors at 3-wide** for one–two feeds (sqrt grid unchanged otherwise). Client script clones from pristine tile templates, increments CAM labels, uses **`overflow-anchor: none`** with manual **`scrollTop`** compensation on recycle, and only treats **`NotAllowedError`** as needing “CLICK TO START FEEDS” (not observer-driven pauses).
> 
> **Layout fix for all walls:** tile 16:9 uses **`padding-top: 56.25%`** instead of **`aspect-ratio`**, so Chrome no longer collapses implicit grid rows and overlapping tiles when the wall scrolls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c055975400eb8ea5466ee21458cdd3d1b10505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->