### PR TITLE
Release v0.0.6 (+ docs audit)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.5"
+    "version": "0.0.6"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": {
     "name": "kdr"
   },

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ the CLI, or pull them straight from this repo with the harness-agnostic
 [`skills`](https://github.com/vercel-labs/skills) installer:
 
 ```bash
-overcast skills install               # menu: pick a harness, writes the SKILL.md files
-overcast skills install --global      # → ~/.claude/skills/overcast
-npx skills add kdr/overcast           # vercel-labs/skills; pulls skills from this repo
+overcast skills install                        # copies the shipped skills into ~/.claude/skills
+overcast skills install --harness claude-code  # explicit harness (claude-code is the only target today)
+npx skills add kdr/overcast                    # vercel-labs/skills; pulls skills from this repo
 ```
 
 **Claude Code plugin** (slash commands + skills as one package):
@@ -226,6 +226,10 @@ surface + env vars.)
 | `cluster` | local face DB: ingest faces → group into people (assign-or-create), `identify`, `recluster`, `label`, HTML `view` |
 | `similar` | cross-modal semantic search over a local CLIP (`basic-clip`) index — `search` by text, `match` by image, video moments included |
 | `enhance` | denoise / normalize / upscale via bundled ffmpeg, or a bound model provider |
+
+**Inspect** — look at the evidence
+| verb | does |
+|---|---|
 | `view` | open media in a scrubbable local HTML player (timeline markers, spectrogram) |
 | `crop` | materialize face/object detections as cropped image records with provenance |
 | `wall` | control-room monitor wall — every case video muted + looping its best evidence moment, case state overlaid |

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -67,10 +67,11 @@ Provider classes:
   frame extraction, detection-crop extraction, and viewer support.
 - **opt-in model/media providers** for `see` / `listen` / `enhance` — Hugging
   Face, fal.ai, ElevenLabs, and local detector/Whisper examples.
-- **visual DBs** — uv-managed OpenCV RANSAC image matching and DeepFace
-  face matching, selected by `image-ransac` / `deepface-local` index types.
+- **visual DBs** — uv-managed OpenCV RANSAC image matching, DeepFace face
+  matching, the `cluster` face DB, and CLIP semantic search, selected by the
+  `image-ransac` / `deepface-local` / `face-cluster` / `basic-clip` index types.
 - **source providers** — external discovery and URL fetching (youtube / tiktok /
-  x / web).
+  x / web / lens reverse-image).
 - **case memory** over primary evidence for `ask` / `brief` / `case memory` —
   `local-grep` by default, or qmd for lifecycle-managed semantic local search.
 
@@ -544,6 +545,32 @@ NO SIGNAL / STILL tiles (with an ffmpeg poster frame when extractable).
 to cover the viewport and the grid keeps extending as it scrolls (rows that
 scroll far out of view are recycled, so it stays cheap forever).
 
+### 18. Copycat sweep (x + lens reverse-image)
+
+Find re-uploads of an original clip across X and Google Lens, confirm with the
+geometry-gated `image` layer, and keep a standing watch. The packaged version of
+this funnel is the `overcast-copycat-sweep` skill.
+
+```bash
+overcast index create originals --type image-ransac --local --json
+overcast image add ./title-card.png --index <index-id> --json   # fingerprint distinctive frames
+overcast source add "x:video:<topic keywords>" --json
+overcast source add lens:./original-frame.png --json          # reverse image search
+overcast scan --since 7d --limit 10 --json                    # triage first: Apify bills per result
+overcast capture <scan-hit-id> --json
+overcast image match <capture-id> --index <index-id> --draw --json
+overcast finding create "copycat: <because-clause>" --ref <image-match-id> --confidence high --json
+overcast brief --export copycats.html
+overcast monitor --every 1d --json
+```
+
+`x:` refs target X/Twitter: `x:@handle` (author), `x:<advanced query>`, and the
+media-targeted `x:video:<q>` / `x:image:<q>`. `lens:<image url|path>` runs a
+Google Lens reverse image search via Apify. `image match` gates on
+planar-projection (homography) validity — read the inlier count + ratio and
+eyeball the `--draw` overlay before calling a rip; keyword overlap alone is not
+a match.
+
 ## Command matrix
 
 | Command | Group | Main output | Default backing | Override | Role |
