### PR TITLE
Update website launch CTAs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ FAL_KEY=
 # ElevenLabs — `listen` (Scribe STT) + `enhance` (voice isolation). https://elevenlabs.io
 ELEVENLABS_API_KEY=
 
+# ── Website analytics (Vite / PostHog) ─────────────────────────────────────
+# Public PostHog project key for the website. Vite only exposes VITE_* names.
+# Copy these into site/.env or your hosting provider's site env settings.
+VITE_PUBLIC_POSTHOG_KEY=
+VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # ── OSINT sources (scan/capture/monitor) ───────────────────────────────────
 # Web search: Tavily preferred, Brave as fallback (set either).
 TAVILY_API_KEY=

--- a/site/.env.example
+++ b/site/.env.example
@@ -1,0 +1,2 @@
+VITE_PUBLIC_POSTHOG_KEY=
+VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "site",
+  "name": "overcast-site",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "site",
+      "name": "overcast-site",
       "version": "0.0.0",
       "dependencies": {
+        "posthog-js": "^1.396.5",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
       },
@@ -482,6 +483,21 @@
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.6.tgz",
+      "integrity": "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.392.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.392.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.0.tgz",
+      "integrity": "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
@@ -1090,6 +1106,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
@@ -1116,6 +1139,17 @@
         }
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1131,6 +1165,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -1164,6 +1207,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1597,6 +1646,38 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.396.5",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.396.5.tgz",
+      "integrity": "sha512-huW/8R151I08i/tkOaAv3Q/yWVqzhqPj3SxyhpgNLB/xysaNeV1ibp6DHzbRWV5D7FRM48Zg6Icxsm4q0irEtg==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/core": "^1.39.5",
+        "@posthog/types": "^1.392.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
+      "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -1812,6 +1893,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "posthog-js": "^1.396.5",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,7 +1,33 @@
 import { useEffect, useState } from 'react'
+import { captureEvent } from './analytics'
 
 const TAGLINE = 'video · recon · osint'
 const GLYPHS = '█▓▒░/\\<>|_'
+const NPM_URL = 'https://www.npmjs.com/package/@kdrrr/overcast'
+const SOURCE_URL = 'https://github.com/kdr/overcast'
+const INSTALL_COMMANDS = [
+  {
+    id: 'cli',
+    label: 'CLI',
+    command: 'npm install -g @kdrrr/overcast',
+  },
+  {
+    id: 'claude-plugin',
+    label: 'Claude plugin',
+    command: '/plugin marketplace add kdr/overcast\n/plugin install overcast@overcast',
+  },
+  {
+    id: 'agent-skills',
+    label: 'Agent skills',
+    command: 'npx skills add kdr/overcast',
+  },
+]
+const FEATURE_POINTS = [
+  'video, audio, image, face, and similarity senses',
+  'OSINT scan, capture, monitor, and case memory',
+  'one verb registry across CLI, plugin, and skills',
+]
+type InstallCommand = (typeof INSTALL_COMMANDS)[number]
 // keep in step with the 6s cycle + 88–95% burst window in index.css
 const CYCLE_MS = 6000
 const BURST_AT_MS = 5280
@@ -62,11 +88,91 @@ function useGlitchedTagline() {
   return text
 }
 