@@ -552,6 +579,9 @@ scroll far out of view are recycled, so it stays cheap forever).
 | `listen` | sense | `audio.analysis` | tinycloud | `setup provider listen "exec:…"` | Speech/audio analysis |
 | `see` | sense | `image.analysis` | brain LLM (image-capable) → HF captioner if token → placeholder | `setup provider see "exec:…"` / `builtin:hf` | Image/frame understanding |
 | `face` | sense | `face.analysis` | tinycloud | custom exec / pinned tinycloud | Face detect/match/index search |
+| `image` | sense | `image.match` | local OpenCV RANSAC (`image-ransac` index) | `OC_VISUAL_DB_PY` | Image/frame geometric matching |
+| `cluster` | sense | `cluster` | local DeepFace (`face-cluster` index) | `OC_VISUAL_DB_PY` | Persistent local face DB |
+| `similar` | sense | `similar.match` | local CLIP (`basic-clip` index) | `OC_VISUAL_DB_PY` | Cross-modal semantic search |
 | `enhance` | sense | `media.enhanced` | local ffmpeg | `setup provider enhance "exec:…"` | Improve media |
 | `view` | inspect | `view` | local HTML viewer / OS open | none | Inspect media/anchors |
 | `crop` | inspect | `media.crop` | local ffmpeg | none | Materialize detection crops |
@@ -596,8 +626,8 @@ overcast provider init listen --profile recon --json
 overcast doctor --profile recon --json
 ```
 
-Presets: `cloudglue` · `hf` · `fal` · `elevenlabs` · `owl-local` · `deepface-local`. Single
-choices use `--verb <watch|listen|see|face|enhance> --choice <id>`.
+Presets: `cloudglue` · `hf` · `fal` · `elevenlabs` · `owl-local` · `deepface-local` ·
+`basic-clip`. Single choices use `--verb <watch|listen|see|face|enhance> --choice <id>`.
 
 ### Pin tinycloud
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -74,6 +74,7 @@ Catalog presets:
 | `elevenlabs` | `listen:elevenlabs`, `enhance:elevenlabs` |
 | `owl-local` | `see:owl-local` |
 | `deepface-local` | `face:deepface-local` |
+| `basic-clip` | `similar:basic-clip` |
 
 Common environment:
 
@@ -366,7 +367,7 @@ sample 8 frames.
 - [`examples/providers/fal/{see,enhance}.sh`](../examples/providers/fal/) — fal.ai Florence-2, ESRGAN image enhance, and DeepFilterNet3 audio enhance.
 - [`examples/providers/detect/detect.py`](../examples/providers/detect/detect.py) — OWLv2 open-vocabulary `see` object detector (OWLv2 / Grounding DINO), image + video.
 - [`examples/providers/tinycloud/see.sh`](../examples/providers/tinycloud/see.sh) — Cloudglue tinycloud image `see`/`extract` provider (describe + on-screen text; boxless `--prompt`/`--detect` facts; tinycloud ≥ 0.3.7).
-- [`examples/providers/visual-db/{image_match,face_match,clip_match}.py`](../examples/providers/visual-db/) — local image RANSAC, DeepFace, and CLIP (basic-clip) matching for visual DB indexes.
+- [`examples/providers/visual-db/{image_match,face_match,clip_match,face_cluster}.py`](../examples/providers/visual-db/) — local image RANSAC, DeepFace, CLIP (basic-clip), and face-cluster DB matching for visual DB indexes.
 - [`examples/providers/sources/{youtube,tiktok,x,web,lens}.sh`](../examples/providers/sources/) — yt-dlp + Apify (tiktok/x/lens) + web-search (Tavily/Brave) + Google Lens reverse-image source providers.
 
 ## Source providers (built-in types)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "Apache-2.0",
   "author": "kdr",

--- a/skills/overcast-copycat-sweep/SKILL.md
+++ b/skills/overcast-copycat-sweep/SKILL.md
@@ -95,8 +95,10 @@ must still say so explicitly ("checked, found none").
 
 Copycats retitle and re-caption, so search topic keywords and confirm with the
 visual/transcript layers: burned-in subtitles and translated dubs defeat text
-matching but not `image` frame matching or `face --match`. Face and image
-similarity scores are 0–100, not 0–1. A repost/quote is a share, not a rip —
+matching but not `image` frame matching or `face --match`. Face similarity is
+0–100 (percent), not 0–1; `image match` reports a RANSAC inlier count (unbounded
+integer) plus an inlier ratio (0–1) — there is no 0–100 image similarity. A
+repost/quote is a share, not a rip —
 confirm the account re-uploaded the media natively (check `x:video:from:<handle>`).
 Apify-backed sources bill per result — prefer few, broad queries over many
 narrow ones.

--- a/skills/overcast-media-bug-triage/SKILL.md
+++ b/skills/overcast-media-bug-triage/SKILL.md
@@ -19,7 +19,7 @@ overcast case init --json
 overcast case setup --yes --json
 overcast watch ./screen-recording.mp4 --json
 overcast listen ./screen-recording.mp4 --describe --json
-overcast see frame://<record-id>@<timestamp> --ocr --json
+overcast see frame://<record-id>@<seconds> --ocr --json
 overcast note "observed UI state or suspected failure" --ref <record-id> --at <time-range> --json
 overcast ask "summarize the bug with reproduction steps and citations" --json
 overcast brief --export ./bug-brief.md --json

--- a/skills/overcast-visual-target-search/SKILL.md
+++ b/skills/overcast-visual-target-search/SKILL.md
@@ -24,7 +24,8 @@ overcast ask "where does the reference person appear, with timestamps and confid
 overcast brief --export ./visual-search.md --json
 ```
 