+function InstallTabs() {
+  const [selected, setSelected] = useState<InstallCommand>(INSTALL_COMMANDS[0])
+  const [copied, setCopied] = useState(false)
+
+  async function copyCommand() {
+    if ('clipboard' in navigator) {
+      await navigator.clipboard.writeText(selected.command)
+    } else {
+      const textarea = document.createElement('textarea')
+      textarea.value = selected.command
+      textarea.setAttribute('readonly', '')
+      textarea.style.position = 'fixed'
+      textarea.style.opacity = '0'
+      document.body.append(textarea)
+      textarea.select()
+      document.execCommand('copy')
+      textarea.remove()
+    }
+    setCopied(true)
+    captureEvent('install_command_copied', {
+      command: selected.command,
+      method: selected.id,
+    })
+    window.setTimeout(() => setCopied(false), 1800)
+  }
+
+  function selectMethod(item: InstallCommand) {
+    setSelected(item)
+    setCopied(false)
+    captureEvent('install_method_selected', { method: item.id })
+  }
+
+  return (
+    <section className="border-2 border-ink bg-cream shadow-[6px_6px_0_0_var(--color-ink)]">
+      <div
+        role="tablist"
+        aria-label="Ways to use overcast"
+        className="grid grid-cols-3 border-b-2 border-ink"
+      >
+        {INSTALL_COMMANDS.map((item) => {
+          const isSelected = item.id === selected.id
+          return (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={isSelected}
+              aria-controls="install-panel"
+              id={`install-tab-${item.id}`}
+              onClick={() => selectMethod(item)}
+              className={`min-h-12 border-r-2 border-ink px-2 py-2 text-center text-[0.65rem] font-bold tracking-[0.16em] uppercase last:border-r-0 focus-visible:outline-3 focus-visible:outline-offset-[-3px] focus-visible:outline-ink sm:text-xs ${
+                isSelected ? 'bg-butter text-ink' : 'bg-white/55 text-ink/60 hover:bg-white'
+              }`}
+            >
+              {item.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <button
+        type="button"
+        id="install-panel"
+        role="tabpanel"
+        aria-labelledby={`install-tab-${selected.id}`}
+        onClick={() => void copyCommand()}
+        className="group flex min-h-24 w-full items-center justify-between gap-4 px-4 py-4 text-left transition hover:bg-white/55 focus-visible:outline-3 focus-visible:outline-offset-[-6px] focus-visible:outline-ink sm:px-5"
+        aria-label={`${selected.label}: copy ${selected.command}`}
+      >
+        <code className="min-w-0 whitespace-pre-wrap break-all text-sm text-ink sm:text-base">
+          {selected.command}
+        </code>
+        <span className="shrink-0 bg-ink px-3 py-1.5 text-[0.65rem] font-bold tracking-[0.16em] text-cream uppercase">
+          {copied ? 'copied' : 'copy'}
+        </span>
+      </button>
+    </section>
+  )
+}
+
 export default function App() {
   const tagline = useGlitchedTagline()
 
   return (
-    <main className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden bg-cream px-6 py-16 text-center font-mono text-ink">
+    <main className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden bg-cream px-5 py-10 text-center font-mono text-ink sm:px-6 sm:py-16">
       <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="blob blob-mint blob-drift-a -top-[25%] -left-[20%] h-[75vmax] w-[75vmax]" />
         <div className="blob blob-sky blob-drift-b top-[-10%] right-[-25%] h-[65vmax] w-[65vmax]" />
@@ -79,13 +185,13 @@ export default function App() {
         </div>
       </div>
 
-      <div className="relative flex w-full flex-col items-center gap-6 sm:gap-8">
+      <div className="relative flex w-full flex-col items-center gap-5 sm:gap-7">
         <img
           src="/logo.svg"
           alt="overcast — a suited figure with a CRT-TV head showing a watching eye, and a mounted CCTV camera"
           width={1254}
           height={1254}
-          className="glitch-logo w-[clamp(240px,38vw,420px)]"
+          className="glitch-logo w-[clamp(210px,34vw,360px)]"
         />
 
         <h1
@@ -108,11 +214,43 @@ export default function App() {
           Senses + OSINT reach for any agent.
         </p>
 
-        <div className="mt-2 flex -rotate-2 items-center gap-2 rounded-full border-2 border-ink bg-butter px-6 py-2.5 shadow-[5px_5px_0_0_var(--color-ink)]">
-          <span className="text-sm font-semibold sm:text-base">&gt; coming soon</span>
-          <span aria-hidden className="animate-blink font-bold">
-            ▮
-          </span>
+        <ul className="grid max-w-2xl gap-2 text-left text-xs font-semibold text-ink/70 sm:grid-cols-3 sm:text-sm">
+          {FEATURE_POINTS.map((point) => (
+            <li key={point} className="flex gap-2">
+              <span aria-hidden className="text-ink">
+                &gt;
+              </span>
+              <span>{point}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-1 flex w-full max-w-2xl flex-col items-stretch gap-5 text-left">
+          <InstallTabs />
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <a
+              href={NPM_URL}
+              onClick={() => captureEvent('cta_clicked', { target: 'npm' })}
+              className="-rotate-1 border-2 border-ink bg-[#cb3837] px-5 py-3 text-center text-sm font-bold text-white shadow-[5px_5px_0_0_var(--color-ink)] transition hover:-translate-y-0.5 hover:shadow-[7px_7px_0_0_var(--color-ink)] focus-visible:outline-3 focus-visible:outline-offset-4 focus-visible:outline-ink"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {'<npm>'}
+            </a>
+            <a
+              href={SOURCE_URL}
+              onClick={() => captureEvent('cta_clicked', { target: 'source' })}
+              className="rotate-1 border-2 border-ink bg-ink px-5 py-3 text-center text-sm font-bold text-white shadow-[5px_5px_0_0_var(--color-ink)] transition hover:-translate-y-0.5 hover:shadow-[7px_7px_0_0_var(--color-ink)] focus-visible:outline-3 focus-visible:outline-offset-4 focus-visible:outline-ink"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {'<github>'}
+            </a>
+          </div>
+
+          <p className="sr-only" aria-live="polite">
+            Copy buttons copy installation commands to the clipboard.
+          </p>
         </div>
       </div>
     </main>

--- a/site/src/analytics.ts
+++ b/site/src/analytics.ts
@@ -1,0 +1,19 @@
+import posthog from 'posthog-js'
+
+const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY
+const POSTHOG_HOST = import.meta.env.VITE_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com'
+
+export function initAnalytics() {
+  if (!POSTHOG_KEY) return
+
+  posthog.init(POSTHOG_KEY, {
+    api_host: POSTHOG_HOST,
+    capture_pageview: true,
+    person_profiles: 'identified_only',
+  })
+}
+
+export function captureEvent(name: string, properties?: Record<string, unknown>) {
+  if (!POSTHOG_KEY) return
+  posthog.capture(name, properties)
+}

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { initAnalytics } from './analytics.ts'
 import './index.css'
 import App from './App.tsx'
+
+initAnalytics()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary

- replace the website coming-soon state with launch CTAs for npm and GitHub
- add a tabbed install panel for CLI, Claude plugin, and agent skills setup
- initialize PostHog analytics behind Vite env vars and document placeholders

## Validation

- npm run build
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-site UI and optional client analytics only; no backend or auth changes, and analytics is a no-op without env keys.
> 
> **Overview**
> Replaces the marketing site **coming soon** state with a launch experience: feature bullets, **npm** and **GitHub** CTAs, and a tabbed **install** panel (CLI, Claude plugin, agent skills) with one-click copy and clipboard fallback.
> 
> Adds **PostHog** via `posthog-js`, initialized at app boot when `VITE_PUBLIC_POSTHOG_KEY` is set; tracks install tab selection, command copy, and CTA clicks. Documents `VITE_PUBLIC_POSTHOG_*` in root `.env.example` and new `site/.env.example`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f35cf9d9bf8f24c7c66d63ed5a42d5509977a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->