-For an object or open-vocabulary target:
+For an object or open-vocabulary target (`--detect` needs a bound detection
+provider first, e.g. `overcast setup provider see "exec:python3 examples/providers/detect/detect.py"`):
 
 ```bash
 overcast see ./clip.mp4 --detect "red backpack" --json
@@ -37,7 +38,7 @@ For logos, landmarks, or near-duplicate visual references:
 ```bash
 overcast index create refs --type image-ransac --local --json
 overcast index add ./reference-logo.png --to <index-id> --json
-overcast image ./clip.mp4 --index <index-id> --json
+overcast image match ./clip.mp4 --index <index-id> --json
 ```
 
 ## Output

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -41,7 +41,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `ask` — Natural-language query over the case memory; answers with record.id + media.at citations.
 - `brief` — Synthesize the case records into a report (timeline + findings); --export to md/html.
 - `case` — Inspect/manage the current case: init | setup | status | info | records | memory | clear.
-- `setup` — Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|show).
+- `setup` — Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|memory|show).
 - `provider` — Run provider setup/init hooks, or list/describe bound providers (provider setup|init|list|describe).
 - `doctor` — Preflight: check pi version, ffmpeg/ffprobe, Cloudglue creds, tinycloud, provider bindings.
 - `skills` — Generate shipped overcast skills + reference from the registry, or install into a harness.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -72,7 +72,6 @@ Options:
   --ocr                  Extract on-image text
   --detect <string>      Comma list of target objects to locate (bind the detect provider for bounding boxes)
   --prompt <string>      Focus the description
-  --embed                Persist a visual embedding (query seed)
 ```
 
 Emits `image.analysis` records.
@@ -299,7 +298,7 @@ overcast wall  [options]
 
 Options:
   --limit <number>       Max tiles, most evidentiary/recent first (~25 is a practical decode ceiling) (default: 12)
-  --source <string>      Only media from this source type (youtube | tiktok | web | local)
+  --source <string>      Only media from this source type (youtube | tiktok | x | web | lens | local)
   --since <string>       Only media with records since (e.g. 24h, 7d, 2026-06-01)
   --export <string>      Wall HTML path (default: .overcast/media/wall.html)
   --refresh <number>     Auto-reload the wall every N seconds (restarts the feeds)
@@ -384,7 +383,7 @@ Options:
   --once                 Single diff pass then exit
   --every <string>       Continuous loop cadence (e.g. 15m, 6h)
   --brief                Summarize the new batch into a brief record
-  --alert <string>       Mirror new records to a sink (stdout | <file>)
+  --alert <string>       Mirror new records to a file sink (they already stream to stdout)
   --format <string>      json | md | txt
   --json                 Shorthand for --format json
 ```
@@ -665,7 +664,7 @@ Configure and persist profiles under ~/.overcast/profiles/. `setup provider <ver
 ```
 overcast setup [action] [a] [b] [options]
 
-  Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|show).
+  Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|memory|show).
 
   Configure and persist profiles under ~/.overcast/profiles/. `setup provider <verb> <spec>` binds a verb to a provider (exec:<cmd> | http(s)://… | inproc:<module>). `setup llm <provider> <model>` sets the brain. `setup memory <local-grep|qmd>` configures case search. `setup show` prints the active profile.
 
@@ -701,7 +700,7 @@ Options:
   --profile <string>     Profile name to write/read (default: active/default)
   --verb <string>        provider setup: verb to configure
   --choice <string>      provider setup: catalog choice id
-  --preset <string>      provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local)
+  --preset <string>      provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local|basic-clip)
   --yes                  provider setup apply: confirm profile changes
   --json                 JSON output
   --format <string>      json | md | txt

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -444,7 +444,7 @@ overcast case init --json
 overcast case setup --yes --json
 overcast watch ./screen-recording.mp4 --json
 overcast listen ./screen-recording.mp4 --describe --json
-overcast see frame://<record-id>@<timestamp> --ocr --json
+overcast see frame://<record-id>@<seconds> --ocr --json
 overcast note "observed UI state or suspected failure" --ref <record-id> --at <time-range> --json
 overcast ask "summarize the bug with reproduction steps and citations" --json
 overcast brief --export ./bug-brief.md --json
@@ -559,7 +559,8 @@ overcast ask "where does the reference person appear, with timestamps and confid
 overcast brief --export ./visual-search.md --json
 \`\`\`
 
-For an object or open-vocabulary target:
+For an object or open-vocabulary target (\`--detect\` needs a bound detection
+provider first, e.g. \`overcast setup provider see "exec:python3 examples/providers/detect/detect.py"\`):
 
 \`\`\`bash
 overcast see ./clip.mp4 --detect "red backpack" --json
@@ -572,7 +573,7 @@ For logos, landmarks, or near-duplicate visual references:
 \`\`\`bash
 overcast index create refs --type image-ransac --local --json
 overcast index add ./reference-logo.png --to <index-id> --json
-overcast image ./clip.mp4 --index <index-id> --json
+overcast image match ./clip.mp4 --index <index-id> --json
 \`\`\`
 
 ## Output
@@ -689,8 +690,10 @@ must still say so explicitly ("checked, found none").
 
 Copycats retitle and re-caption, so search topic keywords and confirm with the
 visual/transcript layers: burned-in subtitles and translated dubs defeat text
-matching but not \`image\` frame matching or \`face --match\`. Face and image
-similarity scores are 0–100, not 0–1. A repost/quote is a share, not a rip —
+matching but not \`image\` frame matching or \`face --match\`. Face similarity is
+0–100 (percent), not 0–1; \`image match\` reports a RANSAC inlier count (unbounded
+integer) plus an inlier ratio (0–1) — there is no 0–100 image similarity. A
+repost/quote is a share, not a rip —
 confirm the account re-uploaded the media natively (check \`x:video:from:<handle>\`).
 Apify-backed sources bill per result — prefer few, broad queries over many
 narrow ones.

--- a/src/state/target.ts
+++ b/src/state/target.ts
@@ -1,6 +1,6 @@
 // target = the standing scope (what scan/monitor look for), persisted to
 // .overcast/target.json. A target is a name, a free-text prompt, or a reference
-// image/clip (image targets route through `see --embed` for a visual seed).
+// image/clip (image targets are matched via `face --match` / local visual indexes).
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { randomBytes } from "node:crypto";
@@ -11,8 +11,6 @@ export interface TargetEntry {
   id: string;
   kind: "name" | "prompt" | "image";
   value: string;
-  /** for image targets, the visual-seed record id (from see --embed) */
-  seed?: string;
   created: string;
 }
 

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -1072,7 +1072,7 @@ export const monitorVerb: VerbSpec = {
     { name: "once", summary: "Single diff pass then exit", type: "boolean" },
     { name: "every", summary: "Continuous loop cadence (e.g. 15m, 6h)", type: "string" },
     { name: "brief", summary: "Summarize the new batch into a brief record", type: "boolean" },
-    { name: "alert", summary: "Mirror new records to a sink (stdout | <file>)", type: "string" },
+    { name: "alert", summary: "Mirror new records to a file sink (they already stream to stdout)", type: "string" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -114,7 +114,6 @@ export const seeVerb: VerbSpec = {
     { name: "ocr", summary: "Extract on-image text", type: "boolean" },
     { name: "detect", summary: "Comma list of target objects to locate (bind the detect provider for bounding boxes)", type: "string" },
     { name: "prompt", summary: "Focus the description", type: "string" },
-    { name: "embed", summary: "Persist a visual embedding (query seed)", type: "boolean" },
   ],
   outputKind: "image.analysis",
   providerKey: "see",

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -226,7 +226,7 @@ function effectiveProviders(profile: Profile): Record<string, Record<string, unk
 export const setupVerb: VerbSpec = {
   name: "setup",
   group: "config",
-  summary: "Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|show).",
+  summary: "Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|memory|show).",
   description:
     "Configure and persist profiles under ~/.overcast/profiles/. `setup provider <verb> <spec>` binds a " +
     "verb to a provider (exec:<cmd> | http(s)://… | inproc:<module>). `setup llm <provider> <model>` sets " +
@@ -316,7 +316,7 @@ export const providerVerb: VerbSpec = {
     { name: "profile", summary: "Profile name to write/read (default: active/default)", type: "string" },
     { name: "verb", summary: "provider setup: verb to configure", type: "string" },
     { name: "choice", summary: "provider setup: catalog choice id", type: "string" },
-    { name: "preset", summary: "provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local)", type: "string" },
+    { name: "preset", summary: "provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local|basic-clip)", type: "string" },
     { name: "yes", summary: "provider setup apply: confirm profile changes", type: "boolean" },
     { name: "json", summary: "JSON output", type: "boolean" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },

--- a/src/verbs/wall.ts
+++ b/src/verbs/wall.ts
@@ -41,7 +41,7 @@ export const wallVerb: VerbSpec = {
   args: [],
   flags: [
     { name: "limit", summary: "Max tiles, most evidentiary/recent first (~25 is a practical decode ceiling)", type: "number", default: 12 },
-    { name: "source", summary: "Only media from this source type (youtube | tiktok | web | local)", type: "string" },
+    { name: "source", summary: "Only media from this source type (youtube | tiktok | x | web | lens | local)", type: "string" },
     { name: "since", summary: "Only media with records since (e.g. 24h, 7d, 2026-06-01)", type: "string" },
     { name: "export", summary: "Wall HTML path", type: "string", default: WALL_DEFAULT_EXPORT },
     { name: "refresh", summary: "Auto-reload the wall every N seconds (restarts the feeds)", type: "number" },
@@ -77,7 +77,7 @@ export const wallVerb: VerbSpec = {
     const infinite = ctx.opts.infinite === true;
     const source = ctx.opts.source != null ? String(ctx.opts.source).trim() : undefined;
     if (ctx.opts.source != null && !source) {
-      return [err("--source requires a value (youtube | tiktok | web | local)")];
+      return [err("--source requires a value (youtube | tiktok | x | web | lens | local)")];
     }
     const rawExport = ctx.opts.export != null ? String(ctx.opts.export) : WALL_DEFAULT_EXPORT;
     const htmlPath = rawExport === WALL_DEFAULT_EXPORT ? join(ctx.case.mediaDir, "wall.html") : resolve(rawExport);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.1.
 
-export const OVERCAST_VERSION = "0.0.5";
+export const OVERCAST_VERSION = "0.0.6";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.1";

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -68,7 +68,9 @@ bash test/e2e/live/run.sh 10 11 70   # just watch, listen, headless
 `00_cli` (version/commands/help + all env-var docs + doctor) · `10_watch` ·
 `11_listen` (Cloudglue + ElevenLabs) · `12_see` (HF + fal + Cloudglue tinycloud
 see/extract ≥ 0.3.7 + local OWLv2) ·
-`13_enhance_view` · `20_sources` (Tavily/Apify/yt-dlp) · `21_pipeline`
+`13_enhance_view` · `14_face` (real tinycloud face detect + `--match`) ·
+`15_crop` (materialize real detections as JPEGs) · `20_sources`
+(Tavily/Apify/yt-dlp) · `21_pipeline`
 (source→capture→sense) · `26_x_copycat` (x keyword text search + user-scoped
 video capture from the CDN + headless agent x sweep + headless
 overcast-copycat-sweep skill invocation with brief HTML export) ·
@@ -81,7 +83,11 @@ unrelated clip, showcase a brief with the embedded match overlay) ·
 (local basic-clip CLIP DB with real media: fixtures derived from real videos,
 caption-driven queries, all four cross-modal modes — text×video, image×video,
 image×image, text×image — a headless-agent `similar search` leg, and a
-self-contained HTML evidence page `clip_db_evidence.html`) · `30_read`
+self-contained HTML evidence page `clip_db_evidence.html`) · `17_face_cluster`
+(local face-cluster DB with real media: wizard-provisioned index, `cluster add`
+ingest → assign-or-create, `recluster`, held-out `identify`, gallery `view`) ·
+`25_case_setup` (real-media setup save/edit; setup history stays
+operational-only) · `30_read`
 (ask/brief over real records) · `31_visualization` (CSI status/brief/records
 exports with real visual targets and matches) · `32_headless_visualization`
 (headless agent `--mode json` export trace, default CSI HTML theme) · `33_wall`


### PR DESCRIPTION
Preps the v0.0.6 patch release and lands a full documentation audit of CLAUDE.md, README, skills, reference docs, and per-verb CLI help against the verb registry (`overcast commands --json`) and the actual implementations.

## Docs audit fixes

**Registry / CLI help (source of truth for generated skills):**
- `see`: removed the phantom `--embed` flag — declared in help but never read by the implementation (`overcast see img.jpg --embed` silently did nothing). Also scrubbed the stale `see --embed` comments and the dead `TargetEntry.seed` field in `src/state/target.ts`.
- `provider --preset` help: added missing `basic-clip` to the preset enum.
- `wall --source` help + error: added missing `x` and `lens` source types.
- `setup` summary: added the implemented-but-unlisted `memory` subcommand.
- `monitor --alert` help: clarified it's a file sink (records already stream to stdout).

**README:**
- Fixed the `skills install` block: there is no interactive menu and no `--global` flag; it copies all shipped skills into `~/.claude/skills` (`--harness claude-code` is the only target).
- Split `view` / `crop` / `wall` out of the **Senses** table into an **Inspect** table, matching the registry's grouping.

**docs/flows.md:**
- Visual-DB provider-class bullet now covers `face-cluster` + `basic-clip`; sources bullet now covers `lens`.
- Command matrix gains the missing `image`, `cluster`, `similar` rows.
- New flow **18. Copycat sweep (x + lens reverse-image)** covering the `x:` refs (`x:@handle`, `x:video:<q>`, `x:image:<q>`), `lens:` reverse-image search, and the geometry-gated `image match` layer.
- Preset list gains `basic-clip`.

**docs/providers.md:** preset table gains `basic-clip` → `similar:basic-clip`; visual-db samples list gains `face_cluster.py`.

**Skills (fixed in `src/skill-gen.ts` templates, regenerated):**
- visual-target-search: `overcast image ./clip.mp4 …` → `overcast image match …` (the bare form errors); noted that `see --detect` requires binding a detection provider first.
- copycat-sweep: corrected the score-scale caveat — face similarity is 0–100 (percent), but `image match` reports a RANSAC inlier count + 0–1 inlier ratio (there is no 0–100 image similarity).
- media-bug-triage: `frame://<record-id>@<timestamp>` → `@<seconds>` (the parser only accepts numeric seconds).

**test/e2e/README.md:** live-case list gains the missing `14_face`, `15_crop`, `17_face_cluster`, `25_case_setup`.

Confirmed accurate during the audit (no changes needed): CLAUDE.md/AGENTS.md, all env vars, pinned versions (pi 0.80.1, tinycloud ≥0.3.4 / rec 0.3.7, node ≥22), source-ref grammars, slash-command list, record contract, provider transports, and per-verb flag coverage for the other 24 verbs.

## Release v0.0.6

`npm version 0.0.6 --no-git-tag-version` + `sync-version` — package.json, package-lock.json, `src/version.ts`, and both `.claude-plugin/*.json` bumped in lockstep (`sync-version.mjs --check` passes).

## Verification

- `npm run typecheck` clean
- `npm test`: 542/542 unit tests pass
- `npm run test:e2e` (offline fixtures): 164/164 pass
- `skills generate` is byte-stable against the committed skills

## After merge (per RELEASING.md)

```bash
git checkout main && git pull
git tag v0.0.6 && git push origin v0.0.6
```

The tag push triggers `release.yml`: npm publish via OIDC trusted publishing + cross-compiled bun binaries attached to the GitHub Release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and help text; the only runtime-adjacent change is removing the documented-but-unimplemented `see --embed` flag and stale target `seed` field, which should not affect working flows.
> 
> **Overview**
> **Release v0.0.6** — version bumped in lockstep across `package.json`, lockfile, `src/version.ts`, and Claude plugin manifests.
> 
> **Docs & skills audit** so README, `docs/flows.md`, `docs/providers.md`, generated skills, and `verbs.md` match the registry and real behavior:
> 
> - **README**: Corrects `skills install` (no menu/`--global`; copies to `~/.claude/skills`). Splits **Inspect** (`view` / `crop` / `wall`) out of the Senses table.
> - **`docs/flows.md`**: Documents visual DB index types (`face-cluster`, `basic-clip`), `lens` sources, command-matrix rows for `image` / `cluster` / `similar`, the **copycat sweep** flow (X + Lens + geometry-gated `image match`), and the `basic-clip` preset.
> - **Skills** (templates in `src/skill-gen.ts` + committed outputs): `image match` subcommand, `frame://@<seconds>`, detection-provider note for `see --detect`, and copycat score-scale caveats (face 0–100 vs RANSAC inliers/ratio).
> 
> **CLI help / registry fixes** in verb specs: drops undocumented **`see --embed`** from help and removes the unused `TargetEntry.seed` field; **`setup`** summary lists **`memory`**; **`wall --source`** and **`provider --preset`** include **`x`**, **`lens`**, and **`basic-clip`**; **`monitor --alert`** clarified as file-only (stdout already streams records).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405dc379a2724a00c0d2664feba06f1399f91cb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->