### PR TITLE
Analyst-grade briefs, status, and proactive findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,14 +129,27 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `youtube:playlist:<id>` or a URL; `tiktok:@user`, `tiktok:#tag`; `x:@handle`,
   `x:<advanced query>`, `x:video:<q>` / `x:image:<q>` (media targeting); `web:<q>`;
   `lens:<image url|path>` (Google Lens reverse image search via Apify).
-- **State** — `target` / `source` manage standing scope; `note` records human
-  observations (anchored via `--ref`/`--at`/`--tag`/`--confidence`); `finding`
-  (create/list/accept/dismiss) holds manual + setup-automated findings;
-  `prebrief` stands up name+target+source in one shot.
+- **State** — `target` / `source` manage standing scope; a target is a *line of
+  investigation* (`add --question`, `close <id> --as answered|dead-end --note`,
+  `reopen`; closed lines stop seeding scans). `note` records human observations
+  (anchored via `--ref`/`--at`/`--tag`/`--confidence`; the `thread:<tgt_id>` tag
+  narrates a line for the brief/status thread cards). `finding`
+  (create/list/accept/dismiss) holds manual + *suggested* findings: score/text
+  triggers (face ≥75, image RANSAC, similar ≥85, cluster ≥70, target-phrase
+  matches) emit `status:"suggested"` leads that stay OUT of ask/brief evidence
+  until reviewed — `finding list --state triage` queues them, `accept` promotes a
+  lead to evidence, `dismiss` rejects it (never re-fires). Mode is
+  `setup.findings` (`suggest` default | `review` legacy | `off`), thresholds via
+  `case setup --findings-threshold`. `prebrief` stands up name+target+source in
+  one shot.
 - **Read** — `ask` (cited retrieval over case memory; `--deep`/`--memory qmd` for
   semantic local search; `--index <id>` answers over a media-descriptions index,
-  `--probe` for moment search), `brief` (timeline/findings report, `--export`
-  md/html, `--theme plain|csi`).
+  `--probe` for moment search), `brief` — **short by default**: verdict + goal
+  status + key findings + lines of investigation (per-target threads with stage +
+  activity sparkline) + triage queue + coverage gaps + a compact record trail;
+  `--full` appends the verbatim record dump (audit), `--export` md/html,
+  `--theme plain|csi`. `/debrief` (prompt) drives the analyst loop: triage leads →
+  narrate each thread → close resolved lines → refresh `tldr` → export.
 - **Case** — `case init | setup | status | info | records | memory | clear`.
   `case status`/`records`/`brief` HTML `--export` takes `--theme plain|csi`
   (direct CLI defaults to `plain`; agent/TUI `.html` exports default to `csi`).
@@ -154,8 +167,8 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
 - **Base verbs from pi** (don't reimplement): `read write edit bash grep find ls`.
 
 Slash commands (TUI): `/target /source /index /case /prebrief /view /wall /setup
-/provider /finding` (extension commands) and `/ask /brief` (prompt templates in
-`prompts/`), plus pi built-ins (`/model /tree /session /resume`).
+/provider /finding` (extension commands) and `/ask /brief /debrief` (prompt
+templates in `prompts/`), plus pi built-ins (`/model /tree /session /resume`).
 
 ## Case model & memory
 
@@ -170,7 +183,8 @@ Case memory is **evidence-only**. `ask` / `brief` read primary evidence
 bound memory providers — `local-grep` (always on) and optional `qmd` (semantic;
 `setup memory qmd`, then rebuild before querying). Read/meta and operational
 records (`ask brief case setup doctor provider skills index target source
-prebrief wall`, finding review-rows, dismissed findings, cluster DB
+prebrief wall`, finding review-rows, dismissed **and suggested** findings (a
+suggested lead is quarantined until `finding accept` promotes it), cluster DB
 reads/maintenance `list/show/view/label/recluster`) are excluded even when they
 match the query. `face`/`see`/`image`/`similar`/`cluster` detections index only
 compact summaries / counts / moments / matched refs — raw boxes, thumbnails,

--- a/README.md
+++ b/README.md
@@ -189,15 +189,27 @@ A **case is just a directory** with a `.overcast/` store — switch cases with
 
 Use the three report surfaces for different jobs:
 
-- `brief` answers "what does the evidence say?" It reports over the same
-  evidence-only boundary as case memory, so setup/read/meta records are excluded.
+- `brief` answers "what does the evidence say?" **Short by default**: it leads
+  with the verdict, key findings (with visual proof), the **lines of
+  investigation** (per-target threads with a stage + activity sparkline), the
+  triage queue of suggested leads, and coverage gaps — then a compact record
+  trail. `--full` appends the verbatim per-record timeline (the audit dump). It
+  reports over the same evidence-only boundary as case memory, so setup/read/meta
+  records — and un-accepted **suggested** findings — are excluded.
 - `case records` answers "what exactly happened?" It is the append-only audit log
   and includes operational records such as setup, target/source changes, index
   work, asks, briefs, and status checks.
-- `case status` answers "where is this case right now?" It summarizes setup
-  health, targets, sources, indexes, memory/index state, store counts, artifacts,
-  and match visualizations when available. It is a dashboard, not evidence for
-  later memory or briefs.
+- `case status` answers "where is this case right now?" It's a **mission board**:
+  a goal headline + per-target threads on a stage ladder
+  (cold → collecting → leads → corroborated → answered/dead-end), a per-source
+  coverage funnel, scan/monitor/brief freshness, and a **triage** queue of
+  suggested findings — with setup health, store counts, and match visualizations
+  below. It is a dashboard, not evidence for later memory or briefs.
+
+Run the **`/debrief`** prompt to drive the analyst loop over these surfaces:
+triage the suggested leads (`finding accept`/`dismiss`), write one
+`thread:<target-id>` note narrating each line of investigation, close resolved
+lines, refresh the `tldr` note, then export the brief.
 
 Direct CLI HTML exports default to the compatible `plain` theme unless
 `--theme csi` is set. Agent/TUI tool calls default `.html` exports to `csi` for
@@ -241,16 +253,17 @@ surface + env vars.)
 | `capture` | fetch a URL / scan-hit / local path into the case |
 | `monitor` | scan on a loop, diff the seen-set, pipe new items into a sense (`--once` / `--every`) |
 | `index` | index media into searchable corpora: remote media/entities/face indexes, plus local `image-ransac`, `deepface-local`, and `basic-clip` DBs |
-| `target` / `source` / `note` | manage the standing scope, where to look, and human-authored observations |
-| `finding` | create and review findings (`create` / `list` / `accept` / `dismiss`) — manual + setup-automated |
+| `target` | a **line of investigation**: `add --question`, `list`, `close <id> --as answered\|dead-end --note`, `reopen` — closed lines stop seeding scans |
+| `source` / `note` | where to look, and human-authored observations |
+| `finding` | manual + **auto-suggested** findings (`create` / `list` / `accept` / `dismiss`). Score triggers (face/image/similar/cluster match) + target text hits auto-emit `suggested` leads via a hook on every verb; `finding list --state triage` queues them, `accept` promotes a lead to evidence, `dismiss` blocks re-suggestion. Leads are quarantined from ask/brief until accepted |
 | `prebrief` | stand up a case (name + target + source) in one shot |
 
 **Read** — synthesize the case
 | verb | does |
 |---|---|
 | `ask` | natural-language query over case memory → answer with `record.id` + `media.at` citations; `--deep` uses configured semantic memory such as qmd; `--index <id>` answers over a media-descriptions index (`--probe` for moment search) |
-| `brief` | timeline / findings report; `--export` to md/html |
-| `case` | inspect/manage the case: `init` / `setup` / `info` / `records` / `memory` (`memory get <id> --field <name> --offset/--limit` pages a large record field in full) |
+| `brief` | analyst report — **short by default** (verdict / key findings / lines of investigation / triage / coverage / compact trail), `--full` for the verbatim timeline; `--export` to md/html |
+| `case` | inspect/manage the case: `init` / `setup` / `status` (mission board) / `info` / `records` / `memory` / `clear` (`memory get <id> --field <name> --offset/--limit` pages a large record field in full) |
 
 **Config / SDK / dist** — `setup` (bind providers + brain LLM), `provider`
 (init/list/describe), `doctor` (preflight), `skills` (generate/install).
@@ -276,7 +289,7 @@ immediately; use `--no-index` to save the setup without starting remote ingest.
 ```bash
 overcast case setup plan --target "@pier9" --memory local-grep --source "web:pier 9" --index "media:media" --json
 overcast case setup --name "dock-incident" --target "@pier9" --memory local-grep --source "web:pier 9" --yes --json
-overcast case setup edit --provider "listen:elevenlabs,see:owl-local" --auto-sense "watch,listen" --auto-index-new --findings review --yes --json
+overcast case setup edit --provider "listen:elevenlabs,see:owl-local" --auto-sense "watch,listen" --auto-index-new --findings suggest --yes --json
 overcast case setup show --json
 overcast case setup edit --target "new subject" --source "youtube:@channel" --yes --json
 ```
@@ -336,13 +349,21 @@ overcast case setup edit \
   --provider-indexable "listen,see" \
   --auto-sense "watch,listen" \
   --auto-index-new \
-  --findings review \
+  --findings suggest \
   --yes --json
 
 overcast monitor --once --json          # new media follows the setup automation policy
-overcast finding list --json            # review automated target matches
-overcast finding dismiss <finding-id> --json
+overcast finding list --state triage --json   # queue auto-suggested leads (open + suggested)
+overcast finding accept <finding-id> --json    # promote a lead into ask/brief evidence
+overcast finding dismiss <finding-id> --json   # reject a lead (never re-suggested)
 ```
+
+Findings default to `--findings suggest` (score/text triggers auto-emit
+`suggested` leads on every verb; tune the score floors with
+`case setup --findings-threshold face=75,similar=85,cluster=70,image_inliers=1`).
+`--findings review` is the legacy text-only mode; `--findings off` disables it.
+`finding list` alone shows only `open` findings — pass `--state triage` (or
+`--state suggested`) to see the auto-suggested leads.
 
 Use `overcast case setup edit --no-auto-index-new --yes --json` to turn off
 automatic indexing later without clearing the rest of the case automation

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -34,8 +34,9 @@ Provider configuration has **two levels**:
 - **Case provider policy** lives in `.overcast/setup.json` and records which
   provider choices a case expects, which provider outputs are eligible for local
   memory/indexing, which senses run automatically on newly captured media,
-  whether new media is auto-indexed, and whether automated target matches become
-  reviewable findings.
+  whether new media is auto-indexed, and how findings auto-suggest — a persist
+  hook fires on every verb and emits `suggested` leads from score triggers plus
+  target text matches (default `suggest` mode), quarantined until accepted.
 
 Runtime execution always follows the **active profile binding**. Case setup
 stores choice/policy metadata and can clear a built-in such as `enhance:ffmpeg`,
@@ -55,9 +56,16 @@ overcast case setup edit \
   --provider-indexable "listen,see" \
   --auto-sense "watch,listen" \
   --auto-index-new \
-  --findings review \
+  --findings suggest \
   --yes --json
 ```
+
+Findings **auto-suggest** by default (`--findings suggest`): a persist hook on
+every evidence verb emits `status:"suggested"` findings from score triggers
+(face ≥75, image RANSAC ≥1 inlier, similar ≥85, cluster ≥70) and non-image
+target text matches, quarantined until you `finding accept` them. Tune the floors
+with `case setup --findings-threshold face=75,similar=85,cluster=70,image_inliers=1`;
+`--findings review` is the legacy text-only mode and `off` disables it.
 
 Provider classes:
 
@@ -149,13 +157,13 @@ Eligible fields when allowed by the signal filter:
 | `scan` | title, snippet, url, source, published | — |
 | `capture` | title, snippet, text, path, source, kind | — |
 | `enhance` | summary, path, ops, output | — |
-| `finding` | root findings with `text` + `status` | review-rows, dismissed, list envelopes |
+| `finding` | root findings with `text` + `status` | review-rows, suggested, dismissed, list envelopes |
 
 Excluded from memory and briefs: prior read/meta output (`ask`, `brief`,
 `case`); setup/operational output (`setup`, `doctor`, `provider`, `skills`,
 `index`, `target`, `source`, `prebrief`); finding review-rows, finding-command
-errors, `finding list` envelopes, and dismissed root findings (still auditable in
-records/logs).
+errors, `finding list` envelopes, and `suggested` (excluded until accepted) or
+dismissed root findings (still auditable in records/logs).
 
 Raw detection payloads are intentionally not searchable. Use exact record reads
 (`case memory get <id>`) or `crop <record-id>` for boxes/images.
@@ -167,10 +175,15 @@ Raw detection payloads are intentionally not searchable. Use exact record reads
   `setup memory qmd` (or `case setup --memory qmd`) and
   `case memory index rebuild --memory qmd`.
 - **Local memory passages:** `case memory search "..."` returns snippets.
-- **Briefs:** `brief` reports over the same evidence boundary.
-- **Case status:** `case status` is a current-state dashboard: setup health,
-  targets, sources, indexes, memory/index state, store counts, artifacts, and
-  match visualizations when available.
+- **Briefs:** `brief` reports over the same evidence boundary — short by default
+  (verdict → goal status → key findings → lines of investigation → triage →
+  coverage → compact record trail); `--full` appends the verbatim per-record
+  timeline.
+- **Case status:** `case status` is a **mission board**: the goal headline, each
+  target as a line of investigation on a stage ladder
+  (cold→collecting→leads→corroborated→answered/dead-end), a coverage funnel,
+  freshness, and the triage queue — with setup health, store counts, and match
+  visualizations below.
 - **Case records:** `case records` is the append-only audit log. It includes
   operational/read/meta records that are intentionally excluded from memory and
   briefs, so use it for trace, provenance, and debugging.
@@ -215,8 +228,8 @@ should not be used to create visual DBs; create them explicitly with
 binary media, embeddings, frame samples, or visualization images.
 
 In short: open `brief` when you want the evidence narrative, `case status` when
-you want the live case dashboard, and `case records` when you need the full
-history of what the system and user did.
+you want the live mission board (goal, target threads, coverage, triage), and
+`case records` when you need the full history of what the system and user did.
 
 Direct CLI HTML exports default to `plain` for compatibility. Agent/TUI tool
 calls default `.html` exports to the `csi` visualization theme when the verb
@@ -243,7 +256,7 @@ overcast case setup edit \
   --provider-indexable "listen,see" \
   --auto-sense "watch,listen" \
   --auto-index-new \
-  --findings review \
+  --findings suggest \
   --yes --json
 ```
 
@@ -251,7 +264,8 @@ overcast case setup edit \
 2. Run init hooks + `doctor` to surface missing credentials or local deps.
 3. Per case, record the expected provider choices with `case setup --provider`.
 4. Mark which outputs are memory/index eligible (`--provider-indexable`).
-5. Choose whether scans/monitors auto-sense, auto-index, and create findings.
+5. Choose whether scans/monitors auto-sense and auto-index; findings auto-suggest
+   on every evidence verb (`--findings suggest`, the default).
 
 ### 2. First-run case setup wizard
 
@@ -274,7 +288,7 @@ overcast case setup \
   --provider "see:owl-local" \
   --provider-indexable "see" \
   --auto-sense "watch,see" \
-  --findings review \
+  --findings suggest \
   --yes
 overcast case setup status
 overcast scan --local
@@ -296,7 +310,7 @@ overcast watch ./clip.mp4
 overcast note "rear plate is missing" --ref <watch-record-id> --at 12-18 --tag vehicle
 overcast ask "What happened in the clip?"
 overcast view <watch-record-id>
-overcast brief --export report.md
+overcast brief --export report.md        # short verdict-led brief; add --full for the verbatim timeline
 ```
 
 ### 4. Local visual DB: logos, faces, and semantic (CLIP) search
@@ -370,12 +384,13 @@ overcast case setup \
   --provider "listen:elevenlabs" \
   --provider-indexable "listen" \
   --auto-sense "watch,listen" \
-  --findings review \
+  --findings suggest \
   --yes
 overcast scan --limit 5 --pull
-overcast finding list --json
+overcast finding list --state triage --json      # open + suggested leads
+overcast finding accept <finding-id>             # promote a lead to evidence (or: finding dismiss)
 overcast ask "What new claims or events appear?"
-overcast brief --export acme-watch.md
+overcast brief --export acme-watch.md            # short verdict-led brief; --full for the timeline
 ```
 
 Each pulled AV hit is captured, then run through the setup automation chain
@@ -395,10 +410,10 @@ overcast case setup \
   --source youtube:@acme \
   --auto-sense "watch" \
   --auto-index-new \
-  --findings review \
+  --findings suggest \
   --yes
 overcast monitor --every 15m --limit 5 --brief --alert .overcast/alerts.jsonl
-overcast finding list --json
+overcast finding list --state triage --json      # open + suggested leads → finding accept/dismiss
 ```
 
 Run `monitor --every` under tmux/a scheduler. New hits are captured + sensed;
@@ -519,9 +534,13 @@ overcast ask "What observations mention license plates?"
 overcast brief --scope verb:note --export analyst-notes.md
 ```
 
-Use `note` for observations; use `finding create` to pin confirmed evidence
-(`finding accept`/`dismiss` append review rows; dismissed findings stay auditable
-but drop out of memory/briefs).
+Use `note` for observations; use `finding create` to pin confirmed evidence.
+Findings also **auto-suggest**: matching verbs (`face --match`, `image match`,
+`similar match`, `cluster identify`, or a sense verb hitting a target) emit
+`status:"suggested"` leads. Triage them with `finding list --state triage`
+(open + suggested), then `finding accept` (→ evidence) or `finding dismiss` (a
+dismissed suggestion never re-fires for the same match). Both `suggested` and
+dismissed findings stay auditable but drop out of memory/briefs.
 
 ### 17. Control-room wall
 
@@ -558,9 +577,10 @@ overcast source add "x:video:<topic keywords>" --json
 overcast source add lens:./original-frame.png --json          # reverse image search
 overcast scan --since 7d --limit 10 --json                    # triage first: Apify bills per result
 overcast capture <scan-hit-id> --json
-overcast image match <capture-id> --index <index-id> --draw --json
-overcast finding create "copycat: <because-clause>" --ref <image-match-id> --confidence high --json
-overcast brief --export copycats.html
+overcast image match <capture-id> --index <index-id> --draw --json   # a RANSAC hit auto-suggests a lead
+overcast finding list --state triage --json                          # the copycat lead is already suggested
+overcast finding accept <finding-id> --json                          # accept it (or hand-author: finding create --ref <image-match-id>; dedup drops the dup)
+overcast brief --export copycats.html                               # short verdict-led brief; --full for the frame dump
 overcast monitor --every 1d --json
 ```
 
@@ -570,6 +590,27 @@ Google Lens reverse image search via Apify. `image match` gates on
 planar-projection (homography) validity — read the inlier count + ratio and
 eyeball the `--draw` overlay before calling a rip; keyword overlap alone is not
 a match.
+
+### 19. Triage auto-suggested leads / analyst debrief
+
+Findings auto-suggest as you work — turn the queue of leads into resolved lines
+of investigation, then a verdict-led brief.
+
+```bash
+overcast face ./clip.mp4 --match ./suspect.jpg --json   # a ≥75 match auto-suggests a lead
+overcast finding list --state triage --json             # open + suggested leads awaiting review
+overcast finding accept <finding-id> --json             # promote a lead to evidence…
+overcast finding dismiss <other-id> --json              # …or block it (never re-suggested for that match)
+overcast target close <target-id> --as answered --note "confirmed: suspect appears at 00:14" --json
+overcast case status --json                             # mission board: threads on the stage ladder + triage
+overcast brief --export debrief.html                    # short verdict-led brief; --full for the timeline
+```
+
+Targets are **lines of investigation**: `target add --question` frames one,
+`target close <id> --as answered|dead-end --note` resolves it (closed lines stop
+seeding scans), and `target reopen` revives it. The `/debrief` prompt automates
+this whole loop — triage leads, write `thread:<tgt_id>` narrative notes, close
+resolved lines, refresh the `tldr` note, and `brief --export`.
 
 ## Command matrix
 
@@ -590,13 +631,13 @@ a match.
 | `capture` | osint | `capture` | local copy/stdin or source fetch | source provider | Acquire media/content |
 | `monitor` | osint | `scan.hit` + capture/sense | scan/capture/sense chain | source + sense overrides | Repeated discovery w/ dedupe |
 | `index` | osint | `index` | tinycloud library collections | pinned tinycloud | Remote typed indexes |
-| `target` | state | `target` | local state | none | Standing scope |
+| `target` | state | `target` | local state | none | Line of investigation (`add --question` / `close --as answered\|dead-end` / `reopen`) |
 | `source` | state | `source` | local state | source provider types | Where to look |
 | `note` | state | `note` | local human record | none | Human observations |
-| `finding` | state | `finding` | local record / setup automation | none | Findings + review |
+| `finding` | state | `finding` | local record / setup automation | none | Findings lifecycle: `create\|list\|accept\|dismiss`, `--state triage` (open + suggested) |
 | `prebrief` | config | `prebrief` | local state | none | Case kickoff |
 | `ask` | read | `answer` | local-grep | qmd or `--index` (tinycloud) | Query memory / remote index |
-| `brief` | read | `brief` | local records | none | Case report |
+| `brief` | read | `brief` | local records | none | Case report — short by default (verdict/threads/triage/coverage), `--full` for the timeline |
 | `case` | state | `case` | local store/memory/setup | none | Inspect/manage case + setup |
 | `setup` | config | `setup` | profile files | none | Bind providers/LLM/memory |
 | `provider` | config | `provider` | provider hooks / catalog | profile descriptors | Provider setup/init/list |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -95,14 +95,16 @@ overcast case setup edit \
   --provider-indexable "listen,see" \
   --auto-sense "watch,listen" \
   --auto-index-new \
-  --findings review \
+  --findings suggest \
   --yes --json
 ```
 
 This records which provider choices the case expects, which outputs can feed
 local memory/indexing, and whether `scan --pull` / `monitor` should run senses
-automatically for newly discovered media. Explicit `--pipe` on `scan` or
-`monitor` still overrides setup automation for that run. Use
+automatically for newly discovered media. `--findings suggest` (the default)
+auto-suggests findings from score/text matches on every evidence verb; `review`
+is the legacy text-only mode and `off` disables it. Explicit `--pipe` on `scan`
+or `monitor` still overrides setup automation for that run. Use
 `case setup edit --no-auto-index-new --yes --json` to disable automatic indexing
 later without removing the selected providers or auto-sense chain.
 
@@ -405,7 +407,10 @@ default is `local-grep`, which scans indexable fields from `.overcast/records`
 Only primary evidence records are eligible for memory and briefs: read/meta and
 operational bookkeeping records (`ask`, `brief`, `case`, `setup`, `doctor`,
 `index`, `target`, `source`, `prebrief`, legacy `collection`, etc.) are excluded even if they contain matching
-text. Remote indexes stay explicit through the case index mirror and
+text. Root `finding`s follow the same rule as flows.md's searchability table:
+accepted findings are evidence, but `suggested` (until accepted) and dismissed
+findings are quarantined from memory/briefs. Remote indexes stay explicit
+through the case index mirror and
 `ask --index`. Face and object detection records are searchable only through
 compact summary fields (summaries, counts, categories, moments), not raw boxes,
 thumbnail blobs, or full detection arrays. `crop` records are fully searchable

--- a/prompts/brief.md
+++ b/prompts/brief.md
@@ -2,9 +2,13 @@
 name: brief
 description: Synthesize the case into a structured report.
 ---
-Use the `brief` verb to synthesize the current case's records into a report:
-a timeline of findings, the entities/sources involved, and the key conclusions,
-each anchored to `record.id` + `media.at`. To produce a shareable artifact, pass
-`--export ./brief.html` (or `.md`).
+Use the `brief` verb to synthesize the current case's records into a report.
+By default the brief is **short**: it leads with the verdict, key findings,
+lines of investigation (per-target threads with stage + activity), the triage
+queue of suggested leads awaiting review, and coverage gaps — followed by a
+compact record trail. Pass `--full` for the complete verbatim record timeline
+(the audit dump). Every item is anchored to `record.id` + `media.at`; read any
+record in full with `overcast case memory get <id>`. To produce a shareable
+artifact, pass `--export ./brief.html` (or `.md`).
 
 Scope (optional): $ARGUMENTS

--- a/prompts/debrief.md
+++ b/prompts/debrief.md
@@ -1,0 +1,35 @@
+---
+name: debrief
+description: Triage suggested leads, narrate each line of investigation, then export the brief.
+---
+Run an analyst debrief over the current case. The verbs are deterministic; YOU
+supply the judgment and narrative (overcast never runs an LLM inside a verb).
+Work through these steps in order, using the tools:
+
+1. **Triage the suggested leads.** Run `finding list --state triage --json`. For
+   each suggested finding, weigh its `signal.score` and the cited record's
+   provenance (`source_url` / `source_excerpt`). Then either
+   `finding accept <id>` (it becomes evidence in ask/brief) or
+   `finding dismiss <id>` (a dismissed lead never re-suggests). Say why in one
+   line per decision.
+
+2. **Read the mission board.** Run `case status --json` and look at
+   `pulse`/`threads` — each target is a line of investigation with a stage
+   (cold → collecting → leads → corroborated). For every active thread, write ONE
+   note tagged `thread:<target_id>` (2–3 sentences: the state of that line and the
+   next move, or why it's a dead end):
+   `note "…" --tag thread:<target_id>`. The brief renders these into the thread
+   cards, so keep them tight and evidence-anchored.
+
+3. **Close resolved lines.** If a thread is answered, `target close <id> --as
+   answered --note "…"`; if it led nowhere, `target close <id> --as dead-end
+   --note "…"`. Closed lines stop seeding scans and show dimmed in the report.
+
+4. **Refresh the TL;DR.** Write (or update) one narrative note tagged `tldr`
+   summarizing the case's current verdict: `note "…" --tag tldr`.
+
+5. **Export the brief.** Run `brief --export ./brief.html --theme csi` (add
+   `--full` only if the reader needs the verbatim record dump). Report the path
+   and a two-line summary of where the investigation stands.
+
+Optional focus / scope: $ARGUMENTS

--- a/skills/overcast-copycat-sweep/SKILL.md
+++ b/skills/overcast-copycat-sweep/SKILL.md
@@ -56,6 +56,13 @@ Pass `--draw` on `image match` so each matched frame writes a RANSAC overlay
 `--ref` in step 5 — the brief embeds that overlay in the finding card as
 visual proof.
 
+Each `image match` / `face --match` / `listen`-on-a-match already
+**auto-suggests** a finding (image RANSAC ≥1 inlier, face ≥75%): run
+`overcast finding list --state triage --json` to see the leads, then
+`finding accept <id>` (usually enough — the lead is already there) or
+`finding dismiss <id>`. Step 5's manual `finding create --ref <match-record>`
+stays valid for a richer because-clause (dedup suppresses the duplicate).
+
 **Local mode (no external source).** The skill works entirely on local files:
 skip steps 2–3 and run `image match` / `face --match` / `listen` directly on
 candidate videos already on disk (or captured earlier). This is how you compare a
@@ -74,8 +81,9 @@ media/indexes when no source is enabled.
 ```bash
 overcast finding create "copycat: <original> re-uploaded by @<author> (<views> views) — image frames 3x (best 94 inliers), face 87/100" --ref <image-match-record-id> --confidence high --json
 overcast note "checked x + youtube (<n> hits); <m> candidates escalated; <k> confirmed: @<author> ..." --tag tldr --json
+overcast target close <target-id> --as answered --note "copycats found + reported" --json  # once a line resolves
 # Wait for the note result before exporting, so the TL;DR is included.
-overcast brief --export ./copycats.html --json
+overcast brief --export ./copycats.html --json   # short by default (verdict-led); add --full for the frame-by-frame dump
 overcast monitor --every 1d --json
 ```
 

--- a/skills/overcast-init/SKILL.md
+++ b/skills/overcast-init/SKILL.md
@@ -53,6 +53,8 @@ One-time setup for overcast.
    ```
 7. **Case setup later** — use the main `overcast` skill per investigation to run
    `case setup`, select targets/sources/indexes, and optionally set case-level
-   automation such as `--auto-sense`, `--auto-index-new`, and `--findings review`.
+   automation such as `--auto-sense`, `--auto-index-new`, and `--findings`
+   (defaults to `suggest` — score/text triggers auto-suggest leads; `review` is
+   the legacy text-only mode, `off` disables).
 
 Then use the `overcast` skill to drive the verbs.

--- a/skills/overcast-media-bug-triage/SKILL.md
+++ b/skills/overcast-media-bug-triage/SKILL.md
@@ -22,7 +22,7 @@ overcast listen ./screen-recording.mp4 --describe --json
 overcast see frame://<record-id>@<seconds> --ocr --json
 overcast note "observed UI state or suspected failure" --ref <record-id> --at <time-range> --json
 overcast ask "summarize the bug with reproduction steps and citations" --json
-overcast brief --export ./bug-brief.md --json
+overcast brief --full --export ./bug-brief.md --json   # --full: this flow wants the verbatim evidence timeline (the default brief is short)
 ```
 
 Use `watch` for screen recordings and demos. Add `listen --describe` when

--- a/skills/overcast-recon-brief/SKILL.md
+++ b/skills/overcast-recon-brief/SKILL.md
@@ -19,9 +19,10 @@ overcast doctor --sources --json
 overcast case init --json
 overcast case setup --target "<target>" --source "web:<query>" --yes --json
 overcast scan --pull --json
-overcast finding list --json
+overcast finding list --state triage --json   # auto-suggested leads (bare `list` shows only open)
+overcast finding accept <id> --json            # promote a real lead to evidence (or `dismiss <id>`)
 overcast ask "what are the relevant hits, dates, sources, and confidence levels?" --json
-overcast brief --export ./recon-brief.md --json
+overcast brief --export ./recon-brief.md --json   # short by default; add --full for the verbatim timeline
 ```
 
 For a one-time polling pass, use:
@@ -40,10 +41,14 @@ overcast monitor --every 30m --json
 
 Produce a cited brief with:
 
-- timeline entries tied to source URLs and record IDs;
+- the short brief's lead sections — verdict, key findings, lines of investigation
+  (per-target threads), triage queue, and coverage gaps (`--full` for the
+  verbatim per-record timeline tied to source URLs and record IDs);
 - relevant hits from `scan --pull` and captured media observations;
-- accepted, dismissed, and review-needed findings separated by confidence;
+- findings triaged from the auto-suggested queue via `finding accept`/`dismiss`,
+  separated by confidence;
 - clear gaps where sources, credentials, or media captures were unavailable.
+- `/debrief` automates this recon → triage → thread-notes → brief loop.
 
 ## Evidence Rules
 

--- a/skills/overcast-visual-target-search/SKILL.md
+++ b/skills/overcast-visual-target-search/SKILL.md
@@ -18,10 +18,12 @@ For a person with a reference image:
 ```bash
 overcast doctor --json
 overcast case init --json
-overcast face ./clip.mp4 --match ./person.jpg --json
+overcast face ./clip.mp4 --match ./person.jpg --json   # a match ≥75% auto-suggests a finding
+overcast finding list --state triage --json            # triage the auto-suggested lead(s)…
+overcast finding accept <id> --json                    # …accept a real match (or `dismiss <id>`)
 overcast crop <face-record-id> --all --class face --json
 overcast ask "where does the reference person appear, with timestamps and confidence?" --json
-overcast brief --export ./visual-search.md --json
+overcast brief --export ./visual-search.md --json      # short by default; --full for the per-match timeline
 ```
 
 For an object or open-vocabulary target (`--detect` needs a bound detection
@@ -38,13 +40,17 @@ For logos, landmarks, or near-duplicate visual references:
 ```bash
 overcast index create refs --type image-ransac --local --json
 overcast index add ./reference-logo.png --to <index-id> --json
-overcast image match ./clip.mp4 --index <index-id> --json
+overcast image match ./clip.mp4 --index <index-id> --json   # a RANSAC hit auto-suggests a finding
+overcast finding list --state triage --json                  # then accept/dismiss the lead
 ```
 
 ## Output
 
 Return timestamped matches, similarity or confidence where available, source
 `record.id`, `media.at`, and cropped evidence paths created by `crop`.
+`face --match` / `image match` auto-suggest findings — resolve them with
+`finding list --state triage` → `accept`/`dismiss` so a run doesn't leave an
+un-triaged queue; the default `brief` is short, `--full` for the per-match timeline.
 State whether the match came from `face --match`, `see --detect`, or local
 `image-ransac` matching.
 

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -33,7 +33,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `capture` — Fetch a resource (URL / scan.hit / local path) into the case as a capture record.
 - `monitor` — scan on a loop; diff against the seen-set; pipe new items into a sense. --once or --every <interval>.
 - `index` — Manage tinycloud indexes that index a target's videos (create/attach/add/list/show/delete/remove/entities).
-- `target` — Define/refine the standing scope (add|list|rm|show). Persisted to .overcast/target.json.
+- `target` — Define/refine the standing scope, a.k.a. a line of investigation (add|list|rm|show|close|reopen). Persisted to .overcast/target.json.
 - `source` — Register where to look (add <type>:<ref> | list | enable|disable <id> | rm <id>).
 - `note` — Add a human observation/finding to the case, optionally anchored to evidence.
 - `finding` — Create and review findings (create|list|accept|dismiss).

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -53,15 +53,15 @@ Run any verb from bash and parse the JSON record:
 ```bash
 overcast watch ./clip.mp4 --json          # video.analysis record
 overcast scan --pull --json               # enumerate sources, capture + sense
-overcast finding list --json              # review automated target matches
+overcast finding list --state triage --json  # triage auto-suggested leads (accept/dismiss)
 overcast note "rear plate is missing" --ref <record-id> --at 12-18 --json
 overcast face ./clip.mp4 --thumbnails --json  # detect faces (boxes + provider frame thumbnails)
 overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video (JPEG/PNG query image)
 overcast crop <face-or-see-record-id> --all --class face --json  # materialize detection crops as evidence
 overcast ask "every white van, with timestamps" --json
 overcast case memory index status --json  # inspect default local-grep case search
-overcast brief --export ./brief.html      # evidence-only narrative report
-overcast case status --export ./status.html --theme csi   # current case dashboard
+overcast brief --export ./brief.html      # short analyst brief (verdict-led); --full for the verbatim timeline
+overcast case status --export ./status.html --theme csi   # mission board (threads, coverage, triage)
 overcast case records --export ./records.html --theme csi # full audit log
 ```
 
@@ -82,15 +82,37 @@ Built-in source refs for `source add <type>:<ref>`:
 pages are in [reference/verbs.md](reference/verbs.md) (progressive disclosure —
 read it when you need a verb's exact flags).
 
+### Lines of investigation & triage
+
+A `target` is a **line of investigation**: `target add <value> --question "…"`
+records what would resolve it; `target close <id> --as answered|dead-end --note`
+marks it done (closed lines stop seeding scans); `target reopen <id>` reactivates.
+
+Findings **auto-suggest** by default: score triggers (face ≥75, image RANSAC,
+similar ≥85, cluster ≥70) and non-image target text matches emit `suggested`
+leads on every verb — so a standalone `face --match` / `image match` /
+`similar match` / `cluster identify` surfaces a lead. Suggested leads are
+quarantined from `ask`/`brief` until accepted. Triage with
+`finding list --state triage` (bare `list` shows only `open`), then
+`finding accept <id>` (→ evidence) or `finding dismiss <id>` (blocks re-suggestion).
+The **`/debrief`** prompt automates the loop: triage leads → write one
+`thread:<target-id>` narrative note per line → `target close` resolved lines →
+refresh the `tldr` note → `brief --export`.
+
 ### Brief vs status vs records
 
-Use `brief` for the evidence narrative: it reports over the same evidence-only
-boundary as case memory, so setup/read/meta records are excluded.
+Use `brief` for the evidence narrative — **short by default**: verdict → goal
+status → key findings (with visual proof) → lines of investigation (per-target
+threads with a stage + activity sparkline) → triage queue → coverage gaps → a
+compact record trail. `--full` appends the verbatim per-record timeline. It
+reports over the same evidence-only boundary as case memory, so setup/read/meta
+records — and un-accepted `suggested` findings — are excluded.
 
-Use `case status` for the current dashboard: setup health, targets, sources,
-indexes, memory/index state, record/store counts, artifacts, and match
-visualizations when available. Treat it as situational context, not evidence for
-later memory or briefs.
+Use `case status` as the **mission board**: a goal headline + per-target threads
+on a stage ladder (cold → collecting → leads → corroborated → answered/dead-end),
+a per-source coverage funnel, scan/monitor/brief freshness, and the triage queue —
+with setup health, store counts, and match visualizations below. Treat it as
+situational context, not evidence for later memory or briefs.
 
 Use `case records` for the audit trail: it includes the append-only operational
 history, including setup, target/source changes, index work, asks, briefs, and
@@ -229,9 +251,15 @@ overcast case setup edit \
   --provider-indexable "listen,see" \
   --auto-sense "watch,listen" \
   --auto-index-new \
-  --findings review \
+  --findings suggest \
   --yes --json
 ```
+
+Findings default to `--findings suggest` (score/text triggers auto-emit
+`suggested` leads on every verb; tune floors with
+`case setup --findings-threshold face=75,similar=85,cluster=70,image_inliers=1`);
+`review` is the legacy text-only mode, `off` disables. `finding list` alone
+shows only `open` findings — pass `--state triage` to see the leads.
 
 Use `overcast case setup edit --no-auto-index-new --yes --json` to disable
 automatic indexing later without removing the selected providers or auto-sense

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -474,6 +474,7 @@ overcast brief  [options]
 
 Options:
   --scope <string>       Filter, e.g. since:24h or verb:watch
+  --full                 Include the full verbatim record timeline (audit dump) instead of the compact appendix
   --export <string>      Write a report file (.md or .html)
   --theme <string>       HTML export theme: plain | csi (default: plain)
   --format <string>      json | md | txt
@@ -486,19 +487,24 @@ Emits `brief` records.
 
 ### `overcast target`
 
-Define/refine the standing scope (add|list|rm|show). Persisted to .overcast/target.json.
+A target is a line of investigation. `add --question` records what would resolve it; `close <id> --as answered|dead-end --note` marks the line done (closed lines stop seeding scan/monitor); `reopen <id>` reactivates it. Status feeds the brief/status thread cards.
 
 ```
 overcast target <action> [value] [options]
 
-  Define/refine the standing scope (add|list|rm|show). Persisted to .overcast/target.json.
+  Define/refine the standing scope, a.k.a. a line of investigation (add|list|rm|show|close|reopen). Persisted to .overcast/target.json.
+
+  A target is a line of investigation. `add --question` records what would resolve it; `close <id> --as answered|dead-end --note` marks the line done (closed lines stop seeding scan/monitor); `reopen <id>` reactivates it. Status feeds the brief/status thread cards.
 
 Arguments:
-  action           add | list | rm | show
-  value            target value (for add) or id (for rm)
+  action           add | list | rm | show | close | reopen
+  value            target value (for add) or id (for rm/close/reopen)
 
 Options:
   --image                Treat the value as a reference image path
+  --question <string>    add: what would resolve this line of investigation
+  --as <string>          close: answered | dead-end
+  --note <string>        close: why (answered how / why it's a dead end)
   --json                 JSON output
   --format <string>      json | md | txt
 ```
@@ -554,21 +560,21 @@ Emits `note` records.
 
 ### `overcast finding`
 
-Creates manual findings and lists/reviews automated finding records emitted by setup automation. `accept` and `dismiss` append review records that reference the original finding; dismissed findings remain auditable but are excluded from memory/brief evidence.
+Creates manual findings and lists/reviews automated findings. Score/text triggers emit `suggested` findings (leads) that stay OUT of memory/brief evidence until reviewed — `finding list --state triage` queues them newest-first, `accept` promotes a lead into evidence, `dismiss` rejects it (a dismissed suggestion never re-fires for the same match). Review records reference the original finding; dismissed findings remain auditable.
 
 ```
 overcast finding [action] [id] [options]
 
   Create and review findings (create|list|accept|dismiss).
 
-  Creates manual findings and lists/reviews automated finding records emitted by setup automation. `accept` and `dismiss` append review records that reference the original finding; dismissed findings remain auditable but are excluded from memory/brief evidence.
+  Creates manual findings and lists/reviews automated findings. Score/text triggers emit `suggested` findings (leads) that stay OUT of memory/brief evidence until reviewed — `finding list --state triage` queues them newest-first, `accept` promotes a lead into evidence, `dismiss` rejects it (a dismissed suggestion never re-fires for the same match). Review records reference the original finding; dismissed findings remain auditable.
 
 Arguments:
   action           create | list | accept | dismiss (default: list)
   id               finding id for accept/dismiss, or text for create
 
 Options:
-  --state <string>       list: open | accepted | dismissed | all
+  --state <string>       list: open | suggested | accepted | dismissed | all | triage (open+suggested), or a comma-list
   --target <string>      create: target/scope this finding supports
   --ref <string>         create: source record id, capture id, media path, or URL
   --at <string>          create: evidence timestamp seconds, hh:mm:ss, or start-end
@@ -612,7 +618,8 @@ Options:
   --auto-sense <string>  setup/edit: comma-separated senses to run on newly captured media
   --auto-index-new       setup/edit: automatically add newly analyzed media to configured indexes
   --no-auto-index-new    setup/edit: disable automatic indexing for newly analyzed media
-  --findings <string>    setup/edit: automated finding workflow (off | review)
+  --findings <string>    setup/edit: automated finding workflow (suggest | review | off; default suggest)
+  --findings-threshold <string> setup/edit: comma-separated score-trigger floors (face=75,similar=85,cluster=70,image_inliers=1)
   --video <string>       setup/edit: comma-separated local videos/URLs to route
   --folder <string>      setup/edit: comma-separated local media folders to remember
   --no-index             setup/edit: save setup routes without starting remote collection ingestion
@@ -620,6 +627,7 @@ Options:
   --verb <string>        Filter records by kind
   --since <string>       Time filter (e.g. 24h, 2026-06-01)
   --export <string>      Write a case status/log report (.md or .html)
+  --full                 status: append the raw payload JSON for auditing
   --theme <string>       HTML export theme: plain | csi (default: plain)
   --field <string>       Payload field to read in full (memory get)
   --offset <number>      Start char offset when paging a field (memory get)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { parseVerbArgs, renderVerbHelp } from "./registry/to-cli.js";
 import { openCase } from "./case.js";
 import { loadProfile, type HomeOptions } from "./profile.js";
 import { makeRecord, type OvercastRecord } from "./record.js";
+import { persistRecords } from "./registry/persist.js";
 import { renderForFormat } from "./render.js";
 import { loadDotEnv } from "./env.js";
 
@@ -353,14 +354,9 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       return 1;
     }
 
-    // persist into the active case, but skip a record explicitly tagged for a
-    // different case (e.g. `case init <other-dir>` already wrote it there).
-    // Transient records are user-facing control results, not case history.
-    for (const rec of records) {
-      if (rec.meta?.transient === true || rec.meta?.persisted === true) continue;
-      if (rec.meta?.case && rec.meta.case !== c.dir) continue;
-      c.writeRecord(rec);
-    }
+    // persist into the active case (shared seam: guards + finding triggers);
+    // suggested-finding leads render alongside the verb's own output.
+    records = [...records, ...persistRecords(c, records)];
 
     const wantJson = parsed.opts.json === true || parsed.opts.format === "json";
     const format = wantJson ? "json" : (parsed.opts.format as string) ?? "human";

--- a/src/extension/slash.ts
+++ b/src/extension/slash.ts
@@ -11,6 +11,7 @@ import { tokenizeCommand } from "../providers/sources/index.js";
 import { openCase } from "../case.js";
 import { loadProfile, resolveHome } from "../profile.js";
 import type { OvercastRecord } from "../record.js";
+import { persistRecords } from "../registry/persist.js";
 import { renderForFormat, renderRecord } from "../render.js";
 import type { VerbContext } from "../registry/types.js";
 import { maybeScheduleCaseClearReset } from "./case-clear-reset.js";
@@ -76,15 +77,10 @@ export function registerSlashCommands(pi: ExtensionAPI): void {
           profileName,
         };
         try {
-          const recs = await spec.run(ctx);
-          // skip a record tagged for a different case (already persisted there),
-          // matching the CLI / agent-tool persist guards.
-          for (const r of recs) {
-            if (r.meta?.transient === true) continue;
-            if (r.meta?.persisted === true) continue;
-            if (r.meta?.case && r.meta.case !== c.dir) continue;
-            c.writeRecord(r);
-          }
+          let recs = await spec.run(ctx);
+          // persist via the shared seam (guards + finding triggers); surface
+          // suggested leads with the command's own output.
+          recs = [...recs, ...persistRecords(c, recs)];
           // honor --json/--format like the CLI (so a paged chunk isn't truncated)
           const fmt = parsed.opts.json ? "json" : (parsed.opts.format as string | undefined);
           emitResult(pi, recs.map((r) => summarize(r, fmt)).join("\n\n") || `▶ ${name}: (no records)`);

--- a/src/record.ts
+++ b/src/record.ts
@@ -116,7 +116,11 @@ export function memoryRecords(records: OvercastRecord[]): OvercastRecord[] {
   return records.filter((rec) => {
     if (!isMemoryRecord(rec)) return false;
     if (rec.verb !== "finding") return true;
-    return findingStatus.get(rec.id) !== "dismissed";
+    // quarantine: dismissed findings are rejected evidence; suggested findings
+    // are unreviewed leads — neither may pollute ask/brief until accepted
+    // (accepting flips the effective status via a review record).
+    const status = findingStatus.get(rec.id);
+    return status !== "dismissed" && status !== "suggested";
   });
 }
 

--- a/src/registry/persist.ts
+++ b/src/registry/persist.ts
@@ -1,0 +1,42 @@
+/**
+ * The single persist seam for verb output — CLI, agent tool, and TUI slash all
+ * write records through here so the guards (transient / already-persisted /
+ * other-case) can't drift, and so finding triggers run on EVERY fresh evidence
+ * record: a standalone `face --match` / `image match` / `similar match` /
+ * `cluster identify` surfaces a suggested-finding lead exactly like a
+ * scan/monitor chain does. Trigger evaluation is best-effort — it must never
+ * break the verb's own output.
+ */
+import type { Case } from "../case.js";
+import type { OvercastRecord } from "../record.js";
+import { evaluateTriggers, resolveFindingsPolicy } from "../signals/triggers.js";
+import { loadSetup } from "../state/setup.js";
+import { listTargets } from "../state/target.js";
+
+/** Persist a verb's records into the case store, then run finding triggers over
+ *  what was written. Returns any suggested-finding records it appended so the
+ *  caller can render them alongside the verb's own output. */
+export function persistRecords(c: Case, records: OvercastRecord[], opts: { signals?: boolean } = {}): OvercastRecord[] {
+  const persisted: OvercastRecord[] = [];
+  for (const rec of records) {
+    if (rec.meta?.transient === true || rec.meta?.persisted === true) continue;
+    if (rec.meta?.case && rec.meta.case !== c.dir) continue;
+    c.writeRecord(rec);
+    persisted.push(rec);
+  }
+  if (opts.signals === false || !persisted.length) return [];
+  try {
+    // chain-created findings are already in the batch (and now the store), so
+    // dedup inside evaluateTriggers keeps this second pass idempotent.
+    const suggestions = evaluateTriggers({
+      fresh: persisted,
+      existing: c.records(),
+      targets: listTargets(c),
+      policy: resolveFindingsPolicy(loadSetup(c)),
+    });
+    for (const s of suggestions) c.writeRecord(s);
+    return suggestions;
+  } catch {
+    return [];
+  }
+}

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -10,6 +10,7 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import type { VerbSpec, VerbContext, FlagSpec } from "./types.js";
 import { makeRecord, type OvercastRecord, type JsonMap } from "../record.js";
+import { persistRecords } from "./persist.js";
 import { expandHome, expandHomeArg } from "../fs-path.js";
 import { renderRecord, pageCommand } from "../render.js";
 import { isHtmlExportPath } from "../report/html.js";
@@ -274,14 +275,9 @@ export function toAgentTool(spec: VerbSpec, deps: ToolDeps): ToolDefinition {
         };
       }
 
-      // skip a record explicitly tagged for a different case (already persisted
-      // there) — e.g. `case init <other-dir>`. Transient records are user-facing
-      // control results, not case history.
-      for (const rec of records) {
-        if (rec.meta?.transient === true || rec.meta?.persisted === true) continue;
-        if (rec.meta?.case && rec.meta.case !== c.dir) continue;
-        c.writeRecord(rec);
-      }
+      // persist via the shared seam (guards + finding triggers); suggested
+      // leads ride back to the agent with the verb's own records.
+      records = [...records, ...persistRecords(c, records)];
 
       const summary = renderRecords(records);
       return {

--- a/src/report/components.ts
+++ b/src/report/components.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared report primitives — DOM-free string builders used by wall, brief, and
+ * status so freshness/coverage/thread rendering can't drift between surfaces.
+ * No node/ffmpeg/pi imports; offline-unit-testable like report/wall.ts.
+ */
+import { escapeHtml } from "./html.js";
+
+/** Compact age: 45s / 12m / 3h / 6d. "—" for unknown. Shared by every freshness
+ *  chip so the wall HUD and the status board read identically. */
+export function fmtAge(sec: number | null | undefined): string {
+  if (sec == null || !Number.isFinite(sec)) return "—";
+  if (sec < 60) return `${Math.max(0, Math.round(sec))}s`;
+  if (sec < 3600) return `${Math.round(sec / 60)}m`;
+  if (sec < 86400) return `${Math.round(sec / 3600)}h`;
+  return `${Math.round(sec / 86400)}d`;
+}
+
+/** Seconds → m:ss or h:mm:ss (media timestamps). */
+export function fmtTime(s: number): string {
+  const t = Math.max(0, Math.round(s));
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const sec = String(t % 60).padStart(2, "0");
+  return h ? `${h}:${String(m).padStart(2, "0")}:${sec}` : `${m}:${sec}`;
+}
+
+const BLOCKS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+/** A unicode block sparkline from activity bins — renders identically in the
+ *  terminal payload, markdown, and HTML (no SVG, no CDN). Empty input → a flat
+ *  baseline so a card never shows a blank gap. */
+export function sparkline(bins: number[]): string {
+  if (!bins.length) return "";
+  const max = Math.max(...bins);
+  if (max <= 0) return BLOCKS[0].repeat(bins.length);
+  return bins.map((v) => BLOCKS[Math.min(BLOCKS.length - 1, Math.round((v / max) * (BLOCKS.length - 1)))]).join("");
+}
+
+export type ChipTone = "" | "cyan" | "amber" | "magenta" | "bad" | "green";
+
+/** A CSI chip. Tone maps to the palette classes csiShell/wall already define. */
+export function chip(text: string, tone: ChipTone = ""): string {
+  return `<span class="chip${tone ? " " + tone : ""}">${escapeHtml(text)}</span>`;
+}
+
+/** W/L/S/F sense-coverage badges — lit letters for present modalities. */
+export function coverageBadges(coverage: { watch?: boolean; listen?: boolean; see?: boolean; face?: boolean }): string {
+  const cells: Array<[string, boolean]> = [
+    ["W", !!coverage.watch],
+    ["L", !!coverage.listen],
+    ["S", !!coverage.see],
+    ["F", !!coverage.face],
+  ];
+  return `<span class="badges">${cells.map(([l, on]) => `<b class="${on ? "on" : ""}">${l}</b>`).join("")}</span>`;
+}

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -24,8 +24,14 @@ export interface TimelineRecord {
 export interface TimelineSynthesis {
   tldr?: string;
   verdict: string;
+  /** the honest goal-progress line (pulse headline), shown under the verdict */
+  headline?: string;
   sources: Array<{ source: string; hits: number }>;
   findings: Array<{ id: string; status: string; text: string; confidence?: unknown; overlays?: string[] }>;
+  /** lines of investigation — per-target thread cards */
+  threads?: Array<{ value: string; stage: string; spark?: string; funnel: string; question?: string; note?: string }>;
+  /** suggested leads awaiting triage */
+  triage?: Array<{ id: string; text: string; confidence?: unknown }>;
 }
 
 const VISUAL_EXT_RE = /\.(avif|bmp|gif|jpe?g|png|webp)(?:[?#].*)?$/i;
@@ -150,9 +156,10 @@ export function renderCsiTimelineReport(report: TimelineReport): string {
  *  rather than omitting the panel — "we checked and found nothing" is a result. */
 function renderSynthesis(syn: TimelineSynthesis | undefined): string {
   if (!syn) return "";
+  const tldrNext = [syn.tldr ? syn.verdict : "", syn.headline ?? ""].filter(Boolean);
   const tldr = renderTldr({
     headline: syn.tldr ?? syn.verdict,
-    findings: syn.tldr ? [syn.verdict] : [],
+    findings: tldrNext,
   });
   const sources = syn.sources.length
     ? `<ul>${syn.sources.map((s) => `<li><strong>${escapeHtml(s.source)}</strong> — ${s.hits} hit${s.hits === 1 ? "" : "s"}</li>`).join("")}</ul>`
@@ -164,29 +171,116 @@ function renderSynthesis(syn: TimelineSynthesis | undefined): string {
       }).join("")}</ul>`
     : `<p class="meta">none recorded</p>`;
   return `${tldr}
+    ${renderThreadCards(syn.threads)}
+    ${renderTriagePanel(syn.triage)}
     <section class="grid" data-csi-synthesis="true" style="margin:0 0 18px">
       <section class="panel"><h2>Sources checked</h2>${sources}</section>
       <section class="panel"><h2>Matches &amp; findings</h2>${findings}</section>
     </section>`;
 }
 
+/** Lines of investigation — a card grid of target threads with stage chip,
+ *  activity sparkline, evidence funnel, and next/why. Dead-end cards dim. */
+function renderThreadCards(threads: TimelineSynthesis["threads"]): string {
+  if (!threads || !threads.length) return "";
+  const toneFor = (stage: string) => (stage === "DEAD-END" ? "bad" : stage === "ANSWERED" ? "cyan" : stage === "CORROBORATED" || stage === "LEADS" ? "amber" : "");
+  const cards = threads.map((t) => {
+    const dim = t.stage === "DEAD-END" ? ' style="opacity:.55"' : "";
+    const chip = `<span class="chip ${toneFor(t.stage)}">${escapeHtml(t.stage)}</span>`;
+    return `<article class="context-card"${dim}>
+      <span class="label">TARGET</span>
+      <p><strong>${escapeHtml(t.value)}</strong> ${chip}${t.spark ? ` <span class="cyan">${escapeHtml(t.spark)}</span>` : ""}</p>
+      ${t.question ? `<p class="meta">? ${escapeHtml(t.question)}</p>` : ""}
+      <p class="meta">${escapeHtml(t.funnel)}</p>
+      ${t.note ? `<p class="meta">${escapeHtml(t.note)}</p>` : ""}
+    </article>`;
+  }).join("");
+  return `<section style="margin:0 0 18px"><h2 style="margin:0 0 8px">Lines of investigation</h2><section class="context">${cards}</section></section>`;
+}
+
+function renderTriagePanel(triage: TimelineSynthesis["triage"]): string {
+  if (!triage || !triage.length) return "";
+  const rows = triage.slice(0, 5).map((t) =>
+    `<li><span class="id">${escapeHtml(t.id)}</span>${t.confidence != null ? ` <span class="amber">[${escapeHtml(String(t.confidence))}]</span>` : ""} ${escapeHtml(t.text)}<div class="meta">accept: overcast finding accept ${escapeHtml(t.id)}</div></li>`,
+  ).join("");
+  return `<section class="panel" style="margin:0 0 18px"><h2>Triage — ${triage.length} awaiting review</h2><ul class="findings">${rows}</ul></section>`;
+}
+
 export function renderCsiStatusReport(report: StatusReport): string {
   const payload = report.payload;
   const chips = statusChips(payload);
-  const tldr = renderTldr(payload.tldr);
+  const mission = payload.mission as { headline?: string; progress?: Record<string, number> } | undefined;
+  const nextActions = Array.isArray(payload.next_actions) ? (payload.next_actions as string[]) : [];
+  // mission headline banner (falls back to the legacy tldr for older payloads)
+  const tldr = mission?.headline
+    ? renderTldr({ headline: mission.headline, next: nextActions })
+    : renderTldr(payload.tldr);
+  const missionThreads = statusThreads(payload);
+  const threads = renderThreadCards(missionThreads);
+  const triage = renderTriagePanel(statusTriageRows(payload));
+  const coverage = renderCoveragePanel(payload);
   const context = renderContextSections(payload);
-  const promoted = new Set(["tldr", "targets", "sources", "match_visualizations"]);
-  const panels = Object.entries(payload).filter(([key]) => !promoted.has(key)).map(([key, value]) => renderStatusPanel(key, value)).join("\n");
+  // demote operational detail (store/setup/memory/registries) into a collapsed
+  // panel grid below the mission board.
+  const demoted = new Set(["tldr", "mission", "threads", "coverage", "triage", "gaps", "freshness", "next_actions", "progress", "targets", "sources", "match_visualizations"]);
+  const panels = Object.entries(payload).filter(([key]) => !demoted.has(key)).map(([key, value]) => renderStatusPanel(key, value)).join("\n");
   return csiShell(report.title, report.subtitle, `
     ${tldr}
-    ${context}
     <section class="stats" aria-label="case status stats">
       ${chips}
     </section>
-    <main class="grid" data-csi-status="true">
+    ${threads}
+    <section class="grid" style="margin:0 0 18px">${triage}${coverage}</section>
+    ${context}
+    <details data-csi-status="true"><summary>store &amp; setup detail</summary><div class="grid">
       ${panels}
-    </main>
+    </div></details>
   `);
+}
+
+/** Map status payload threads → the thread-card view model. */
+function statusThreads(payload: Record<string, unknown>): TimelineSynthesis["threads"] {
+  const threads = Array.isArray(payload.threads) ? (payload.threads as Array<Record<string, unknown>>) : [];
+  const label: Record<string, string> = { answered: "ANSWERED", "dead-end": "DEAD-END", corroborated: "CORROBORATED", leads: "LEADS", collecting: "COLLECTING", cold: "COLD" };
+  return threads.map((th) => {
+    const f = th.funnel as { scan: number; captures: number; senses: number; matches: number } | undefined;
+    const fnd = th.findings as { accepted: number; open: number; suggested: number } | undefined;
+    const funnel = f ? `scan ${f.scan} → cap ${f.captures} → sense ${f.senses} → match ${f.matches}${fnd ? ` · findings ${fnd.accepted}/${fnd.open}/${fnd.suggested}` : ""}` : "";
+    return {
+      value: String(th.value ?? ""),
+      stage: label[String(th.stage)] ?? String(th.stage ?? "").toUpperCase(),
+      spark: sparklineFrom(Array.isArray(th.activityBins) ? (th.activityBins as number[]) : []),
+      funnel,
+      question: typeof th.question === "string" ? th.question : undefined,
+      note: th.status !== "active" && typeof th.why === "string" ? th.why : undefined,
+    };
+  });
+}
+
+function statusTriageRows(payload: Record<string, unknown>): TimelineSynthesis["triage"] {
+  const triage = Array.isArray(payload.triage) ? (payload.triage as Array<Record<string, unknown>>) : [];
+  if (!triage.length) return undefined;
+  return triage.map((t) => ({ id: String(t.id ?? ""), text: String(t.text ?? ""), confidence: t.confidence }));
+}
+
+function renderCoveragePanel(payload: Record<string, unknown>): string {
+  const coverage = Array.isArray(payload.coverage) ? (payload.coverage as Array<Record<string, unknown>>) : [];
+  const gaps = Array.isArray(payload.gaps) ? (payload.gaps as string[]) : [];
+  if (!coverage.length && !gaps.length) return "";
+  const rows = coverage.length
+    ? `<ul>${coverage.map((c) => `<li><strong>${escapeHtml(String(c.spec))}</strong>${c.enabled ? "" : " <span class=\"meta\">(disabled)</span>"} — ${escapeHtml(String(c.hits))} → ${escapeHtml(String(c.captured))} → ${escapeHtml(String(c.sensed))}${c.gap ? ` <span class="bad">gap</span>` : ""}</li>`).join("")}</ul>`
+    : `<p class="meta">no sources configured</p>`;
+  const gapList = gaps.length ? `<p class="meta">Gaps:</p><ul class="findings">${gaps.slice(0, 5).map((g) => `<li class="amber">${escapeHtml(g)}</li>`).join("")}</ul>` : "";
+  return `<section class="panel"><h2>Coverage</h2>${rows}${gapList}</section>`;
+}
+
+/** Local sparkline (avoids a components import cycle in html.ts). */
+function sparklineFrom(bins: number[]): string | undefined {
+  if (!bins.length) return undefined;
+  const blocks = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+  const max = Math.max(...bins);
+  if (max <= 0) return blocks[0].repeat(bins.length);
+  return bins.map((v) => blocks[Math.min(blocks.length - 1, Math.round((v / max) * (blocks.length - 1)))]).join("");
 }
 
 export interface ClusterGalleryPerson {

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -252,7 +252,9 @@ function statusThreads(payload: Record<string, unknown>): TimelineSynthesis["thr
       spark: sparklineFrom(Array.isArray(th.activityBins) ? (th.activityBins as number[]) : []),
       funnel,
       question: typeof th.question === "string" ? th.question : undefined,
-      note: th.status !== "active" && typeof th.why === "string" ? th.why : undefined,
+      // analyst line narrative (thread note), else the closed reason
+      note: typeof th.narrative === "string" ? th.narrative
+        : th.status !== "active" && typeof th.why === "string" ? th.why : undefined,
     };
   });
 }

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -198,12 +198,20 @@ function renderThreadCards(threads: TimelineSynthesis["threads"]): string {
   return `<section style="margin:0 0 18px"><h2 style="margin:0 0 8px">Lines of investigation</h2><section class="context">${cards}</section></section>`;
 }
 
-function renderTriagePanel(triage: TimelineSynthesis["triage"]): string {
+/** `total` is the true backlog count (may exceed the rows passed, which are
+ *  capped for the payload); the heading and overflow line use it so the header
+ *  never claims more than it lists without an "…and N more" hint. */
+function renderTriagePanel(triage: TimelineSynthesis["triage"], total?: number): string {
   if (!triage || !triage.length) return "";
-  const rows = triage.slice(0, 5).map((t) =>
+  const count = total ?? triage.length;
+  const shown = triage.slice(0, 5);
+  const rows = shown.map((t) =>
     `<li><span class="id">${escapeHtml(t.id)}</span>${t.confidence != null ? ` <span class="amber">[${escapeHtml(String(t.confidence))}]</span>` : ""} ${escapeHtml(t.text)}<div class="meta">accept: overcast finding accept ${escapeHtml(t.id)}</div></li>`,
   ).join("");
-  return `<section class="panel" style="margin:0 0 18px"><h2>Triage — ${triage.length} awaiting review</h2><ul class="findings">${rows}</ul></section>`;
+  const more = count > shown.length
+    ? `<li class="meta">…and ${count - shown.length} more (overcast finding list --state suggested)</li>`
+    : "";
+  return `<section class="panel" style="margin:0 0 18px"><h2>Triage — ${count} awaiting review</h2><ul class="findings">${rows}${more}</ul></section>`;
 }
 
 export function renderCsiStatusReport(report: StatusReport): string {
@@ -217,7 +225,10 @@ export function renderCsiStatusReport(report: StatusReport): string {
     : renderTldr(payload.tldr);
   const missionThreads = statusThreads(payload);
   const threads = renderThreadCards(missionThreads);
-  const triage = renderTriagePanel(statusTriageRows(payload));
+  // the true backlog count (mission.progress.triage_pending) may exceed the
+  // capped rows in payload.triage — pass it so the heading doesn't undercount.
+  const triagePending = typeof mission?.progress?.triage_pending === "number" ? mission.progress.triage_pending : undefined;
+  const triage = renderTriagePanel(statusTriageRows(payload), triagePending);
   const coverage = renderCoveragePanel(payload);
   const context = renderContextSections(payload);
   // demote operational detail (store/setup/memory/registries) into a collapsed

--- a/src/report/wall.ts
+++ b/src/report/wall.ts
@@ -11,6 +11,8 @@ import { pathToFileURL } from "node:url";
 import { findingStatusMap, isReady, type OvercastRecord } from "../record.js";
 import { isRegisterableMediaRecord } from "../verbs/media-ref.js";
 import { isRootFindingRecord } from "../verbs/finding.js";
+import { sourceScanFreshness, latestTimed, triageCounts } from "../signals/pulse.js";
+import { fmtAge, fmtTime } from "./components.js";
 import { escapeHtml, summarizePayload, type HtmlTheme } from "./html.js";
 
 export interface WallAnchor {
@@ -56,6 +58,8 @@ export interface WallHud {
   records: number;
   counts: Record<string, number>;
   openFindings: number;
+  /** un-triaged suggested-finding leads awaiting accept/dismiss */
+  suggestedFindings: number;
   lastScans: Array<{ source: string; time: string; ageSeconds: number }>;
   lastScanAgeSeconds: number | null;
   monitor: { time: string; ageSeconds: number; newItems: number } | null;
@@ -384,27 +388,9 @@ function buildHud(records: OvercastRecord[], o: HudOptions): WallHud {
   const counts: Record<string, number> = {};
   for (const r of records) counts[r.verb] = (counts[r.verb] ?? 0) + 1;
 
-  // last scan per source — not persisted anywhere; derived from scan records.
-  // Ready rows only (like monitor/brief freshness): a failed or cred-blocked
-  // sweep must not make a source look freshly scanned.
-  const scanTimes = new Map<string, number>();
-  for (const r of records) {
-    if (r.verb !== "scan" || !isReady(r)) continue;
-    const p = payloadOf(r);
-    if (p.op === "pull_progress") continue;
-    const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
-    if (Number.isNaN(t)) continue;
-    const source = typeof p.source === "string" && p.source ? p.source : "scan";
-    if (t > (scanTimes.get(source) ?? Number.NEGATIVE_INFINITY)) scanTimes.set(source, t);
-  }
-  const lastScans = [...scanTimes.entries()]
-    .map(([source, t]) => ({
-      source,
-      time: new Date(t).toISOString(),
-      ageSeconds: Math.max(0, (o.now - t) / 1000),
-    }))
-    .sort((a, b) => a.ageSeconds - b.ageSeconds);
-
+  // Freshness derivation is shared with case status via signals/pulse, so the
+  // HUD and the mission board can't drift.
+  const lastScans = sourceScanFreshness(records, o.now);
   const monitorLatest = latestTimed(records, "monitor");
   const briefLatest = latestTimed(records, "brief");
   const newItems = monitorLatest ? payloadOf(monitorLatest.rec).new_items : undefined;
@@ -418,6 +404,7 @@ function buildHud(records: OvercastRecord[], o: HudOptions): WallHud {
     records: records.length,
     counts,
     openFindings: o.openFindings,
+    suggestedFindings: triageCounts(records).suggested,
     lastScans,
     lastScanAgeSeconds: lastScans.length ? lastScans[0].ageSeconds : null,
     monitor: monitorLatest
@@ -431,17 +418,6 @@ function buildHud(records: OvercastRecord[], o: HudOptions): WallHud {
     refreshSeconds: o.refreshSeconds ?? null,
     infinite: o.infinite ?? false,
   };
-}
-
-function latestTimed(records: OvercastRecord[], verb: string): { rec: OvercastRecord; t: number } | undefined {
-  let best: { rec: OvercastRecord; t: number } | undefined;
-  for (const rec of records) {
-    if (rec.verb !== verb || !isReady(rec)) continue;
-    const t = rec.meta?.time ? Date.parse(String(rec.meta.time)) : NaN;
-    if (Number.isNaN(t)) continue;
-    if (!best || t > best.t) best = { rec, t };
-  }
-  return best;
 }
 
 function payloadOf(r: OvercastRecord): Record<string, unknown> {
@@ -529,6 +505,9 @@ function renderHud(hud: WallHud): string {
   chips.push(
     `<span class="chip${hud.openFindings ? " bad" : ""}">● ${hud.openFindings} OPEN FINDING${hud.openFindings === 1 ? "" : "S"}</span>`,
   );
+  if (hud.suggestedFindings) {
+    chips.push(`<span class="chip amber">TRIAGE ${hud.suggestedFindings}</span>`);
+  }
   for (const s of hud.lastScans.slice(0, 4)) {
     chips.push(`<span class="chip cyan">SCAN ${escapeHtml(s.source.toUpperCase())} ${fmtAge(s.ageSeconds)}</span>`);
   }
@@ -576,22 +555,6 @@ function renderTile(tile: WallTile, index: number): string {
     <code>overcast view ${escapeHtml(shellQuote(tile.ref))} --at ${tile.anchor.span ? `${tile.anchor.start}-${tile.anchor.end}` : Math.round(tile.anchor.at)}</code>
   </div>
 </figure>`;
-}
-
-function fmtTime(s: number): string {
-  const t = Math.max(0, Math.round(s));
-  const h = Math.floor(t / 3600);
-  const m = Math.floor((t % 3600) / 60);
-  const sec = String(t % 60).padStart(2, "0");
-  return h ? `${h}:${String(m).padStart(2, "0")}:${sec}` : `${m}:${sec}`;
-}
-
-function fmtAge(sec: number | null): string {
-  if (sec == null || !Number.isFinite(sec)) return "—";
-  if (sec < 60) return `${Math.max(0, Math.round(sec))}s`;
-  if (sec < 3600) return `${Math.round(sec / 60)}m`;
-  if (sec < 86400) return `${Math.round(sec / 3600)}h`;
-  return `${Math.round(sec / 86400)}d`;
 }
 
 function shellQuote(s: string): string {

--- a/src/signals/pulse.ts
+++ b/src/signals/pulse.ts
@@ -127,7 +127,6 @@ function sensedRefs(records: OvercastRecord[]): Set<string> {
 /** Per-source coverage funnel: configured sources joined to their scan hits,
  *  captures (via source_id → hit → capture provenance), and sensed media. */
 function buildCoverage(records: OvercastRecord[], sources: SourceEntry[], now: number): SourceCoverage[] {
-  const fresh = new Map(sourceScanFreshness(records, now).map((s) => [s.source, s.ageSeconds]));
   const sensed = sensedRefs(records);
   const captures = records.filter((r) => r.verb === "capture" && isReady(r));
 
@@ -147,8 +146,11 @@ function buildCoverage(records: OvercastRecord[], sources: SourceEntry[], now: n
         .map((c) => c.media?.ref ?? (typeof payloadOf(c).path === "string" ? (payloadOf(c).path as string) : undefined))
         .filter((ref): ref is string => !!ref && sensed.has(ref)),
     ).size;
-    const platform = typeof payloadOf(hitRecords[0] ?? {}).source === "string" ? String(payloadOf(hitRecords[0]).source) : undefined;
-    const age = platform ? fresh.get(platform) ?? null : null;
+    // per-SOURCE freshness: newest of THIS source's own hit records (source_id),
+    // not the platform-shared freshness — two x:@a / x:@b sources must not share
+    // an age just because they're the same platform.
+    const lastHitMs = Math.max(Number.NEGATIVE_INFINITY, ...hitRecords.map(timeMs).filter((t) => !Number.isNaN(t)));
+    const age = Number.isFinite(lastHitMs) ? Math.max(0, (now - lastHitMs) / 1000) : null;
     return {
       id: src.id,
       spec: `${src.type}:${src.ref}`,

--- a/src/signals/pulse.ts
+++ b/src/signals/pulse.ts
@@ -1,0 +1,225 @@
+/**
+ * Case pulse — the derived "how is this investigation doing" signal bundle that
+ * status + brief render and wall's HUD reuses. Pure over the record store + state
+ * registries (no I/O). The freshness primitives (sourceScanFreshness, latestTimed)
+ * are the single source of truth for scan/monitor/brief recency — wall imports
+ * them so its HUD can't drift from status.
+ */
+import { findingStatusMap, isMemoryRecord, isReady, type OvercastRecord } from "../record.js";
+import { isRootFindingRecord } from "../verbs/finding.js";
+import { buildThreads, threadsHeadline, type TargetThread } from "./threads.js";
+import type { TargetEntry } from "../state/target.js";
+import { isTargetClosed } from "../state/target.js";
+import type { SourceEntry } from "../state/source.js";
+
+function payloadOf(r: OvercastRecord): Record<string, unknown> {
+  return r.payload && typeof r.payload === "object" ? (r.payload as Record<string, unknown>) : {};
+}
+
+function timeMs(r: OvercastRecord): number {
+  const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+  return Number.isNaN(t) ? NaN : t;
+}
+
+export interface ScanFreshness {
+  source: string;
+  time: string;
+  ageSeconds: number;
+}
+
+/** Last successful scan per source label (payload.source), newest first. Ready
+ *  rows only — a failed/cred-blocked sweep must not read as fresh. Excludes the
+ *  op:pull_progress running-aggregate rows. Shared by wall's HUD and casePulse. */
+export function sourceScanFreshness(records: OvercastRecord[], now: number): ScanFreshness[] {
+  const scanTimes = new Map<string, number>();
+  for (const r of records) {
+    if (r.verb !== "scan" || !isReady(r)) continue;
+    const p = payloadOf(r);
+    if (p.op === "pull_progress") continue;
+    const t = timeMs(r);
+    if (Number.isNaN(t)) continue;
+    const source = typeof p.source === "string" && p.source ? p.source : "scan";
+    if (t > (scanTimes.get(source) ?? Number.NEGATIVE_INFINITY)) scanTimes.set(source, t);
+  }
+  return [...scanTimes.entries()]
+    .map(([source, t]) => ({ source, time: new Date(t).toISOString(), ageSeconds: Math.max(0, (now - t) / 1000) }))
+    .sort((a, b) => a.ageSeconds - b.ageSeconds);
+}
+
+/** Newest ready record of a verb + its parsed epoch-ms time. */
+export function latestTimed(records: OvercastRecord[], verb: string): { rec: OvercastRecord; t: number } | undefined {
+  let best: { rec: OvercastRecord; t: number } | undefined;
+  for (const rec of records) {
+    if (rec.verb !== verb || !isReady(rec)) continue;
+    const t = timeMs(rec);
+    if (Number.isNaN(t)) continue;
+    if (!best || t > best.t) best = { rec, t };
+  }
+  return best;
+}
+
+export interface SourceCoverage {
+  id: string;
+  spec: string;
+  type: string;
+  enabled: boolean;
+  lastScanAgeSeconds: number | null;
+  hits: number;
+  captured: number;
+  sensed: number;
+  /** enabled source that has never produced a ready scan hit */
+  gap: boolean;
+}
+
+export interface TriageCounts {
+  suggested: number;
+  open: number;
+  accepted: number;
+  dismissed: number;
+}
+
+export interface CasePulse {
+  headline: string;
+  threads: TargetThread[];
+  progress: {
+    targets_total: number;
+    targets_open: number;
+    targets_answered: number;
+    targets_dead: number;
+    open_findings: number;
+    accepted_findings: number;
+    triage_pending: number;
+  };
+  triage: TriageCounts;
+  coverage: SourceCoverage[];
+  media: { captured: number; sensed: number; unsensed: number };
+  freshness: {
+    lastScans: ScanFreshness[];
+    lastScanAgeSeconds: number | null;
+    monitor: { time: string; ageSeconds: number; newItems: number } | null;
+    briefAgeSeconds: number | null;
+  };
+  gaps: string[];
+}
+
+const SENSE_VERBS = new Set(["watch", "listen", "see", "face", "image", "similar", "cluster", "crop", "enhance"]);
+
+/** Triage buckets over root findings, by effective (reviewed) status. */
+export function triageCounts(records: OvercastRecord[]): TriageCounts {
+  const statusMap = findingStatusMap(records);
+  const out: TriageCounts = { suggested: 0, open: 0, accepted: 0, dismissed: 0 };
+  for (const f of records.filter(isRootFindingRecord)) {
+    const s = (statusMap.get(f.id) ?? "open") as keyof TriageCounts;
+    if (s in out) out[s] += 1;
+  }
+  return out;
+}
+
+/** The set of media refs that have ≥1 ready sense record. */
+function sensedRefs(records: OvercastRecord[]): Set<string> {
+  const refs = new Set<string>();
+  for (const r of records) {
+    if (SENSE_VERBS.has(r.verb) && isReady(r) && r.media?.ref) refs.add(r.media.ref);
+  }
+  return refs;
+}
+
+/** Per-source coverage funnel: configured sources joined to their scan hits,
+ *  captures (via source_id → hit → capture provenance), and sensed media. */
+function buildCoverage(records: OvercastRecord[], sources: SourceEntry[], now: number): SourceCoverage[] {
+  const fresh = new Map(sourceScanFreshness(records, now).map((s) => [s.source, s.ageSeconds]));
+  const sensed = sensedRefs(records);
+  const captures = records.filter((r) => r.verb === "capture" && isReady(r));
+
+  return sources.map((src) => {
+    const hitRecords = records.filter((r) => {
+      if (r.verb !== "scan" || !isReady(r)) return false;
+      const p = payloadOf(r);
+      return p.source_id === src.id && typeof p.url === "string" && p.url.length > 0;
+    });
+    const hitIds = new Set(hitRecords.map((r) => r.id));
+    const captured = captures.filter((c) => {
+      const p = payloadOf(c);
+      return typeof p.source_record === "string" && hitIds.has(p.source_record);
+    });
+    const sensedCount = new Set(
+      captured
+        .map((c) => c.media?.ref ?? (typeof payloadOf(c).path === "string" ? (payloadOf(c).path as string) : undefined))
+        .filter((ref): ref is string => !!ref && sensed.has(ref)),
+    ).size;
+    const platform = typeof payloadOf(hitRecords[0] ?? {}).source === "string" ? String(payloadOf(hitRecords[0]).source) : undefined;
+    const age = platform ? fresh.get(platform) ?? null : null;
+    return {
+      id: src.id,
+      spec: `${src.type}:${src.ref}`,
+      type: src.type,
+      enabled: src.enabled,
+      lastScanAgeSeconds: age,
+      hits: hitRecords.length,
+      captured: captured.length,
+      sensed: sensedCount,
+      gap: src.enabled && hitRecords.length === 0,
+    };
+  });
+}
+
+export interface CasePulseInput {
+  records: OvercastRecord[];
+  targets: TargetEntry[];
+  sources: SourceEntry[];
+  now?: number;
+}
+
+/** Assemble the full case pulse. `now` injectable for deterministic tests. */
+export function casePulse(input: CasePulseInput): CasePulse {
+  const now = input.now ?? Date.now();
+  const { records, targets, sources } = input;
+
+  const threads = buildThreads(records, targets, now);
+  const triage = triageCounts(records);
+  const coverage = buildCoverage(records, sources, now);
+
+  const captures = records.filter((r) => r.verb === "capture" && isReady(r));
+  const sensed = sensedRefs(records);
+  const capturedRefs = new Set(captures.map((c) => c.media?.ref ?? (typeof payloadOf(c).path === "string" ? (payloadOf(c).path as string) : c.id)));
+  const sensedCaptured = [...capturedRefs].filter((ref) => sensed.has(ref)).length;
+
+  const lastScans = sourceScanFreshness(records, now);
+  const monitorLatest = latestTimed(records, "monitor");
+  const briefLatest = latestTimed(records, "brief");
+  const newItems = monitorLatest ? payloadOf(monitorLatest.rec).new_items : undefined;
+
+  const gaps: string[] = [];
+  for (const c of coverage) if (c.gap) gaps.push(`${c.spec} enabled but never scanned`);
+  const unsensed = captures.length - sensedCaptured;
+  if (unsensed > 0) gaps.push(`${unsensed} capture${unsensed === 1 ? "" : "s"} pulled but never sensed`);
+
+  const answered = targets.filter((t) => t.status === "answered").length;
+  const dead = targets.filter((t) => t.status === "dead-end").length;
+
+  return {
+    headline: threadsHeadline(threads, triage.suggested),
+    threads,
+    progress: {
+      targets_total: targets.length,
+      targets_open: targets.filter((t) => !isTargetClosed(t)).length,
+      targets_answered: answered,
+      targets_dead: dead,
+      open_findings: triage.open,
+      accepted_findings: triage.accepted,
+      triage_pending: triage.suggested,
+    },
+    triage,
+    coverage,
+    media: { captured: captures.length, sensed: sensedCaptured, unsensed: Math.max(0, unsensed) },
+    freshness: {
+      lastScans,
+      lastScanAgeSeconds: lastScans.length ? lastScans[0].ageSeconds : null,
+      monitor: monitorLatest
+        ? { time: new Date(monitorLatest.t).toISOString(), ageSeconds: Math.max(0, (now - monitorLatest.t) / 1000), newItems: typeof newItems === "number" ? newItems : 0 }
+        : null,
+      briefAgeSeconds: briefLatest ? Math.max(0, (now - briefLatest.t) / 1000) : null,
+    },
+    gaps,
+  };
+}

--- a/src/signals/pulse.ts
+++ b/src/signals/pulse.ts
@@ -129,17 +129,24 @@ function sensedRefs(records: OvercastRecord[]): Set<string> {
 function buildCoverage(records: OvercastRecord[], sources: SourceEntry[], now: number): SourceCoverage[] {
   const sensed = sensedRefs(records);
   const captures = records.filter((r) => r.verb === "capture" && isReady(r));
+  // how many enabled sources share each platform type — an unstamped hit can
+  // only be attributed by type when that type has a SINGLE source (otherwise
+  // it's ambiguous and attributing to all would double-count / clear real gaps).
+  const typeCount = new Map<string, number>();
+  for (const s of sources) typeCount.set(s.type, (typeCount.get(s.type) ?? 0) + 1);
 
   return sources.map((src) => {
+    const uniqueOfType = (typeCount.get(src.type) ?? 0) === 1;
     const hitRecords = records.filter((r) => {
       if (r.verb !== "scan" || !isReady(r)) return false;
       const p = payloadOf(r);
       if (typeof p.url !== "string" || !p.url.length) return false;
       // exact match on the stamped source_id (current pipeline stamps it at
-      // enumerate time); fall back to the platform type for legacy/adhoc hits
-      // that predate stamping, so real sweeps don't read as "never scanned".
+      // enumerate time); fall back to the platform type ONLY for the unique
+      // source of that type, so legacy/adhoc hits don't read as "never scanned"
+      // without over-attributing an ambiguous hit to every same-type source.
       if (typeof p.source_id === "string") return p.source_id === src.id;
-      return typeof p.source === "string" && p.source === src.type;
+      return uniqueOfType && typeof p.source === "string" && p.source === src.type;
     });
     const hitIds = new Set(hitRecords.map((r) => r.id));
     const captured = captures.filter((c) => {

--- a/src/signals/pulse.ts
+++ b/src/signals/pulse.ts
@@ -134,7 +134,12 @@ function buildCoverage(records: OvercastRecord[], sources: SourceEntry[], now: n
     const hitRecords = records.filter((r) => {
       if (r.verb !== "scan" || !isReady(r)) return false;
       const p = payloadOf(r);
-      return p.source_id === src.id && typeof p.url === "string" && p.url.length > 0;
+      if (typeof p.url !== "string" || !p.url.length) return false;
+      // exact match on the stamped source_id (current pipeline stamps it at
+      // enumerate time); fall back to the platform type for legacy/adhoc hits
+      // that predate stamping, so real sweeps don't read as "never scanned".
+      if (typeof p.source_id === "string") return p.source_id === src.id;
+      return typeof p.source === "string" && p.source === src.type;
     });
     const hitIds = new Set(hitRecords.map((r) => r.id));
     const captured = captures.filter((c) => {

--- a/src/signals/rollup.ts
+++ b/src/signals/rollup.ts
@@ -1,0 +1,95 @@
+/**
+ * Timeline rollups — collapse a fan-out of records into digestible groups so a
+ * brief's record trail reads as "one artifact, five looks" instead of dozens of
+ * loose rows. Pure derivation, no I/O.
+ *
+ * Grouping precedence (each record joins the first that applies):
+ *  1. shared media.ref → an "artifact" group (the clip/image + every sense/crop
+ *     record on it), reusing the wall's ref-grouping idea;
+ *  2. provenance source_record → fold a match/crop/finding into its parent
+ *     artifact group when it cites one;
+ *  3. otherwise a singleton "record" group.
+ *
+ * meta.run (a per-scan/monitor run id) is an OPTIONAL first key: when present it
+ * wins, so a whole sweep collapses to one "sweep" group. Records without it fall
+ * through to the media-chain rules — so this works today without stamping runs.
+ */
+import type { OvercastRecord } from "../record.js";
+
+export interface TimelineGroup {
+  key: string;
+  kind: "sweep" | "artifact" | "record";
+  title: string;
+  /** per-verb counts inside the group */
+  counts: Record<string, number>;
+  /** newest record time in the group (ISO), or undefined */
+  time?: string;
+  /** ids of the grouped records, chronological */
+  recordIds: string[];
+}
+
+function payloadOf(r: OvercastRecord): Record<string, unknown> {
+  return r.payload && typeof r.payload === "object" ? (r.payload as Record<string, unknown>) : {};
+}
+
+function timeMs(r: OvercastRecord): number {
+  const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+  return Number.isNaN(t) ? Number.POSITIVE_INFINITY : t;
+}
+
+function baseName(ref: string): string {
+  const parts = ref.replace(/[?#].*$/, "").split(/[\\/]/);
+  return parts[parts.length - 1] || ref;
+}
+
+/** The grouping key + kind for a record: run > media.ref > source_record > self. */
+function keyFor(r: OvercastRecord, refByRecordId: Map<string, string>): { key: string; kind: TimelineGroup["kind"] } {
+  const run = r.meta?.run;
+  if (typeof run === "string" && run) return { key: `run:${run}`, kind: "sweep" };
+  if (r.media?.ref) return { key: `ref:${r.media.ref}`, kind: "artifact" };
+  const src = payloadOf(r).source_record;
+  if (typeof src === "string" && refByRecordId.has(src)) return { key: `ref:${refByRecordId.get(src)}`, kind: "artifact" };
+  return { key: `rec:${r.id}`, kind: "record" };
+}
+
+/** Group a chronological record list into digestible timeline groups. */
+export function groupTimeline(records: OvercastRecord[]): TimelineGroup[] {
+  // first pass: map record id → its media.ref, so a child citing a parent by
+  // source_record can join the parent's artifact group.
+  const refByRecordId = new Map<string, string>();
+  for (const r of records) if (r.media?.ref) refByRecordId.set(r.id, r.media.ref);
+
+  const groups = new Map<string, TimelineGroup>();
+  const order: string[] = [];
+  for (const r of records) {
+    const { key, kind } = keyFor(r, refByRecordId);
+    let g = groups.get(key);
+    if (!g) {
+      g = { key, kind, title: titleFor(kind, key), counts: {}, recordIds: [] };
+      groups.set(key, g);
+      order.push(key);
+    }
+    g.counts[r.verb] = (g.counts[r.verb] ?? 0) + 1;
+    g.recordIds.push(r.id);
+    const t = timeMs(r);
+    if (Number.isFinite(t)) {
+      const prev = g.time ? Date.parse(g.time) : Number.NEGATIVE_INFINITY;
+      if (t > prev) g.time = new Date(t).toISOString();
+    }
+  }
+  return order.map((k) => groups.get(k)!);
+}
+
+function titleFor(kind: TimelineGroup["kind"], key: string): string {
+  if (kind === "sweep") return `sweep ${key.slice("run:".length)}`;
+  if (kind === "artifact") return baseName(key.slice("ref:".length));
+  return key.slice("rec:".length);
+}
+
+/** A one-line "verb ×n, verb ×n" summary of a group's contents. */
+export function groupSummary(g: TimelineGroup): string {
+  return Object.entries(g.counts)
+    .sort()
+    .map(([verb, n]) => (n === 1 ? verb : `${verb} ×${n}`))
+    .join(", ");
+}

--- a/src/signals/threads.ts
+++ b/src/signals/threads.ts
@@ -64,6 +64,9 @@ export interface TargetThread {
   recentIds: string[];
   /** a short "why" for a dead/answered line, else undefined */
   why?: string;
+  /** newest `thread:<id>`-tagged note text — the analyst's line narrative from
+   *  `/debrief`, surfaced on the brief/status thread cards */
+  narrative?: string;
 }
 
 const SENSE_VERBS = new Set(["watch", "listen", "see", "face", "image", "similar", "cluster", "crop", "enhance"]);
@@ -184,6 +187,16 @@ export function buildThreads(records: OvercastRecord[], targets: TargetEntry[], 
       ? undefined
       : target.status_note ?? (status === "answered" ? "closed as answered" : "closed as dead end");
 
+    // newest `thread:<id>` note = the analyst's line narrative (from /debrief)
+    const narrative = [...linkedEvidence]
+      .filter((r) => noteTaggedForThread(r, target.id))
+      .sort((a, b) => timeOf(b) - timeOf(a))
+      .map((r) => {
+        const t = payloadOf(r).text;
+        return typeof t === "string" && t.trim() ? t.trim() : undefined;
+      })
+      .find(Boolean);
+
     return {
       id: target.id,
       value: target.value,
@@ -200,6 +213,7 @@ export function buildThreads(records: OvercastRecord[], targets: TargetEntry[], 
       activityBins: activityBins(times, now),
       recentIds,
       why,
+      narrative,
     };
   });
 }

--- a/src/signals/threads.ts
+++ b/src/signals/threads.ts
@@ -1,0 +1,221 @@
+/**
+ * Threads — a "line of investigation" is a target, viewed through the evidence,
+ * findings, and notes linked to it. Pure derivation over the record store (no
+ * I/O), so brief + status render the same struct.
+ *
+ * Linking (priority order, all derived — no new persisted links):
+ *  1. findings by payload.target_id === target.id, or payload.target === value;
+ *  2. name/prompt targets: evidence records whose text contains the value
+ *     (targetMatchesEvidence — the same matcher the text-target trigger uses);
+ *  3. image targets: face/image/similar/cluster records referencing the value;
+ *  4. notes tagged `thread:<tgt_id>` (the /debrief convention).
+ *
+ * Stage — the honest goal-progress ordinal (no fake %):
+ *   answered / dead-end  ← analyst declared via `target close`
+ *   corroborated         ← ≥1 accepted finding linked
+ *   leads                ← ≥1 open/suggested finding linked
+ *   collecting           ← ≥1 evidence record linked
+ *   cold                 ← nothing linked yet
+ */
+import { findingStatusMap, isMemoryRecord, isReady, type OvercastRecord } from "../record.js";
+import { isRootFindingRecord } from "../verbs/finding.js";
+import { targetMatchesEvidence, payloadText } from "./triggers.js";
+import { targetStatus, type TargetEntry } from "../state/target.js";
+
+export type ThreadStage = "answered" | "dead-end" | "corroborated" | "leads" | "collecting" | "cold";
+
+/** Display labels for the thread stages — shared by brief + status renderers. */
+export const THREAD_STAGE_LABEL: Record<ThreadStage, string> = {
+  answered: "ANSWERED",
+  "dead-end": "DEAD-END",
+  corroborated: "CORROBORATED",
+  leads: "LEADS",
+  collecting: "COLLECTING",
+  cold: "COLD",
+};
+
+export interface ThreadFindingCounts {
+  suggested: number;
+  open: number;
+  accepted: number;
+  dismissed: number;
+}
+
+export interface TargetThread {
+  id: string;
+  value: string;
+  kind: TargetEntry["kind"];
+  question?: string;
+  status: "active" | "answered" | "dead-end";
+  status_note?: string;
+  stage: ThreadStage;
+  /** per-evidence-verb counts of linked records (findings excluded) */
+  evidence: Record<string, number>;
+  /** rolled-up funnel numbers for the one-line thread summary */
+  funnel: { scan: number; captures: number; senses: number; matches: number };
+  findings: ThreadFindingCounts;
+  /** newest linked-activity timestamp (ISO), or undefined when cold */
+  lastActivity?: string;
+  /** count of linked evidence records in the last 24h / 7d — the momentum read */
+  recent: { day: number; week: number };
+  /** ≤8 activity bins (oldest→newest) of linked-record counts, for a sparkline */
+  activityBins: number[];
+  /** ids of the most recent linked records (evidence + findings), newest first */
+  recentIds: string[];
+  /** a short "why" for a dead/answered line, else undefined */
+  why?: string;
+}
+
+const SENSE_VERBS = new Set(["watch", "listen", "see", "face", "image", "similar", "cluster", "crop", "enhance"]);
+const MATCH_VERBS = new Set(["face", "image", "similar", "cluster"]);
+
+function payloadOf(r: OvercastRecord): Record<string, unknown> {
+  return r.payload && typeof r.payload === "object" ? (r.payload as Record<string, unknown>) : {};
+}
+
+function timeOf(r: OvercastRecord): number {
+  const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function baseName(ref: string): string {
+  const parts = ref.replace(/[?#].*$/, "").split(/[\\/]/);
+  return (parts[parts.length - 1] || ref).toLowerCase();
+}
+
+/** Does a match/reference record point at an image target's ref? */
+function referencesImageTarget(rec: OvercastRecord, value: string): boolean {
+  const p = payloadOf(rec);
+  const candidates = [p.reference, p.query, p.input, p.file, rec.media?.ref].filter((x): x is string => typeof x === "string");
+  const target = baseName(value);
+  return candidates.some((c) => c === value || baseName(c) === target);
+}
+
+/** notes tagged `thread:<tgt_id>` — the /debrief per-thread narrative anchor. */
+function noteTaggedForThread(rec: OvercastRecord, targetId: string): boolean {
+  if (rec.verb !== "note") return false;
+  const tags = payloadOf(rec).tags;
+  return Array.isArray(tags) && tags.some((t) => String(t).toLowerCase() === `thread:${targetId.toLowerCase()}`);
+}
+
+/** Whether a (non-finding) evidence record links to a target. */
+function evidenceLinksTarget(rec: OvercastRecord, target: TargetEntry): boolean {
+  if (noteTaggedForThread(rec, target.id)) return true;
+  if (target.kind === "image") {
+    return MATCH_VERBS.has(rec.verb) && referencesImageTarget(rec, target.value);
+  }
+  return targetMatchesEvidence(target.value, payloadText(rec));
+}
+
+function findingLinksTarget(finding: OvercastRecord, target: TargetEntry): boolean {
+  const p = payloadOf(finding);
+  if (typeof p.target_id === "string" && p.target_id === target.id) return true;
+  return typeof p.target === "string" && p.target.length > 0 && p.target === target.value;
+}
+
+function stageFor(status: "active" | "answered" | "dead-end", findings: ThreadFindingCounts, evidenceCount: number): ThreadStage {
+  if (status === "answered") return "answered";
+  if (status === "dead-end") return "dead-end";
+  if (findings.accepted > 0) return "corroborated";
+  if (findings.open > 0 || findings.suggested > 0) return "leads";
+  if (evidenceCount > 0) return "collecting";
+  return "cold";
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+
+/** Bucket linked-record timestamps into `bins` bins spanning first→now. */
+function activityBins(times: number[], now: number, bins = 8): number[] {
+  const out = new Array(bins).fill(0);
+  const dated = times.filter((t) => t > 0);
+  if (!dated.length) return out;
+  const first = Math.min(...dated);
+  const span = Math.max(now - first, 1);
+  for (const t of dated) {
+    const idx = Math.min(bins - 1, Math.floor(((t - first) / span) * bins));
+    out[idx] += 1;
+  }
+  return out;
+}
+
+/** Build the per-target thread views. `now` is injectable for deterministic tests. */
+export function buildThreads(records: OvercastRecord[], targets: TargetEntry[], now = Date.now()): TargetThread[] {
+  const statusMap = findingStatusMap(records);
+  const findings = records.filter(isRootFindingRecord);
+  // non-finding evidence candidates (memory-eligible, excludes operational/meta)
+  const evidence = records.filter((r) => r.verb !== "finding" && isMemoryRecord(r));
+
+  return targets.map((target) => {
+    const status = targetStatus(target);
+    const linkedEvidence = evidence.filter((r) => evidenceLinksTarget(r, target));
+    const linkedFindings = findings.filter((f) => findingLinksTarget(f, target));
+
+    const counts: ThreadFindingCounts = { suggested: 0, open: 0, accepted: 0, dismissed: 0 };
+    for (const f of linkedFindings) {
+      const s = (statusMap.get(f.id) ?? "open") as keyof ThreadFindingCounts;
+      if (s in counts) counts[s] += 1;
+    }
+
+    const evidenceByVerb: Record<string, number> = {};
+    for (const r of linkedEvidence) evidenceByVerb[r.verb] = (evidenceByVerb[r.verb] ?? 0) + 1;
+
+    const funnel = {
+      scan: linkedEvidence.filter((r) => r.verb === "scan").length,
+      captures: linkedEvidence.filter((r) => r.verb === "capture").length,
+      senses: linkedEvidence.filter((r) => SENSE_VERBS.has(r.verb)).length,
+      matches: linkedEvidence.filter((r) => MATCH_VERBS.has(r.verb)).length,
+    };
+
+    // activity = linked evidence + linked findings (leads count as activity)
+    const activity = [...linkedEvidence, ...linkedFindings];
+    const times = activity.map(timeOf);
+    const lastMs = times.length ? Math.max(...times) : 0;
+    const recentDay = times.filter((t) => t > 0 && now - t <= DAY_MS).length;
+    const recentWeek = times.filter((t) => t > 0 && now - t <= WEEK_MS).length;
+
+    const recentIds = [...activity]
+      .sort((a, b) => timeOf(b) - timeOf(a))
+      .slice(0, 8)
+      .map((r) => r.id);
+
+    const stage = stageFor(status, counts, linkedEvidence.length);
+    const why = status === "active"
+      ? undefined
+      : target.status_note ?? (status === "answered" ? "closed as answered" : "closed as dead end");
+
+    return {
+      id: target.id,
+      value: target.value,
+      kind: target.kind,
+      question: target.question,
+      status,
+      status_note: target.status_note,
+      stage,
+      evidence: evidenceByVerb,
+      funnel,
+      findings: counts,
+      lastActivity: lastMs ? new Date(lastMs).toISOString() : undefined,
+      recent: { day: recentDay, week: recentWeek },
+      activityBins: activityBins(times, now),
+      recentIds,
+      why,
+    };
+  });
+}
+
+/** A one-sentence progress read across all threads — the "how close to goal"
+ *  line for status/brief headlines. */
+export function threadsHeadline(threads: TargetThread[], triagePending: number): string {
+  if (!threads.length) return triagePending ? `No lines of investigation yet; ${triagePending} suggestion${triagePending === 1 ? "" : "s"} awaiting triage` : "No lines of investigation yet";
+  const active = threads.filter((t) => t.status === "active");
+  const answered = threads.filter((t) => t.status === "answered").length;
+  const dead = threads.filter((t) => t.status === "dead-end").length;
+  const withLeads = active.filter((t) => t.stage === "leads" || t.stage === "corroborated").length;
+  const parts: string[] = [];
+  if (active.length) parts.push(`${active.length} line${active.length === 1 ? "" : "s"} active${withLeads ? ` (${withLeads} with leads)` : ""}`);
+  if (answered) parts.push(`${answered} answered`);
+  if (dead) parts.push(`${dead} dead-end`);
+  if (triagePending) parts.push(`${triagePending} suggestion${triagePending === 1 ? "" : "s"} awaiting triage`);
+  return parts.join(", ") || "No open lines of investigation";
+}

--- a/src/signals/triggers.ts
+++ b/src/signals/triggers.ts
@@ -25,6 +25,12 @@ import type { CaseSetup, SetupFindingsPolicy, SetupFindingsThresholds } from "..
 
 export const DEFAULT_FINDINGS_MODE = "suggest";
 
+/** Verbs whose payload carries meaningful free text a target phrase can match:
+ *  analyzed media (watch/listen/see) + analyst notes. Scan enumeration hits and
+ *  raw captures are excluded so one item can't emit a text lead from its hit AND
+ *  again from its analyzed content (matches the pre-persist-hook chain reach). */
+export const TEXT_TARGET_VERBS: ReadonlySet<string> = new Set(["watch", "listen", "see", "note"]);
+
 /** Fire floors (score triggers skip matches below these) and "high" confidence
  *  bands. face/similar/cluster are 0–100 percent; image is inlier count. */
 export interface TriggerThresholds {
@@ -279,9 +285,15 @@ export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
     // and would otherwise self-match the text-target trigger.
     if (rec.verb === "finding" || !isMemoryRecord(rec)) continue;
 
-    // text-target: both modes; status + dismissed semantics differ.
+    // text-target: only content-bearing evidence (analyzed media + analyst
+    // notes), NOT scan enumeration hits or raw captures. The old chain ran the
+    // text trigger on the SENSED record only; the persist hook now sees every
+    // record, so without this gate a target phrase in a scan-hit title AND in the
+    // watch content of the same item would emit two leads (different source_record
+    // + media.ref, so dedup can't fold them). Multi-sense-on-one-clip still folds
+    // via the shared media.ref in hasEquivalentFinding.
     const haystack = payloadText(rec);
-    for (const target of opts.targets) {
+    for (const target of TEXT_TARGET_VERBS.has(rec.verb) ? opts.targets : []) {
       if (target.kind === "image") continue;
       if (!targetMatchesEvidence(target.value, haystack)) continue;
       const all = seen();

--- a/src/signals/triggers.ts
+++ b/src/signals/triggers.ts
@@ -25,11 +25,18 @@ import type { CaseSetup, SetupFindingsPolicy, SetupFindingsThresholds } from "..
 
 export const DEFAULT_FINDINGS_MODE = "suggest";
 
-/** Verbs whose payload carries meaningful free text a target phrase can match:
- *  analyzed media (watch/listen/see) + analyst notes. Scan enumeration hits and
- *  raw captures are excluded so one item can't emit a text lead from its hit AND
- *  again from its analyzed content (matches the pre-persist-hook chain reach). */
-export const TEXT_TARGET_VERBS: ReadonlySet<string> = new Set(["watch", "listen", "see", "note"]);
+/** Verbs whose payload is MACHINE-analyzed content a target phrase can surface
+ *  in unexpectedly (watch/listen/see). Deliberately excludes:
+ *   - scan hits / raw captures — enumeration metadata; one item must not lead
+ *     from its hit AND again from its analyzed content (undedupable — different
+ *     source_record + media.ref);
+ *   - notes — analyst-authored input, not machine-discovered evidence. The
+ *     `/debrief` `thread:`/`tldr` notes routinely name the target, and
+ *     auto-suggesting a finding that cites the analyst's own narrative is pure
+ *     triage noise. Analysts promote a note to a finding explicitly via
+ *     `finding create`.
+ *  This matches the pre-persist-hook chain reach (it only ran on sensed records). */
+export const TEXT_TARGET_VERBS: ReadonlySet<string> = new Set(["watch", "listen", "see"]);
 
 /** Fire floors (score triggers skip matches below these) and "high" confidence
  *  bands. face/similar/cluster are 0–100 percent; image is inlier count. */

--- a/src/signals/triggers.ts
+++ b/src/signals/triggers.ts
@@ -20,7 +20,7 @@
  */
 import { findingStatusMap, isMemoryRecord, type OvercastRecord } from "../record.js";
 import { makeFinding } from "../verbs/finding.js";
-import type { TargetEntry } from "../state/target.js";
+import { isTargetClosed, type TargetEntry } from "../state/target.js";
 import type { CaseSetup, SetupFindingsPolicy, SetupFindingsThresholds } from "../state/setup.js";
 
 export const DEFAULT_FINDINGS_MODE = "suggest";
@@ -276,6 +276,11 @@ export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
   const mode = opts.policy?.mode ?? DEFAULT_FINDINGS_MODE;
   if (mode !== "review" && mode !== "suggest") return [];
   const thresholds = resolvedThresholds(opts.policy);
+  // closed lines (answered/dead-end) are no longer actively pursued, so they
+  // must not accumulate new suggested findings — same invariant scanLocalCase /
+  // primaryTarget enforce. A score match on media still fires unlinked (the
+  // match is intrinsically interesting), it just isn't attributed to a dead line.
+  const targets = opts.targets.filter((t) => !isTargetClosed(t));
   const out: OvercastRecord[] = [];
   const seen = () => [...opts.existing, ...(opts.pending ?? []), ...out];
 
@@ -293,7 +298,7 @@ export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
     // + media.ref, so dedup can't fold them). Multi-sense-on-one-clip still folds
     // via the shared media.ref in hasEquivalentFinding.
     const haystack = payloadText(rec);
-    for (const target of TEXT_TARGET_VERBS.has(rec.verb) ? opts.targets : []) {
+    for (const target of TEXT_TARGET_VERBS.has(rec.verb) ? targets : []) {
       if (target.kind === "image") continue;
       if (!targetMatchesEvidence(target.value, haystack)) continue;
       const all = seen();
@@ -317,7 +322,7 @@ export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
     if (mode !== "suggest") continue;
     const sig = extractSignal(rec, thresholds);
     if (!sig) continue;
-    const target = linkImageTarget(opts.targets, [
+    const target = linkImageTarget(targets, [
       obj(rec.payload)?.reference as string | undefined,
       sig.matched,
     ]);

--- a/src/signals/triggers.ts
+++ b/src/signals/triggers.ts
@@ -1,0 +1,331 @@
+/**
+ * Finding triggers — the "does this evidence deserve the analyst's attention?"
+ * layer. Pure functions over records: no I/O, no provider calls, offline-testable
+ * (like report/wall.ts). Two trigger families share one dedup + policy gate:
+ *
+ * - text-target: a non-image target's phrase appears verbatim in a sensed
+ *   payload (the original scan/monitor automation, moved here from verbs/osint.ts).
+ * - score triggers: a face/image/similar/cluster match record clears its
+ *   similarity threshold (face + similar + cluster scores are 0–100 percent,
+ *   image is RANSAC inlier count — NOT 0–1 fractions).
+ *
+ * Policy (setup.findings.mode):
+ * - "suggest" (default, incl. missing setup): all triggers fire, emitting root
+ *   findings with status "suggested" — quarantined from memory/brief evidence
+ *   until reviewed (finding accept/dismiss); a dismissed suggestion never
+ *   re-fires for the same (kind, target, source) key.
+ * - "review" (legacy): text-target only, status "open"; dismissed does NOT
+ *   block re-creation (preserved pre-suggest semantics).
+ * - "off": nothing fires.
+ */
+import { findingStatusMap, isMemoryRecord, type OvercastRecord } from "../record.js";
+import { makeFinding } from "../verbs/finding.js";
+import type { TargetEntry } from "../state/target.js";
+import type { CaseSetup, SetupFindingsPolicy, SetupFindingsThresholds } from "../state/setup.js";
+
+export const DEFAULT_FINDINGS_MODE = "suggest";
+
+/** Fire floors (score triggers skip matches below these) and "high" confidence
+ *  bands. face/similar/cluster are 0–100 percent; image is inlier count. */
+export interface TriggerThresholds {
+  face: number;
+  face_high: number;
+  similar: number;
+  similar_high: number;
+  cluster: number;
+  cluster_high: number;
+  image_inliers: number;
+  image_inliers_high: number;
+}
+
+export const DEFAULT_TRIGGER_THRESHOLDS: TriggerThresholds = {
+  face: 75,
+  face_high: 85,
+  similar: 85,
+  similar_high: 90,
+  cluster: 70,
+  cluster_high: 80,
+  image_inliers: 1,
+  image_inliers_high: 40,
+};
+
+/** The saved findings policy, with the missing-setup / missing-policy default
+ *  applied: suggestions are on unless a case explicitly opted out. */
+export function resolveFindingsPolicy(setup: CaseSetup | undefined): SetupFindingsPolicy {
+  return setup?.findings ?? { mode: DEFAULT_FINDINGS_MODE };
+}
+
+export function payloadText(rec: OvercastRecord): string {
+  if (typeof rec.payload === "string") return rec.payload;
+  try {
+    return JSON.stringify(rec.payload);
+  } catch {
+    return "";
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Whole-phrase, case-insensitive, word-boundaried match of a target value
+ *  against serialized evidence text. Shared by triggers and thread linking. */
+export function targetMatchesEvidence(target: string, text: string): boolean {
+  const normalizedTarget = target.trim().replace(/\s+/g, " ");
+  if (!normalizedTarget) return false;
+  const phrase = normalizedTarget.split(" ").map(escapeRegex).join("\\s+");
+  return new RegExp(`(^|[^\\p{L}\\p{N}_])${phrase}(?=$|[^\\p{L}\\p{N}_])`, "iu").test(text);
+}
+
+/** A cleared score trigger, ready to ride into the finding payload. */
+export interface TriggerSignal {
+  kind: "face-match" | "image-match" | "similar-match" | "cluster-identify" | "text-target";
+  score?: number;
+  threshold?: number;
+  unit?: "percent" | "inliers";
+  /** the best-scoring moment (seconds or span) in the source media, if anchored */
+  at?: number | [number, number];
+  /** matched ref / person label — whatever names the other side of the match */
+  matched?: string;
+}
+
+type Obj = Record<string, unknown>;
+
+function obj(v: unknown): Obj | undefined {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Obj) : undefined;
+}
+
+function arr(v: unknown): Obj[] {
+  return Array.isArray(v) ? (v.filter((x) => x && typeof x === "object") as Obj[]) : [];
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function atOf(entry: Obj): number | [number, number] | undefined {
+  const a = entry.at;
+  if (typeof a === "number") return a;
+  if (Array.isArray(a) && typeof a[0] === "number" && typeof a[1] === "number") return [a[0], a[1]];
+  return undefined;
+}
+
+/** Best (score, at, matched) across an array of match/face entries. */
+function best(entries: Obj[], scoreKey: string): { score: number; at?: number | [number, number]; matched?: string } | undefined {
+  let top: { score: number; at?: number | [number, number]; matched?: string } | undefined;
+  for (const e of entries) {
+    const s = num(e[scoreKey]);
+    if (s === undefined) continue;
+    if (!top || s > top.score) {
+      const matched = typeof e.ref === "string" ? e.ref : typeof e.file === "string" ? e.file : typeof e.label === "string" ? e.label : undefined;
+      top = { score: s, at: atOf(e), matched };
+    }
+  }
+  return top;
+}
+
+function definedEntries(o: SetupFindingsThresholds | undefined): Partial<TriggerThresholds> {
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(o ?? {})) if (typeof v === "number") out[k] = v;
+  return out;
+}
+
+function resolvedThresholds(policy: SetupFindingsPolicy | undefined): TriggerThresholds {
+  return { ...DEFAULT_TRIGGER_THRESHOLDS, ...definedEntries(policy?.thresholds) };
+}
+
+/** Extract a cleared score signal from a match-shaped record, or undefined when
+ *  the record isn't a match op / nothing clears the floor. Tolerant of both the
+ *  tinycloud and local (deepface / RANSAC / CLIP) payload shapes. */
+export function extractSignal(rec: OvercastRecord, thresholds: TriggerThresholds): TriggerSignal | undefined {
+  const p = obj(rec.payload);
+  if (!p) return undefined;
+  const op = typeof p.op === "string" ? p.op : undefined;
+
+  if (rec.verb === "face" && op === "match") {
+    // tinycloud + deepface-local both emit faces[] with similarity (0–100);
+    // tinycloud also mirrors a compact moments[] projection.
+    const top = best(arr(p.faces), "similarity") ?? best(arr(p.moments), "similarity");
+    if (!top || top.score < thresholds.face) return undefined;
+    return { kind: "face-match", score: top.score, threshold: thresholds.face, unit: "percent", at: top.at, matched: typeof p.reference === "string" ? p.reference : top.matched };
+  }
+
+  if (rec.verb === "image" && op === "match") {
+    const top = best(arr(p.matches), "num_inliers");
+    if (!top || top.score < thresholds.image_inliers) return undefined;
+    return { kind: "image-match", score: top.score, threshold: thresholds.image_inliers, unit: "inliers", at: top.at, matched: top.matched };
+  }
+
+  if (rec.verb === "similar" && op === "match") {
+    // image→image only; text→image `search` is too noisy to auto-suggest.
+    const top = best(arr(p.matches), "similarity");
+    if (!top || top.score < thresholds.similar) return undefined;
+    return { kind: "similar-match", score: top.score, threshold: thresholds.similar, unit: "percent", at: top.at, matched: top.matched };
+  }
+
+  if (rec.verb === "cluster" && op === "identify") {
+    // matches[] = one entry per probe detection, each ranking candidates[]
+    // (existing people) by similarity — the lead is the best candidate overall.
+    let top: { score: number; at?: number | [number, number]; matched?: string } | undefined;
+    for (const m of arr(p.matches)) {
+      const cand = best(arr(m.candidates), "similarity");
+      if (cand && (!top || cand.score > top.score)) top = { ...cand, at: atOf(m) ?? cand.at };
+    }
+    if (!top || top.score < thresholds.cluster) return undefined;
+    return { kind: "cluster-identify", score: top.score, threshold: thresholds.cluster, unit: "percent", at: top.at, matched: top.matched };
+  }
+
+  return undefined;
+}
+
+function highBandFor(kind: TriggerSignal["kind"], thresholds: TriggerThresholds): number | undefined {
+  if (kind === "face-match") return thresholds.face_high;
+  if (kind === "similar-match") return thresholds.similar_high;
+  if (kind === "cluster-identify") return thresholds.cluster_high;
+  if (kind === "image-match") return thresholds.image_inliers_high;
+  return undefined;
+}
+
+function baseName(ref: string): string {
+  const parts = ref.split(/[\\/]/);
+  return parts[parts.length - 1] || ref;
+}
+
+function mediaName(rec: OvercastRecord): string {
+  return rec.media?.ref ? baseName(rec.media.ref) : `${rec.verb} record ${rec.id}`;
+}
+
+/** Link a score signal to an image target by reference-path match (exact value
+ *  or same basename) so the suggestion lands on the analyst's declared line. */
+function linkImageTarget(targets: TargetEntry[], candidates: Array<string | undefined>): TargetEntry | undefined {
+  const norm = (s: string) => baseName(s).toLowerCase();
+  for (const t of targets) {
+    if (t.kind !== "image") continue;
+    for (const c of candidates) {
+      if (c && (t.value === c || norm(t.value) === norm(c))) return t;
+    }
+  }
+  return undefined;
+}
+
+function suggestionText(rec: OvercastRecord, sig: TriggerSignal, target?: TargetEntry): string {
+  const where = mediaName(rec);
+  const forTarget = target ? ` for target '${target.value}'` : "";
+  if (sig.kind === "face-match") return `Reference face${forTarget} matched at ${sig.score?.toFixed(1)}% similarity in ${where}`;
+  if (sig.kind === "image-match") return `Image fingerprint${forTarget} matched (${sig.score} inliers) in ${where}`;
+  if (sig.kind === "similar-match") return `Visual similarity ${sig.score?.toFixed(1)}% to ${sig.matched ? baseName(sig.matched) : "indexed media"}${forTarget} in ${where}`;
+  if (sig.kind === "cluster-identify") return `Probe face matches known person${sig.matched ? ` '${sig.matched}'` : ""} at ${sig.score?.toFixed(1)}% in ${where}`;
+  return `Automated match${forTarget} in ${rec.verb} record ${rec.id}`;
+}
+
+function signalKindOf(payload: Obj): string {
+  const sig = obj(payload.signal);
+  if (sig && typeof sig.kind === "string") return sig.kind;
+  const trigger = typeof payload.trigger === "string" ? payload.trigger : "";
+  if (trigger.startsWith("signal:")) return trigger.slice("signal:".length);
+  // pre-signal automation and manual findings: treated as text-target-shaped
+  return "text-target";
+}
+
+/** Whether an equivalent finding already exists (store + this pass), so the
+ *  analyst is never nagged twice for the same lead. For suggestions a dismissed
+ *  row blocks re-fire; legacy review mode keeps its refire-after-dismiss shape. */
+function hasEquivalentFinding(
+  records: OvercastRecord[],
+  statusMap: Map<string, string>,
+  q: { kind: string; target: string; sourceRecord: OvercastRecord; dismissedBlocks: boolean },
+): boolean {
+  return records.some((rec) => {
+    if (rec.verb !== "finding" || !rec.payload || typeof rec.payload !== "object") return false;
+    const payload = rec.payload as Obj;
+    if (typeof payload.finding_id === "string") return false;
+    if (!q.dismissedBlocks && (statusMap.get(rec.id) ?? "open") === "dismissed") return false;
+    const sameSource = payload.source_record === q.sourceRecord.id;
+    const sameMedia = !!q.sourceRecord.media?.ref && rec.media?.ref === q.sourceRecord.media.ref;
+    if (!sameSource && !sameMedia) return false;
+    // any finding already citing this exact record covers it, whatever the kind
+    // (e.g. an analyst finding on an image-match record beats a re-suggestion).
+    if (sameSource && q.kind !== "text-target") return true;
+    if (signalKindOf(payload) !== q.kind) return false;
+    return String(payload.target ?? "") === q.target;
+  });
+}
+
+export interface EvaluateTriggerOpts {
+  /** just-produced records to evaluate (findings/errors are skipped) */
+  fresh: OvercastRecord[];
+  /** the case store (post-write is fine) — dedup looks here */
+  existing: OvercastRecord[];
+  /** records accumulating in the same pass but not yet persisted */
+  pending?: OvercastRecord[];
+  targets: TargetEntry[];
+  policy: SetupFindingsPolicy | undefined;
+  /** chain context label (e.g. "scan:watch") recorded on the finding */
+  via?: string;
+}
+
+/** Evaluate all finding triggers over fresh records. Returns the new finding
+ *  records to persist (empty when mode is off / nothing clears a threshold). */
+export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
+  const mode = opts.policy?.mode ?? DEFAULT_FINDINGS_MODE;
+  if (mode !== "review" && mode !== "suggest") return [];
+  const thresholds = resolvedThresholds(opts.policy);
+  const out: OvercastRecord[] = [];
+  const seen = () => [...opts.existing, ...(opts.pending ?? []), ...out];
+
+  for (const rec of opts.fresh) {
+    // only true evidence records are trigger SOURCES — never operational/meta
+    // records (prebrief/target/setup/…), whose payloads echo the target value
+    // and would otherwise self-match the text-target trigger.
+    if (rec.verb === "finding" || !isMemoryRecord(rec)) continue;
+
+    // text-target: both modes; status + dismissed semantics differ.
+    const haystack = payloadText(rec);
+    for (const target of opts.targets) {
+      if (target.kind === "image") continue;
+      if (!targetMatchesEvidence(target.value, haystack)) continue;
+      const all = seen();
+      const statusMap = findingStatusMap(all);
+      if (hasEquivalentFinding(all, statusMap, { kind: "text-target", target: target.value, sourceRecord: rec, dismissedBlocks: mode === "suggest" })) continue;
+      out.push(
+        makeFinding({
+          text: `Automated match for target '${target.value}' in ${rec.verb} record ${rec.id}`,
+          target: target.value,
+          targetId: target.id,
+          sourceRecord: rec,
+          trigger: mode === "suggest" ? "signal:text-target" : opts.via ?? "automation",
+          status: mode === "suggest" ? "suggested" : "open",
+          signal: mode === "suggest" ? { kind: "text-target", ...(opts.via ? { via: opts.via } : {}) } : undefined,
+          confidence: mode === "suggest" ? "medium" : undefined,
+        }),
+      );
+    }
+
+    // score triggers: suggest mode only.
+    if (mode !== "suggest") continue;
+    const sig = extractSignal(rec, thresholds);
+    if (!sig) continue;
+    const target = linkImageTarget(opts.targets, [
+      obj(rec.payload)?.reference as string | undefined,
+      sig.matched,
+    ]);
+    const all = seen();
+    const statusMap = findingStatusMap(all);
+    if (hasEquivalentFinding(all, statusMap, { kind: sig.kind, target: target?.value ?? "", sourceRecord: rec, dismissedBlocks: true })) continue;
+    const high = highBandFor(sig.kind, thresholds);
+    out.push(
+      makeFinding({
+        text: suggestionText(rec, sig, target),
+        target: target?.value ?? "",
+        targetId: target?.id,
+        sourceRecord: rec,
+        trigger: `signal:${sig.kind}`,
+        status: "suggested",
+        signal: { ...sig, ...(opts.via ? { via: opts.via } : {}) },
+        confidence: high !== undefined && (sig.score ?? 0) >= high ? "high" : "medium",
+        at: sig.at,
+      }),
+    );
+  }
+  return out;
+}

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -85,15 +85,15 @@ Run any verb from bash and parse the JSON record:
 \`\`\`bash
 overcast watch ./clip.mp4 --json          # video.analysis record
 overcast scan --pull --json               # enumerate sources, capture + sense
-overcast finding list --json              # review automated target matches
+overcast finding list --state triage --json  # triage auto-suggested leads (accept/dismiss)
 overcast note "rear plate is missing" --ref <record-id> --at 12-18 --json
 overcast face ./clip.mp4 --thumbnails --json  # detect faces (boxes + provider frame thumbnails)
 overcast face ./clip.mp4 --match ./suspect.jpg --json   # find this person in the video (JPEG/PNG query image)
 overcast crop <face-or-see-record-id> --all --class face --json  # materialize detection crops as evidence
 overcast ask "every white van, with timestamps" --json
 overcast case memory index status --json  # inspect default local-grep case search
-overcast brief --export ./brief.html      # evidence-only narrative report
-overcast case status --export ./status.html --theme csi   # current case dashboard
+overcast brief --export ./brief.html      # short analyst brief (verdict-led); --full for the verbatim timeline
+overcast case status --export ./status.html --theme csi   # mission board (threads, coverage, triage)
 overcast case records --export ./records.html --theme csi # full audit log
 \`\`\`
 
@@ -114,15 +114,37 @@ Built-in source refs for \`source add <type>:<ref>\`:
 pages are in [reference/verbs.md](reference/verbs.md) (progressive disclosure —
 read it when you need a verb's exact flags).
 
+### Lines of investigation & triage
+
+A \`target\` is a **line of investigation**: \`target add <value> --question "…"\`
+records what would resolve it; \`target close <id> --as answered|dead-end --note\`
+marks it done (closed lines stop seeding scans); \`target reopen <id>\` reactivates.
+
+Findings **auto-suggest** by default: score triggers (face ≥75, image RANSAC,
+similar ≥85, cluster ≥70) and non-image target text matches emit \`suggested\`
+leads on every verb — so a standalone \`face --match\` / \`image match\` /
+\`similar match\` / \`cluster identify\` surfaces a lead. Suggested leads are
+quarantined from \`ask\`/\`brief\` until accepted. Triage with
+\`finding list --state triage\` (bare \`list\` shows only \`open\`), then
+\`finding accept <id>\` (→ evidence) or \`finding dismiss <id>\` (blocks re-suggestion).
+The **\`/debrief\`** prompt automates the loop: triage leads → write one
+\`thread:<target-id>\` narrative note per line → \`target close\` resolved lines →
+refresh the \`tldr\` note → \`brief --export\`.
+
 ### Brief vs status vs records
 
-Use \`brief\` for the evidence narrative: it reports over the same evidence-only
-boundary as case memory, so setup/read/meta records are excluded.
+Use \`brief\` for the evidence narrative — **short by default**: verdict → goal
+status → key findings (with visual proof) → lines of investigation (per-target
+threads with a stage + activity sparkline) → triage queue → coverage gaps → a
+compact record trail. \`--full\` appends the verbatim per-record timeline. It
+reports over the same evidence-only boundary as case memory, so setup/read/meta
+records — and un-accepted \`suggested\` findings — are excluded.
 
-Use \`case status\` for the current dashboard: setup health, targets, sources,
-indexes, memory/index state, record/store counts, artifacts, and match
-visualizations when available. Treat it as situational context, not evidence for
-later memory or briefs.
+Use \`case status\` as the **mission board**: a goal headline + per-target threads
+on a stage ladder (cold → collecting → leads → corroborated → answered/dead-end),
+a per-source coverage funnel, scan/monitor/brief freshness, and the triage queue —
+with setup health, store counts, and match visualizations below. Treat it as
+situational context, not evidence for later memory or briefs.
 
 Use \`case records\` for the audit trail: it includes the append-only operational
 history, including setup, target/source changes, index work, asks, briefs, and
@@ -261,9 +283,15 @@ overcast case setup edit \\
   --provider-indexable "listen,see" \\
   --auto-sense "watch,listen" \\
   --auto-index-new \\
-  --findings review \\
+  --findings suggest \\
   --yes --json
 \`\`\`
+
+Findings default to \`--findings suggest\` (score/text triggers auto-emit
+\`suggested\` leads on every verb; tune floors with
+\`case setup --findings-threshold face=75,similar=85,cluster=70,image_inliers=1\`);
+\`review\` is the legacy text-only mode, \`off\` disables. \`finding list\` alone
+shows only \`open\` findings — pass \`--state triage\` to see the leads.
 
 Use \`overcast case setup edit --no-auto-index-new --yes --json\` to disable
 automatic indexing later without removing the selected providers or auto-sense
@@ -328,7 +356,9 @@ One-time setup for overcast.
    \`\`\`
 7. **Case setup later** — use the main \`overcast\` skill per investigation to run
    \`case setup\`, select targets/sources/indexes, and optionally set case-level
-   automation such as \`--auto-sense\`, \`--auto-index-new\`, and \`--findings review\`.
+   automation such as \`--auto-sense\`, \`--auto-index-new\`, and \`--findings\`
+   (defaults to \`suggest\` — score/text triggers auto-suggest leads; \`review\` is
+   the legacy text-only mode, \`off\` disables).
 
 Then use the \`overcast\` skill to drive the verbs.
 `;
@@ -447,7 +477,7 @@ overcast listen ./screen-recording.mp4 --describe --json
 overcast see frame://<record-id>@<seconds> --ocr --json
 overcast note "observed UI state or suspected failure" --ref <record-id> --at <time-range> --json
 overcast ask "summarize the bug with reproduction steps and citations" --json
-overcast brief --export ./bug-brief.md --json
+overcast brief --full --export ./bug-brief.md --json   # --full: this flow wants the verbatim evidence timeline (the default brief is short)
 \`\`\`
 
 Use \`watch\` for screen recordings and demos. Add \`listen --describe\` when
@@ -497,9 +527,10 @@ overcast doctor --sources --json
 overcast case init --json
 overcast case setup --target "<target>" --source "web:<query>" --yes --json
 overcast scan --pull --json
-overcast finding list --json
+overcast finding list --state triage --json   # auto-suggested leads (bare \`list\` shows only open)
+overcast finding accept <id> --json            # promote a real lead to evidence (or \`dismiss <id>\`)
 overcast ask "what are the relevant hits, dates, sources, and confidence levels?" --json
-overcast brief --export ./recon-brief.md --json
+overcast brief --export ./recon-brief.md --json   # short by default; add --full for the verbatim timeline
 \`\`\`
 
 For a one-time polling pass, use:
@@ -518,10 +549,14 @@ overcast monitor --every 30m --json
 
 Produce a cited brief with:
 
-- timeline entries tied to source URLs and record IDs;
+- the short brief's lead sections — verdict, key findings, lines of investigation
+  (per-target threads), triage queue, and coverage gaps (\`--full\` for the
+  verbatim per-record timeline tied to source URLs and record IDs);
 - relevant hits from \`scan --pull\` and captured media observations;
-- accepted, dismissed, and review-needed findings separated by confidence;
+- findings triaged from the auto-suggested queue via \`finding accept\`/\`dismiss\`,
+  separated by confidence;
 - clear gaps where sources, credentials, or media captures were unavailable.
+- \`/debrief\` automates this recon → triage → thread-notes → brief loop.
 
 ## Evidence Rules
 
@@ -553,10 +588,12 @@ For a person with a reference image:
 \`\`\`bash
 overcast doctor --json
 overcast case init --json
-overcast face ./clip.mp4 --match ./person.jpg --json
+overcast face ./clip.mp4 --match ./person.jpg --json   # a match ≥75% auto-suggests a finding
+overcast finding list --state triage --json            # triage the auto-suggested lead(s)…
+overcast finding accept <id> --json                    # …accept a real match (or \`dismiss <id>\`)
 overcast crop <face-record-id> --all --class face --json
 overcast ask "where does the reference person appear, with timestamps and confidence?" --json
-overcast brief --export ./visual-search.md --json
+overcast brief --export ./visual-search.md --json      # short by default; --full for the per-match timeline
 \`\`\`
 
 For an object or open-vocabulary target (\`--detect\` needs a bound detection
@@ -573,13 +610,17 @@ For logos, landmarks, or near-duplicate visual references:
 \`\`\`bash
 overcast index create refs --type image-ransac --local --json
 overcast index add ./reference-logo.png --to <index-id> --json
-overcast image match ./clip.mp4 --index <index-id> --json
+overcast image match ./clip.mp4 --index <index-id> --json   # a RANSAC hit auto-suggests a finding
+overcast finding list --state triage --json                  # then accept/dismiss the lead
 \`\`\`
 
 ## Output
 
 Return timestamped matches, similarity or confidence where available, source
 \`record.id\`, \`media.at\`, and cropped evidence paths created by \`crop\`.
+\`face --match\` / \`image match\` auto-suggest findings — resolve them with
+\`finding list --state triage\` → \`accept\`/\`dismiss\` so a run doesn't leave an
+un-triaged queue; the default \`brief\` is short, \`--full\` for the per-match timeline.
 State whether the match came from \`face --match\`, \`see --detect\`, or local
 \`image-ransac\` matching.
 
@@ -651,6 +692,13 @@ Pass \`--draw\` on \`image match\` so each matched frame writes a RANSAC overlay
 \`--ref\` in step 5 — the brief embeds that overlay in the finding card as
 visual proof.
 
+Each \`image match\` / \`face --match\` / \`listen\`-on-a-match already
+**auto-suggests** a finding (image RANSAC ≥1 inlier, face ≥75%): run
+\`overcast finding list --state triage --json\` to see the leads, then
+\`finding accept <id>\` (usually enough — the lead is already there) or
+\`finding dismiss <id>\`. Step 5's manual \`finding create --ref <match-record>\`
+stays valid for a richer because-clause (dedup suppresses the duplicate).
+
 **Local mode (no external source).** The skill works entirely on local files:
 skip steps 2–3 and run \`image match\` / \`face --match\` / \`listen\` directly on
 candidate videos already on disk (or captured earlier). This is how you compare a
@@ -669,8 +717,9 @@ media/indexes when no source is enabled.
 \`\`\`bash
 overcast finding create "copycat: <original> re-uploaded by @<author> (<views> views) — image frames 3x (best 94 inliers), face 87/100" --ref <image-match-record-id> --confidence high --json
 overcast note "checked x + youtube (<n> hits); <m> candidates escalated; <k> confirmed: @<author> ..." --tag tldr --json
+overcast target close <target-id> --as answered --note "copycats found + reported" --json  # once a line resolves
 # Wait for the note result before exporting, so the TL;DR is included.
-overcast brief --export ./copycats.html --json
+overcast brief --export ./copycats.html --json   # short by default (verdict-led); add --full for the frame-by-frame dump
 overcast monitor --every 1d --json
 \`\`\`
 

--- a/src/state/setup.ts
+++ b/src/state/setup.ts
@@ -46,8 +46,21 @@ export interface SetupAutomationPolicy {
   auto_index_new: boolean;
 }
 
+/** Score-trigger fire floors (face/similar/cluster: 0–100 percent similarity;
+ *  image_inliers: RANSAC inlier count). Missing keys use the built-in defaults
+ *  in signals/triggers.ts. */
+export interface SetupFindingsThresholds {
+  face?: number;
+  similar?: number;
+  cluster?: number;
+  image_inliers?: number;
+}
+
 export interface SetupFindingsPolicy {
-  mode: "off" | "review" | string;
+  /** "suggest" (default): all triggers emit quarantined suggested findings;
+   *  "review": legacy text-target-only open findings; "off": no automation. */
+  mode: "off" | "review" | "suggest" | string;
+  thresholds?: SetupFindingsThresholds;
 }
 
 export interface CaseSetup {
@@ -90,7 +103,7 @@ export function emptySetup(caseName: string, now = new Date().toISOString()): Ca
     media: { folders: [], videos: [], routes: [] },
     providers: {},
     automation: { auto_sense: [], auto_index_new: false },
-    findings: { mode: "off" },
+    findings: { mode: "suggest" },
     created_at: now,
     updated_at: now,
   };
@@ -104,7 +117,7 @@ export function loadSetup(c: Case): CaseSetup | undefined {
       parsed.memory ??= { backend: "local-grep", signals: ["note", "watch", "listen", "see", "scan"] };
       parsed.memory.signals = Array.isArray(parsed.memory.signals) ? parsed.memory.signals : ["note", "watch", "listen", "see", "scan"];
       parsed.automation ??= { auto_sense: [], auto_index_new: false };
-      parsed.findings ??= { mode: "off" };
+      parsed.findings ??= { mode: "suggest" };
       parsed.providers ??= {};
       return parsed;
     }

--- a/src/state/target.ts
+++ b/src/state/target.ts
@@ -110,12 +110,15 @@ export function setTargetStatus(
 }
 
 /** The primary (most recent OPEN) target, used as the default scan/monitor seed.
- *  Closed lines (answered/dead-end) are skipped so sweeps don't chase them; if
- *  every target is closed, falls back to the most recent so scope never vanishes. */
+ *  Closed lines (answered/dead-end) are skipped so sweeps don't chase them; when
+ *  EVERY line is closed there is no active target — returns undefined rather than
+ *  a closed one, so a query-less source isn't seeded with a dead line's value
+ *  (the same "closed lines stop seeding scans" invariant scanLocalCase /
+ *  evaluateTriggers / autoSeeOpts enforce). */
 export function primaryTarget(c: Case): TargetEntry | undefined {
   const t = load(c).targets;
   for (let i = t.length - 1; i >= 0; i--) {
     if (!isTargetClosed(t[i])) return t[i];
   }
-  return t[t.length - 1];
+  return undefined;
 }

--- a/src/state/target.ts
+++ b/src/state/target.ts
@@ -12,6 +12,23 @@ export interface TargetEntry {
   kind: "name" | "prompt" | "image";
   value: string;
   created: string;
+  /** what would resolve this line of investigation (analyst-authored) */
+  question?: string;
+  /** missing = active. "answered"/"dead-end" close the thread (scan/monitor
+   *  stop seeding from it via primaryTarget). */
+  status?: "active" | "answered" | "dead-end";
+  status_note?: string;
+  status_updated?: string;
+}
+
+/** Effective status of a target (missing = active). */
+export function targetStatus(t: TargetEntry): "active" | "answered" | "dead-end" {
+  return t.status ?? "active";
+}
+
+/** Whether a target line is closed (answered or dead-end). */
+export function isTargetClosed(t: TargetEntry): boolean {
+  return t.status === "answered" || t.status === "dead-end";
 }
 
 export interface TargetStore {
@@ -40,7 +57,7 @@ export function listTargets(c: Case): TargetEntry[] {
 export function addTarget(
   c: Case,
   value: string,
-  opts: { image?: boolean } = {},
+  opts: { image?: boolean; question?: string } = {},
 ): TargetEntry {
   const store = load(c);
   const kind: TargetEntry["kind"] = opts.image
@@ -54,6 +71,7 @@ export function addTarget(
     value,
     created: new Date().toISOString(),
   };
+  if (opts.question) entry.question = opts.question;
   store.targets.push(entry);
   save(c, store);
   return entry;
@@ -67,8 +85,37 @@ export function removeTarget(c: Case, id: string): boolean {
   return store.targets.length < before;
 }
 
-/** The primary (most recent) target, used as the default scan/monitor seed. */
+/** Set a target's investigation status ("active" reopens). Returns the updated
+ *  entry, or undefined when the id is unknown. */
+export function setTargetStatus(
+  c: Case,
+  id: string,
+  status: "active" | "answered" | "dead-end",
+  note?: string,
+): TargetEntry | undefined {
+  const store = load(c);
+  const entry = store.targets.find((t) => t.id === id);
+  if (!entry) return undefined;
+  if (status === "active") {
+    delete entry.status;
+    delete entry.status_note;
+  } else {
+    entry.status = status;
+    if (note) entry.status_note = note;
+    else delete entry.status_note;
+  }
+  entry.status_updated = new Date().toISOString();
+  save(c, store);
+  return entry;
+}
+
+/** The primary (most recent OPEN) target, used as the default scan/monitor seed.
+ *  Closed lines (answered/dead-end) are skipped so sweeps don't chase them; if
+ *  every target is closed, falls back to the most recent so scope never vanishes. */
 export function primaryTarget(c: Case): TargetEntry | undefined {
   const t = load(c).targets;
+  for (let i = t.length - 1; i >= 0; i--) {
+    if (!isTargetClosed(t[i])) return t[i];
+  }
   return t[t.length - 1];
 }

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -16,6 +16,9 @@ import { payloadFields, pageText, fieldNames, getField } from "../render.js";
 import { redactSecrets } from "../env.js";
 import { addSource, listSources, parseSourceSpec, removeSource } from "../state/source.js";
 import { addTarget, listTargets, removeTarget } from "../state/target.js";
+import { casePulse, type CasePulse } from "../signals/pulse.js";
+import { sparkline } from "../report/components.js";
+import { THREAD_STAGE_LABEL } from "../signals/threads.js";
 import { addIndex, listIndexes, normalizeIndexType, removeIndex, LOCAL_INDEX_TYPES } from "../state/index.js";
 import { emptySetup, loadSetup, saveSetup, setupSummary, type CaseSetup, type SetupIndex, type SetupIndexConfig } from "../state/setup.js";
 import { indexVerb } from "./index.js";
@@ -166,11 +169,24 @@ async function buildCaseStatus(ctx: VerbContext): Promise<Record<string, unknown
   const clear = c.clearSummary();
   const saved = loadSetup(c);
   const records = c.records();
+  const pulse = casePulse({ records, targets: listTargets(c), sources: listSources(c) });
   return {
     dir: c.dir,
     initialized: c.exists(),
     info: c.exists() ? c.info() : null,
-    tldr: caseStatusTldr(ctx, records, clear.counts),
+    // mission board: the goal-progress read first, then the derived signals.
+    mission: {
+      headline: c.exists() ? `${c.info().name} — ${pulse.headline}` : "Case is not initialized",
+      progress: pulse.progress,
+    },
+    threads: pulse.threads,
+    coverage: pulse.coverage,
+    triage: statusTriage(records, pulse),
+    gaps: pulse.gaps,
+    freshness: pulse.freshness,
+    next_actions: caseStatusNext(ctx, records, clear.counts, pulse),
+    // tldr kept for one release (renderTldr + older consumers); superseded by mission.
+    tldr: caseStatusTldr(ctx, records, clear.counts, pulse),
     targets: statusTargets(ctx),
     sources: statusSources(ctx),
     match_visualizations: statusMatchVisualizations(records),
@@ -193,6 +209,50 @@ async function buildCaseStatus(ctx: VerbContext): Promise<Record<string, unknown
       indexes: listIndexes(c).length,
     },
   };
+}
+
+/** Suggested-lead rows for the status triage queue (compact, newest first). */
+function statusTriage(records: OvercastRecord[], _pulse: CasePulse): Array<Record<string, unknown>> {
+  const p = (r: OvercastRecord): Record<string, unknown> => (typeof r.payload === "object" && r.payload != null ? (r.payload as Record<string, unknown>) : {});
+  const statusMap = new Map<string, string>();
+  for (const r of records) {
+    if (r.verb !== "finding" || typeof r.payload !== "object" || r.payload == null) continue;
+    const pay = p(r);
+    if (typeof pay.status !== "string") continue;
+    statusMap.set(typeof pay.finding_id === "string" ? pay.finding_id : r.id, pay.status);
+  }
+  return records
+    .filter((r) => {
+      if (r.verb !== "finding" || r.state === "error") return false;
+      const pay = p(r);
+      return typeof pay.finding_id !== "string" && typeof pay.text === "string" && (statusMap.get(r.id) ?? "open") === "suggested";
+    })
+    .sort((a, b) => Date.parse(String(b.meta?.time ?? "")) - Date.parse(String(a.meta?.time ?? "")))
+    .slice(0, 8)
+    .map((r) => {
+      const pay = p(r);
+      const sig = pay.signal && typeof pay.signal === "object" ? (pay.signal as Record<string, unknown>) : {};
+      return {
+        id: r.id,
+        text: String(pay.text ?? ""),
+        confidence: pay.confidence,
+        score: typeof sig.score === "number" ? sig.score : undefined,
+        review: `overcast finding accept ${r.id}`,
+      };
+    });
+}
+
+/** Suggested next actions — pulse-aware (triage first, then gaps, then brief). */
+function caseStatusNext(ctx: VerbContext, records: OvercastRecord[], counts: Record<string, number>, pulse: CasePulse): string[] {
+  const next: string[] = [];
+  if (pulse.progress.triage_pending) next.push(`Triage ${pulse.progress.triage_pending} suggested finding(s): \`overcast finding list --state triage\`.`);
+  if (!listTargets(ctx.case).length) next.push("Add a line of investigation: `overcast target add <value> --question \"…\"`.");
+  for (const g of pulse.gaps.slice(0, 2)) next.push(`Close a coverage gap: ${g}.`);
+  if ((counts.brief ?? 0) === 0 && records.some((r) => (r.state ?? "ready") === "ready")) {
+    next.push("Run `overcast brief --export report.html --theme csi` for the mission report.");
+  }
+  if (!next.length) next.push("Review the open lines of investigation and expand evidence.");
+  return next;
 }
 
 function statusTargets(ctx: VerbContext): Record<string, unknown>[] {
@@ -255,28 +315,16 @@ function statusMatchVisualizations(records: OvercastRecord[]): Record<string, un
 }
 
 
-function caseStatusTldr(ctx: VerbContext, records: OvercastRecord[], counts: Record<string, number>): Record<string, unknown> {
-  const targets = listTargets(ctx.case);
-  const targetText = targets.map((t) => t.value).slice(0, 4);
-  const readyRecords = records.filter((r) => (r.state ?? "ready") === "ready");
-  const evidenceKinds = ["watch", "listen", "see", "face", "image", "similar", "crop", "scan", "capture", "note", "finding"]
-    .filter((verb) => (counts[verb] ?? 0) > 0);
-  const headline = [
-    ctx.case.exists() ? `Case '${ctx.case.info().name}' is initialized` : "Case is not initialized",
-    targetText.length ? `tracking ${targetText.join(", ")}` : "with no standing target",
-    readyRecords.length ? `with ${readyRecords.length} ready record(s)` : "with no ready evidence yet",
-  ].join(" ");
+function caseStatusTldr(ctx: VerbContext, records: OvercastRecord[], counts: Record<string, number>, pulse: CasePulse): Record<string, unknown> {
+  const headline = ctx.case.exists()
+    ? `${ctx.case.info().name} — ${pulse.headline}`
+    : "Case is not initialized";
   const findings: string[] = [];
-  if (targetText.length) findings.push(`Targets in scope: ${targetText.join("; ")}.`);
-  if (evidenceKinds.length) findings.push(`Evidence present: ${evidenceKinds.map((verb) => `${verb} ${counts[verb]}`).join(", ")}.`);
-  for (const rec of recentEvidenceSummaries(records).slice(0, 4)) findings.push(rec);
-  if (!findings.length) findings.push("No evidence records have been added yet.");
-  const next: string[] = [];
-  if (!targetText.length) next.push("Add a target with `case setup --target ... --yes`.");
-  if (!evidenceKinds.length) next.push("Add evidence with watch/listen/see/face/image/similar/note records.");
-  if ((counts.brief ?? 0) === 0 && evidenceKinds.length) next.push("Run `brief --export report.html --theme csi` for an evidence timeline.");
-  if (!next.length) next.push("Review the latest evidence cards and expand details for citations.");
-  return { headline, findings, next };
+  const prog = pulse.progress;
+  findings.push(`${prog.targets_total} line(s) of investigation · ${prog.accepted_findings} accepted, ${prog.open_findings} open finding(s) · ${prog.triage_pending} awaiting triage.`);
+  for (const rec of recentEvidenceSummaries(records).slice(0, 3)) findings.push(rec);
+  if (findings.length === 1 && !prog.targets_total) findings.push("No evidence records have been added yet.");
+  return { headline, findings, next: caseStatusNext(ctx, records, counts, pulse) };
 }
 
 function recentEvidenceSummaries(records: OvercastRecord[]): string[] {
@@ -334,8 +382,75 @@ function caseRecordsMarkdown(title: string, records: OvercastRecord[], counts: R
   return lines.join("\n");
 }
 
-function statusMarkdown(title: string, payload: Record<string, unknown>): string {
-  return [`# ${title}`, "", "```json", JSON.stringify(payload, null, 2), "```", ""].join("\n");
+/** The mission-board status as markdown (terminal + plain HTML). Leads with the
+ *  goal-progress headline, then lines of investigation, triage, coverage, gaps,
+ *  and next actions — the operational store/setup detail is demoted to the tail.
+ *  `--full` appends the raw payload as JSON for auditing. */
+function statusMarkdown(title: string, payload: Record<string, unknown>, full = false): string {
+  const lines: string[] = [`# ${title}`, ""];
+  const mission = payload.mission as { headline?: string; progress?: Record<string, number> } | undefined;
+  if (mission?.headline) lines.push(`**${mission.headline}**`, "");
+
+  const next = Array.isArray(payload.next_actions) ? (payload.next_actions as string[]) : [];
+  if (next.length) {
+    for (const n of next) lines.push(`- next: ${n}`);
+    lines.push("");
+  }
+
+  const threads = Array.isArray(payload.threads) ? (payload.threads as Array<Record<string, unknown>>) : [];
+  lines.push("## Lines of investigation", "");
+  if (threads.length) {
+    for (const th of threads) {
+      const stage = THREAD_STAGE_LABEL[(th.stage as keyof typeof THREAD_STAGE_LABEL)] ?? String(th.stage ?? "").toUpperCase();
+      const bins = Array.isArray(th.activityBins) ? (th.activityBins as number[]) : [];
+      const spark = sparkline(bins);
+      const f = th.funnel as { scan: number; captures: number; senses: number; matches: number } | undefined;
+      const fnd = th.findings as { accepted: number; open: number; suggested: number } | undefined;
+      lines.push(`- **${th.value}** — [${stage}]${spark ? ` \`${spark}\`` : ""}`);
+      if (th.question) lines.push(`  - question: ${th.question}`);
+      if (f) lines.push(`  - scan ${f.scan} → cap ${f.captures} → sense ${f.senses} → match ${f.matches}${fnd ? ` · findings: ${fnd.accepted} acc / ${fnd.open} open / ${fnd.suggested} sug` : ""}`);
+      if (th.status !== "active" && th.why) lines.push(`  - closed: ${th.why}`);
+    }
+  } else {
+    lines.push("- none — add one with `overcast target add <value> --question \"…\"`");
+  }
+  lines.push("");
+
+  const triage = Array.isArray(payload.triage) ? (payload.triage as Array<Record<string, unknown>>) : [];
+  if (triage.length) {
+    lines.push(`## Triage — ${triage.length} awaiting review`, "");
+    for (const t of triage.slice(0, 8)) {
+      lines.push(`- \`${t.id}\`${t.confidence != null ? ` [${t.confidence}]` : ""} ${t.text}`);
+      lines.push(`  - ${t.review}`);
+    }
+    lines.push("");
+  }
+
+  const coverage = Array.isArray(payload.coverage) ? (payload.coverage as Array<Record<string, unknown>>) : [];
+  const gaps = Array.isArray(payload.gaps) ? (payload.gaps as string[]) : [];
+  lines.push("## Coverage", "");
+  if (coverage.length) {
+    for (const c of coverage) {
+      lines.push(`- **${c.spec}**${c.enabled ? "" : " (disabled)"} — ${c.hits} hit(s) → ${c.captured} captured → ${c.sensed} sensed`);
+    }
+  } else {
+    lines.push("- no sources configured");
+  }
+  if (gaps.length) {
+    lines.push("", "**Gaps:**");
+    for (const g of gaps.slice(0, 5)) lines.push(`- ${g}`);
+  }
+  lines.push("");
+
+  const store = payload.store as { records?: number } | undefined;
+  const registries = payload.registries as Record<string, number> | undefined;
+  lines.push("## Store", "");
+  if (store) lines.push(`- records: ${store.records ?? 0}`);
+  if (registries) lines.push(`- registries: ${registries.targets} target(s), ${registries.sources} source(s), ${registries.indexes} index(es)`);
+  lines.push("");
+
+  if (full) lines.push("## Raw", "", "```json", JSON.stringify(payload, null, 2), "```", "");
+  return lines.join("\n");
 }
 
 interface SetupChange {
@@ -754,15 +869,46 @@ function buildSetupChange(ctx: VerbContext, base: CaseSetup, op: "startup_setup"
     setup.automation ??= { auto_sense: [], auto_index_new: false };
   }
   if (findingsMode) {
-    setup.findings = { mode: findingsMode };
+    setup.findings = { ...(setup.findings ?? {}), mode: findingsMode };
     operations.push(`findings: ${findingsMode}`);
   } else {
-    setup.findings ??= { mode: "off" };
+    setup.findings ??= { mode: "suggest" };
+  }
+  if (ctx.opts["findings-threshold"] != null) {
+    const parsed = parseFindingsThresholds(String(ctx.opts["findings-threshold"]));
+    if (!parsed.errors.length) {
+      setup.findings = { ...(setup.findings ?? { mode: "suggest" }), thresholds: { ...(setup.findings?.thresholds ?? {}), ...parsed.thresholds } };
+      operations.push(`findings thresholds: ${Object.entries(parsed.thresholds).map(([k, v]) => `${k}=${v}`).join(",")}`);
+    }
   }
   if (!operations.length && op === "startup_setup") operations.push("save empty setup");
 
   setup.updated_at = new Date().toISOString();
   return { setup, operations, noteRecords };
+}
+
+/** Parse `--findings-threshold face=75,similar=85,...` into a thresholds patch.
+ *  face/similar/cluster are 0–100 percent floors; image_inliers is a count ≥ 1. */
+function parseFindingsThresholds(raw: string): { thresholds: Record<string, number>; errors: string[] } {
+  const thresholds: Record<string, number> = {};
+  const errors: string[] = [];
+  for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
+    const m = part.match(/^([a-z_]+)=(\d+(?:\.\d+)?)$/i);
+    if (!m) {
+      errors.push(`'${part}' (expected key=number)`);
+      continue;
+    }
+    const key = m[1].toLowerCase();
+    const value = Number(m[2]);
+    if (!["face", "similar", "cluster", "image_inliers"].includes(key)) {
+      errors.push(`unknown key '${key}' (expected face | similar | cluster | image_inliers)`);
+    } else if (key === "image_inliers" ? value < 1 : value < 0 || value > 100) {
+      errors.push(`'${part}' out of range (${key === "image_inliers" ? "count ≥ 1" : "0–100"})`);
+    } else {
+      thresholds[key] = value;
+    }
+  }
+  return { thresholds, errors };
 }
 
 function quoteCommandArg(arg: string): string {
@@ -817,7 +963,8 @@ export const caseVerb: VerbSpec = {
     { name: "auto-sense", summary: "setup/edit: comma-separated senses to run on newly captured media", type: "string" },
     { name: "auto-index-new", summary: "setup/edit: automatically add newly analyzed media to configured indexes", type: "boolean" },
     { name: "no-auto-index-new", summary: "setup/edit: disable automatic indexing for newly analyzed media", type: "boolean" },
-    { name: "findings", summary: "setup/edit: automated finding workflow (off | review)", type: "string" },
+    { name: "findings", summary: "setup/edit: automated finding workflow (suggest | review | off; default suggest)", type: "string" },
+    { name: "findings-threshold", summary: "setup/edit: comma-separated score-trigger floors (face=75,similar=85,cluster=70,image_inliers=1)", type: "string" },
     { name: "video", summary: "setup/edit: comma-separated local videos/URLs to route", type: "string" },
     { name: "folder", summary: "setup/edit: comma-separated local media folders to remember", type: "string" },
     { name: "no-index", summary: "setup/edit: save setup routes without starting remote collection ingestion", type: "boolean" },
@@ -825,6 +972,7 @@ export const caseVerb: VerbSpec = {
     { name: "verb", summary: "Filter records by kind", type: "string" },
     { name: "since", summary: "Time filter (e.g. 24h, 2026-06-01)", type: "string" },
     { name: "export", summary: "Write a case status/log report (.md or .html)", type: "string" },
+    { name: "full", summary: "status: append the raw payload JSON for auditing", type: "boolean" },
     { name: "theme", summary: "HTML export theme: plain | csi", type: "string", choices: ["plain", "csi"], default: "plain" },
     { name: "field", summary: "Payload field to read in full (memory get)", type: "string" },
     { name: "offset", summary: "Start char offset when paging a field (memory get)", type: "number" },
@@ -890,7 +1038,7 @@ export const caseVerb: VerbSpec = {
       if (ctx.opts.export) {
         const path = resolve(String(ctx.opts.export));
         const title = `Case status — ${ctx.case.exists() ? ctx.case.info().name : "case"}`;
-        const md = statusMarkdown(title, payload);
+        const md = statusMarkdown(title, payload, ctx.opts.full === true);
         const html = theme === "csi"
           ? renderCsiStatusReport({ title, subtitle: ctx.case.dir, payload })
           : mdToPlainHtml(md, title);
@@ -938,6 +1086,7 @@ export const caseVerb: VerbSpec = {
         "auto-index-new",
         "no-auto-index-new",
         "findings",
+        "findings-threshold",
         "video",
         "folder",
         "memory",
@@ -991,8 +1140,12 @@ export const caseVerb: VerbSpec = {
           return [err(`unknown --auto-sense verb '${verb}' (expected watch, listen, see, face, enhance)`)];
         }
       }
-      if (ctx.opts.findings != null && !["off", "review"].includes(String(ctx.opts.findings).trim().toLowerCase())) {
-        return [err(`unknown --findings mode '${ctx.opts.findings}' (expected off | review)`)];
+      if (ctx.opts.findings != null && !["off", "review", "suggest"].includes(String(ctx.opts.findings).trim().toLowerCase())) {
+        return [err(`unknown --findings mode '${ctx.opts.findings}' (expected suggest | review | off)`)];
+      }
+      if (ctx.opts["findings-threshold"] != null) {
+        const bad = parseFindingsThresholds(String(ctx.opts["findings-threshold"])).errors;
+        if (bad.length) return [err(`invalid --findings-threshold: ${bad.join("; ")}`)];
       }
       const op = saved ? "startup_setup_update" : "startup_setup";
       const before = summarizeSavedSetup(saved);

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -420,12 +420,16 @@ function statusMarkdown(title: string, payload: Record<string, unknown>, full = 
   lines.push("");
 
   const triage = Array.isArray(payload.triage) ? (payload.triage as Array<Record<string, unknown>>) : [];
-  if (triage.length) {
-    lines.push(`## Triage — ${triage.length} awaiting review`, "");
-    for (const t of triage.slice(0, 8)) {
+  // true backlog count (progress.triage_pending); payload.triage is capped at 8
+  const triageTotal = typeof mission?.progress?.triage_pending === "number" ? mission.progress.triage_pending : triage.length;
+  if (triageTotal) {
+    lines.push(`## Triage — ${triageTotal} awaiting review`, "");
+    const shown = triage.slice(0, 8);
+    for (const t of shown) {
       lines.push(`- \`${t.id}\`${t.confidence != null ? ` [${t.confidence}]` : ""} ${t.text}`);
       lines.push(`  - ${t.review}`);
     }
+    if (triageTotal > shown.length) lines.push(`- …and ${triageTotal - shown.length} more (\`overcast finding list --state suggested\`)`);
     lines.push("");
   }
 

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -409,6 +409,7 @@ function statusMarkdown(title: string, payload: Record<string, unknown>, full = 
       lines.push(`- **${th.value}** — [${stage}]${spark ? ` \`${spark}\`` : ""}`);
       if (th.question) lines.push(`  - question: ${th.question}`);
       if (f) lines.push(`  - scan ${f.scan} → cap ${f.captures} → sense ${f.senses} → match ${f.matches}${fnd ? ` · findings: ${fnd.accepted} acc / ${fnd.open} open / ${fnd.suggested} sug` : ""}`);
+      if (th.narrative) lines.push(`  - ${th.narrative}`);
       if (th.status !== "active" && th.why) lines.push(`  - closed: ${th.why}`);
     }
   } else {

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -245,7 +245,9 @@ function statusTriage(records: OvercastRecord[], _pulse: CasePulse): Array<Recor
 /** Suggested next actions — pulse-aware (triage first, then gaps, then brief). */
 function caseStatusNext(ctx: VerbContext, records: OvercastRecord[], counts: Record<string, number>, pulse: CasePulse): string[] {
   const next: string[] = [];
-  if (pulse.progress.triage_pending) next.push(`Triage ${pulse.progress.triage_pending} suggested finding(s): \`overcast finding list --state triage\`.`);
+  // triage_pending counts SUGGESTED leads; point at --state suggested so the
+  // count matches the list (--state triage also returns open findings).
+  if (pulse.progress.triage_pending) next.push(`Triage ${pulse.progress.triage_pending} suggested finding(s): \`overcast finding list --state suggested\`.`);
   if (!listTargets(ctx.case).length) next.push("Add a line of investigation: `overcast target add <value> --question \"…\"`.");
   for (const g of pulse.gaps.slice(0, 2)) next.push(`Close a coverage gap: ${g}.`);
   if ((counts.brief ?? 0) === 0 && records.some((r) => (r.state ?? "ready") === "ready")) {

--- a/src/verbs/finding.ts
+++ b/src/verbs/finding.ts
@@ -23,6 +23,14 @@ export function makeFinding(input: {
   sourceRecord: OvercastRecord;
   trigger: string;
   confidence?: number | string;
+  /** root finding status; "suggested" = quarantined lead awaiting review */
+  status?: string;
+  /** stable target link (payload.target stays the value string for back-compat) */
+  targetId?: string;
+  /** score-trigger evidence: {kind, score, threshold, unit, at?, matched?} */
+  signal?: Record<string, unknown>;
+  /** best-scoring moment override for media.at (defaults to the source's anchor) */
+  at?: number | [number, number];
 }): OvercastRecord {
   const payload: Record<string, unknown> = {
     text: input.text,
@@ -30,10 +38,13 @@ export function makeFinding(input: {
     source_record: input.sourceRecord.id,
     source_verb: input.sourceRecord.verb,
     trigger: input.trigger,
-    status: "open",
+    status: input.status ?? "open",
   };
   if (input.confidence != null) payload.confidence = input.confidence;
-  const media: MediaRef | undefined = input.sourceRecord.media ? { ...input.sourceRecord.media } : undefined;
+  if (input.targetId) payload.target_id = input.targetId;
+  if (input.signal) payload.signal = input.signal;
+  let media: MediaRef | undefined = input.sourceRecord.media ? { ...input.sourceRecord.media } : undefined;
+  if (input.at != null && media?.ref) media = { ref: media.ref, at: input.at };
   return makeRecord({
     verb: "finding",
     format: "json",
@@ -81,14 +92,15 @@ export const findingVerb: VerbSpec = {
   group: "state",
   summary: "Create and review findings (create|list|accept|dismiss).",
   description:
-    "Creates manual findings and lists/reviews automated finding records emitted by setup automation. " +
-    "`accept` and `dismiss` append review records that reference the original finding; dismissed findings remain auditable but are excluded from memory/brief evidence.",
+    "Creates manual findings and lists/reviews automated findings. Score/text triggers emit `suggested` findings (leads) that stay OUT of memory/brief evidence until reviewed — " +
+    "`finding list --state triage` queues them newest-first, `accept` promotes a lead into evidence, `dismiss` rejects it (a dismissed suggestion never re-fires for the same match). " +
+    "Review records reference the original finding; dismissed findings remain auditable.",
   args: [
     { name: "action", summary: "create | list | accept | dismiss (default: list)" },
     { name: "id", summary: "finding id for accept/dismiss, or text for create" },
   ],
   flags: [
-    { name: "state", summary: "list: open | accepted | dismissed | all", type: "string" },
+    { name: "state", summary: "list: open | suggested | accepted | dismissed | all | triage (open+suggested), or a comma-list", type: "string" },
     { name: "target", summary: "create: target/scope this finding supports", type: "string" },
     { name: "ref", summary: "create: source record id, capture id, media path, or URL", type: "string" },
     { name: "at", summary: "create: evidence timestamp seconds, hh:mm:ss, or start-end", type: "string" },
@@ -144,10 +156,27 @@ export const findingVerb: VerbSpec = {
       return [makeRecord({ verb: "finding", format: "json", payload, media, meta: { case: ctx.case.dir, provider: "human" }, state: "ready" })];
     }
     if (action === "list") {
-      const filter = ctx.opts.state ? String(ctx.opts.state) : "open";
+      const filter = (ctx.opts.state ? String(ctx.opts.state) : "open").trim().toLowerCase();
+      const wanted = new Set(
+        filter === "triage" ? ["open", "suggested"] : filter.split(",").map((s) => s.trim()).filter(Boolean),
+      );
       const roots = ctx.case.records().filter(isRootFindingRecord);
-      const findings = roots.map((r) => ({ ...r, review_status: latestFindingStatus(ctx, r.id) }));
-      const filtered = filter === "all" ? findings : findings.filter((r) => r.review_status === filter);
+      const byId = new Map(ctx.case.records().map((r) => [r.id, r]));
+      const findings = roots.map((r) => {
+        const row: Record<string, unknown> = { ...r, review_status: latestFindingStatus(ctx, r.id) };
+        // triage context: the cited record's provenance, so a lead is judgeable
+        // from the queue without a second lookup.
+        const p = r.payload as Record<string, unknown>;
+        const src = typeof p.source_record === "string" ? byId.get(p.source_record) : undefined;
+        const sp = src?.payload && typeof src.payload === "object" ? (src.payload as Record<string, unknown>) : undefined;
+        if (typeof sp?.source_url === "string") row.source_url = sp.source_url;
+        else if (typeof sp?.url === "string") row.source_url = sp.url;
+        if (typeof sp?.source_text === "string") row.source_excerpt = String(sp.source_text).slice(0, 200);
+        return row;
+      });
+      // newest first so fresh suggestions triage from the top
+      findings.sort((a, b) => String((b as { meta?: { time?: string } }).meta?.time ?? "").localeCompare(String((a as { meta?: { time?: string } }).meta?.time ?? "")));
+      const filtered = filter === "all" ? findings : findings.filter((r) => wanted.has(String(r.review_status)));
       return [makeRecord({ verb: "finding", format: "json", payload: { state: filter, findings: filtered }, meta: { transient: true }, state: "ready" })];
     }
     if (action !== "accept" && action !== "dismiss") return [err("usage: finding create|list|accept|dismiss [id]")];

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -20,7 +20,7 @@ import {
   setEnabled,
   removeSource,
 } from "../state/source.js";
-import { addTarget, listTargets, removeTarget, primaryTarget, setTargetStatus } from "../state/target.js";
+import { addTarget, listTargets, removeTarget, primaryTarget, setTargetStatus, isTargetClosed } from "../state/target.js";
 import { listIndexes } from "../state/index.js";
 import { loadSetup } from "../state/setup.js";
 import { loadSeen, saveSeen, hitKey } from "../state/seen.js";
@@ -82,8 +82,12 @@ function localVisualCandidates(refs: string[], imageTargets: Array<{ value: stri
 
 async function scanLocalCase(ctx: VerbContext): Promise<OvercastRecord[]> {
   const targets = listTargets(ctx.case);
-  const imageTargets = targets.filter((t) => t.kind === "image");
-  const nameTargets = targets.filter((t) => t.kind !== "image").map((t) => t.value);
+  // closed lines (answered/dead-end) must not seed local matching either — same
+  // invariant primaryTarget enforces for external scan seeding, so a dead image
+  // line stops auto-producing match candidates + suggested findings.
+  const openTargets = targets.filter((t) => !isTargetClosed(t));
+  const imageTargets = openTargets.filter((t) => t.kind === "image");
+  const nameTargets = openTargets.filter((t) => t.kind !== "image").map((t) => t.value);
   const indexes = listIndexes(ctx.case);
   const faceIndexes = indexes.filter((i) => i.type === "face-analysis");
   const localFaceIndexes = indexes.filter((i) => i.backend === "local" && i.type === "deepface-local");

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -803,7 +803,7 @@ function autoSeeOpts(ctx: VerbContext): VerbContext["opts"] {
     if (choice !== "owl-local" && !/detect\.py\b/.test(run)) return {};
   }
   const labels = listTargets(ctx.case)
-    .filter((t) => t.kind !== "image")
+    .filter((t) => t.kind !== "image" && !isTargetClosed(t))
     .map((t) => t.value.trim())
     .filter(Boolean);
   return labels.length ? { detect: labels.join(", ") } : {};

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -20,7 +20,7 @@ import {
   setEnabled,
   removeSource,
 } from "../state/source.js";
-import { addTarget, listTargets, removeTarget, primaryTarget } from "../state/target.js";
+import { addTarget, listTargets, removeTarget, primaryTarget, setTargetStatus } from "../state/target.js";
 import { listIndexes } from "../state/index.js";
 import { loadSetup } from "../state/setup.js";
 import { loadSeen, saveSeen, hitKey } from "../state/seen.js";
@@ -35,7 +35,7 @@ import { faceVerb } from "./face.js";
 import { imageVerb } from "./image.js";
 import { seeVerb, enhanceVerb } from "./senses.js";
 import { indexVerb } from "./index.js";
-import { latestFindingStatus, makeFinding } from "./finding.js";
+import { evaluateTriggers, resolveFindingsPolicy } from "../signals/triggers.js";
 import { scanHitProvenance, stampProvenance } from "./provenance.js";
 import { redactSecrets } from "../env.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
@@ -663,53 +663,17 @@ async function runExplicitPipeWithPolicy(ctx: VerbContext, caller: string, verb:
   return out;
 }
 
-function payloadText(rec: OvercastRecord): string {
-  if (typeof rec.payload === "string") return rec.payload;
-  try {
-    return JSON.stringify(rec.payload);
-  } catch {
-    return "";
-  }
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function targetMatchesEvidence(target: string, text: string): boolean {
-  const normalizedTarget = target.trim().replace(/\s+/g, " ");
-  if (!normalizedTarget) return false;
-  const phrase = normalizedTarget.split(" ").map(escapeRegex).join("\\s+");
-  return new RegExp(`(^|[^\\p{L}\\p{N}_])${phrase}(?=$|[^\\p{L}\\p{N}_])`, "iu").test(text);
-}
-
+/** Chain-inline finding triggers (scan/monitor sense chains). The shared
+ *  implementation lives in signals/triggers.ts — the persist seam re-runs it
+ *  for standalone verb runs; dedup keeps the two passes idempotent. */
 function automatedFindings(ctx: VerbContext, rec: OvercastRecord, trigger: string, pending: OvercastRecord[] = []): OvercastRecord[] {
-  const setup = loadSetup(ctx.case);
-  if (setup?.findings?.mode !== "review" || rec.state === "error" || rec.state === "needs_credentials") return [];
-  const haystack = payloadText(rec);
-  const out: OvercastRecord[] = [];
-  for (const target of listTargets(ctx.case).filter((t) => t.kind !== "image").map((t) => t.value)) {
-    if (!targetMatchesEvidence(target, haystack)) continue;
-    if (hasAutomatedFinding(ctx, rec, target, pending)) continue;
-    out.push(makeFinding({
-      text: `Automated match for target '${target}' in ${rec.verb} record ${rec.id}`,
-      target,
-      sourceRecord: rec,
-      trigger,
-    }));
-  }
-  return out;
-}
-
-function hasAutomatedFinding(ctx: VerbContext, sourceRecord: OvercastRecord, target: string, pending: OvercastRecord[] = []): boolean {
-  return [...ctx.case.records(), ...pending].some((rec) => {
-    if (rec.verb !== "finding" || !rec.payload || typeof rec.payload !== "object") return false;
-    const payload = rec.payload as Record<string, unknown>;
-    if (typeof payload.finding_id === "string") return false;
-    if (latestFindingStatus(ctx, rec.id) === "dismissed") return false;
-    if (String(payload.target ?? "") !== target) return false;
-    if (payload.source_record === sourceRecord.id) return true;
-    return !!sourceRecord.media?.ref && rec.media?.ref === sourceRecord.media.ref;
+  return evaluateTriggers({
+    fresh: [rec],
+    existing: ctx.case.records(),
+    pending,
+    targets: listTargets(ctx.case),
+    policy: resolveFindingsPolicy(loadSetup(ctx.case)),
+    via: trigger,
   });
 }
 
@@ -1196,13 +1160,19 @@ export const monitorVerb: VerbSpec = {
 export const targetVerb: VerbSpec = {
   name: "target",
   group: "state",
-  summary: "Define/refine the standing scope (add|list|rm|show). Persisted to .overcast/target.json.",
+  summary: "Define/refine the standing scope, a.k.a. a line of investigation (add|list|rm|show|close|reopen). Persisted to .overcast/target.json.",
+  description:
+    "A target is a line of investigation. `add --question` records what would resolve it; `close <id> --as answered|dead-end --note` " +
+    "marks the line done (closed lines stop seeding scan/monitor); `reopen <id>` reactivates it. Status feeds the brief/status thread cards.",
   args: [
-    { name: "action", summary: "add | list | rm | show", required: true },
-    { name: "value", summary: "target value (for add) or id (for rm)" },
+    { name: "action", summary: "add | list | rm | show | close | reopen", required: true },
+    { name: "value", summary: "target value (for add) or id (for rm/close/reopen)" },
   ],
   flags: [
     { name: "image", summary: "Treat the value as a reference image path", type: "boolean" },
+    { name: "question", summary: "add: what would resolve this line of investigation", type: "string" },
+    { name: "as", summary: "close: answered | dead-end", type: "string", choices: ["answered", "dead-end"] },
+    { name: "note", summary: "close: why (answered how / why it's a dead end)", type: "string" },
     { name: "json", summary: "JSON output", type: "boolean" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
   ],
@@ -1213,7 +1183,10 @@ export const targetVerb: VerbSpec = {
     const value = ctx.rest[0];
     if (action === "add") {
       if (!value) return [err("target", "target add requires a value")];
-      const t = addTarget(ctx.case, value, { image: ctx.opts.image === true });
+      const t = addTarget(ctx.case, value, {
+        image: ctx.opts.image === true,
+        question: ctx.opts.question ? String(ctx.opts.question) : undefined,
+      });
       return [makeRecord({ verb: "target", format: "json", payload: { ...t }, state: "ready" })];
     }
     if (action === "rm") {
@@ -1221,9 +1194,23 @@ export const targetVerb: VerbSpec = {
       const ok = removeTarget(ctx.case, value);
       return [makeRecord({ verb: "target", format: "json", payload: { removed: ok, id: value }, state: "ready" })];
     }
+    if (action === "close") {
+      if (!value) return [err("target", "target close requires a target id")];
+      const as = ctx.opts.as ? String(ctx.opts.as) : "answered";
+      if (as !== "answered" && as !== "dead-end") return [err("target", `unknown --as '${as}' (expected answered | dead-end)`)];
+      const updated = setTargetStatus(ctx.case, value, as, ctx.opts.note ? String(ctx.opts.note) : undefined);
+      if (!updated) return [err("target", `target not found: ${value}`)];
+      return [makeRecord({ verb: "target", format: "json", payload: { op: "close", ...updated }, state: "ready" })];
+    }
+    if (action === "reopen") {
+      if (!value) return [err("target", "target reopen requires a target id")];
+      const updated = setTargetStatus(ctx.case, value, "active");
+      if (!updated) return [err("target", `target not found: ${value}`)];
+      return [makeRecord({ verb: "target", format: "json", payload: { op: "reopen", ...updated }, state: "ready" })];
+    }
     // an unrecognized action shouldn't silently fall through to a list
     if (action && action !== "list" && action !== "show") {
-      return [err("target", `unknown target action '${action}' (expected add|list|rm|show)`)];
+      return [err("target", `unknown target action '${action}' (expected add|list|rm|show|close|reopen)`)];
     }
     // list / show
     return [

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -352,6 +352,8 @@ function renderThreadSection(threads: TargetThread[]): string[] {
     lines.push(head);
     if (th.question) lines.push(`  - question: ${th.question}`);
     lines.push(`  - ${threadFunnelLine(th)}`);
+    // the analyst's line narrative (a `thread:<id>` note from /debrief)
+    if (th.narrative) lines.push(`  - ${th.narrative}`);
     if (th.status !== "active" && th.why) {
       lines.push(`  - closed: ${th.why}`);
     } else if (th.stage === "cold") {
@@ -540,7 +542,9 @@ function enrichSynthesis(syn: BriefSynthesis, pulse: CasePulse, records: Overcas
       spark: sparkline(th.activityBins) || undefined,
       funnel: threadFunnelLine(th),
       question: th.question,
-      note: th.status !== "active" ? th.why : undefined,
+      // the analyst's line narrative (thread note); the closed reason for a
+      // closed line with no note
+      note: th.narrative ?? (th.status !== "active" ? th.why : undefined),
     })),
     triage: triage.length ? triage : undefined,
   };

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -541,6 +541,9 @@ function enrichSynthesis(syn: BriefSynthesis, pulse: CasePulse, records: Overcas
   const triage = suggestedFindingRows(records, findingStatusMap(records));
   return {
     ...syn,
+    // rank + cap Key findings identically to the markdown brief (accepted first,
+    // then confidence, then recency, max 8) so --export and the terminal agree.
+    findings: rankFindings(syn.findings).slice(0, 8),
     headline: pulse.headline,
     threads: pulse.threads.map((th) => ({
       value: th.value,

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -416,12 +416,16 @@ function renderCoverageSection(pulse: CasePulse, swept: BriefSynthesis["sources"
 /** Build a markdown brief from the case records. Short (default) leads with the
  *  story — verdict, key findings, lines of investigation, triage, coverage — and
  *  a compact appendix; `full` appends the verbatim record dump (audit artifact). */
-function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: CasePulse; full: boolean; triageRecords?: OvercastRecord[] }): BriefData {
-  // capture reviewed finding statuses BEFORE memoryRecords drops the review rows
-  const statusByFinding = findingStatusMap(records);
-  // the triage backlog is case-wide (unscoped) — a --scope window must not hide
-  // pending suggested leads; falls back to the given records when not provided.
-  const triageRecords = opts.triageRecords ?? records;
+function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: CasePulse; full: boolean; caseRecords?: OvercastRecord[] }): BriefData {
+  // case-wide record set (unscoped): a --scope window must not hide pending
+  // triage leads NOR drop out-of-window accept/dismiss review rows (which would
+  // make an accepted finding read stale `[open]`). Falls back to `records` when
+  // not provided (direct callers pass the full set).
+  const caseRecords = opts.caseRecords ?? records;
+  // reviewed finding statuses come from the FULL case (review rows can land
+  // outside the scope window), captured BEFORE memoryRecords drops them.
+  const statusByFinding = findingStatusMap(caseRecords);
+  const triageRecords = caseRecords;
   // Exclude read/meta and operational outputs (ask/brief/case/setup/doctor/etc.)
   // so briefs and memory search stay evidence-focused instead of citing setup
   // probes, doctor checks, or prior read envelopes as findings.
@@ -464,7 +468,7 @@ function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: 
   lines.push("");
 
   lines.push(...renderThreadSection(opts.pulse.threads));
-  lines.push(...renderTriageSection(triageRecords, findingStatusMap(triageRecords)));
+  lines.push(...renderTriageSection(triageRecords, statusByFinding));
   lines.push(...renderCoverageSection(opts.pulse, synthesis.sources));
 
   // Appendix: the record trail. Short = a compact index with page-it pointers;
@@ -635,7 +639,7 @@ export const briefVerb: VerbSpec = {
     // configured sources look never-scanned and lines read cold under
     // `--scope since:24h`. Only the brief body (synthesis + trail) is scoped.
     const pulse = casePulse({ records: allRecords, targets: listTargets(ctx.case), sources: listSources(ctx.case) });
-    const brief = buildBrief(records, info.name, { pulse, full: ctx.opts.full === true, triageRecords: allRecords });
+    const brief = buildBrief(records, info.name, { pulse, full: ctx.opts.full === true, caseRecords: allRecords });
     const theme = normalizeHtmlTheme(ctx.opts.theme);
     if (!theme) return [readError("brief", `invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
     if (brief.total === 0) {

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -642,7 +642,10 @@ export const briefVerb: VerbSpec = {
     const brief = buildBrief(records, info.name, { pulse, full: ctx.opts.full === true, caseRecords: allRecords });
     const theme = normalizeHtmlTheme(ctx.opts.theme);
     if (!theme) return [readError("brief", `invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
-    if (brief.total === 0) {
+    // Pending only when the WHOLE case is empty — not merely when a --scope
+    // window is. A scoped run over an active case still has a useful body
+    // (threads/coverage/triage from the full-case pulse), so it renders + exports.
+    if (memoryRecords(allRecords).length === 0) {
       return [
         makeRecord({
           verb: "brief",

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -5,7 +5,13 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { makeRecord, memoryRecords, type OvercastRecord } from "../record.js";
-import { collectVisualRefs, isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiTimelineReport, type TimelineRecord } from "../report/html.js";
+import { collectVisualRefs, isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiTimelineReport, type TimelineRecord, type TimelineSynthesis } from "../report/html.js";
+import { sparkline } from "../report/components.js";
+import { casePulse, type CasePulse } from "../signals/pulse.js";
+import { THREAD_STAGE_LABEL, type TargetThread } from "../signals/threads.js";
+import { groupTimeline, groupSummary } from "../signals/rollup.js";
+import { listTargets } from "../state/target.js";
+import { listSources } from "../state/source.js";
 import { posterFrame } from "../media/ffmpeg.js";
 import { resolveMemory, fanOutAnswer, matchesMemoryProvider } from "../providers/memory/index.js";
 import { parseSince } from "../providers/memory/local.js";
@@ -301,10 +307,117 @@ function briefSynthesis(records: OvercastRecord[], statusByFinding: Map<string, 
   return { tldr, verdict, sources: [...bySource].map(([source, hits]) => ({ source, hits })), captures, media_checks: mediaChecks, findings };
 }
 
-/** Build a markdown brief from the case records (timeline + by-kind sections). */
-function buildBrief(records: OvercastRecord[], caseName: string): BriefData {
+const CONFIDENCE_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** Key findings first: accepted before open, then by confidence, then recency
+ *  (findings arrive chronological, so a stable sort by rank keeps newest-wins
+ *  within a tier via the reversed index). Suggested/dismissed are already
+ *  excluded upstream by memoryRecords. */
+function rankFindings(findings: BriefSynthesis["findings"]): BriefSynthesis["findings"] {
+  return findings
+    .map((f, i) => ({ f, i }))
+    .sort((a, b) => {
+      const statusRank = (s: string) => (s === "accepted" ? 2 : s === "open" ? 1 : 0);
+      const byStatus = statusRank(b.f.status) - statusRank(a.f.status);
+      if (byStatus) return byStatus;
+      const byConf = (CONFIDENCE_RANK[String(b.f.confidence ?? "").toLowerCase()] ?? 0) - (CONFIDENCE_RANK[String(a.f.confidence ?? "").toLowerCase()] ?? 0);
+      if (byConf) return byConf;
+      return b.i - a.i; // newer first
+    })
+    .map((x) => x.f);
+}
+
+/** One markdown line summarizing a thread's evidence funnel. */
+function threadFunnelLine(th: TargetThread): string {
+  const f = th.funnel;
+  const parts = [`scan ${f.scan}`, `cap ${f.captures}`, `sense ${f.senses}`, `match ${f.matches}`];
+  const findings: string[] = [];
+  if (th.findings.accepted) findings.push(`${th.findings.accepted} accepted`);
+  if (th.findings.open) findings.push(`${th.findings.open} open`);
+  if (th.findings.suggested) findings.push(`${th.findings.suggested} suggested`);
+  const fnd = findings.length ? ` · findings: ${findings.join(", ")}` : "";
+  return `${parts.join(" → ")}${fnd}`;
+}
+
+/** The "Lines of investigation" section — one block per target thread. */
+function renderThreadSection(threads: TargetThread[]): string[] {
+  const lines: string[] = ["## Lines of investigation", ""];
+  if (!threads.length) {
+    lines.push("- none — add a target with `overcast target add <value> --question \"…\"`", "");
+    return lines;
+  }
+  for (const th of threads) {
+    const spark = sparkline(th.activityBins);
+    const head = `- **${th.value}** — [${THREAD_STAGE_LABEL[th.stage]}]${spark ? ` \`${spark}\`` : ""}`;
+    lines.push(head);
+    if (th.question) lines.push(`  - question: ${th.question}`);
+    lines.push(`  - ${threadFunnelLine(th)}`);
+    if (th.status !== "active" && th.why) {
+      lines.push(`  - closed: ${th.why}`);
+    } else if (th.stage === "cold") {
+      lines.push("  - NEXT: no evidence yet — scan/capture toward this line");
+    } else if (th.findings.suggested) {
+      lines.push(`  - NEXT: triage ${th.findings.suggested} suggested finding${th.findings.suggested === 1 ? "" : "s"} (\`overcast finding list --state triage\`)`);
+    }
+  }
+  lines.push("");
+  return lines;
+}
+
+/** The triage queue — suggested leads awaiting accept/dismiss. Rendered from
+ *  raw records (suggested findings are excluded from synthesis evidence). */
+function renderTriageSection(records: OvercastRecord[], statusByFinding: Map<string, string>): string[] {
+  const suggested = suggestedFindingRows(records, statusByFinding);
+  if (!suggested.length) return [];
+  const lines = [`## Triage — ${suggested.length} suggestion${suggested.length === 1 ? "" : "s"} awaiting review`, ""];
+  for (const r of suggested.slice(0, 5)) {
+    const conf = r.confidence != null ? ` [${r.confidence}]` : "";
+    lines.push(`- \`${r.id}\`${conf} ${r.text}`);
+    lines.push(`  - accept: \`overcast finding accept ${r.id}\` · dismiss: \`overcast finding dismiss ${r.id}\``);
+  }
+  if (suggested.length > 5) lines.push(`- …and ${suggested.length - 5} more (\`overcast finding list --state triage\`)`);
+  lines.push("");
+  return lines;
+}
+
+function isRootFinding(r: OvercastRecord): boolean {
+  const pay = typeof r.payload === "object" && r.payload != null ? (r.payload as Record<string, unknown>) : {};
+  return typeof pay.finding_id !== "string" && typeof pay.status === "string" && typeof pay.text === "string";
+}
+
+/** The coverage section — configured-source freshness funnel + what was actually
+ *  swept (scan-hit rollup) + gaps. Both views matter: configured tells you what
+ *  you meant to watch, swept tells you what you actually checked. */
+function renderCoverageSection(pulse: CasePulse, swept: BriefSynthesis["sources"]): string[] {
+  const lines: string[] = ["## Coverage", ""];
+  if (pulse.coverage.length) {
+    for (const c of pulse.coverage) {
+      const age = c.lastScanAgeSeconds != null ? ` · last scan ${Math.round(c.lastScanAgeSeconds / 3600)}h` : c.gap ? " · never scanned" : "";
+      lines.push(`- **${c.spec}**${c.enabled ? "" : " (disabled)"} — ${c.hits} hit${c.hits === 1 ? "" : "s"} → ${c.captured} captured → ${c.sensed} sensed${age}`);
+    }
+    lines.push("");
+  }
+  lines.push("**Sources checked:**");
+  if (swept.length) {
+    for (const src of swept) lines.push(`- **${src.source}** — ${src.hits} hit${src.hits === 1 ? "" : "s"}`);
+  } else {
+    lines.push("- none — no scan hits in scope");
+  }
+  if (pulse.gaps.length) {
+    lines.push("", "**Gaps:**");
+    for (const g of pulse.gaps.slice(0, 5)) lines.push(`- ${g}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+/** Build a markdown brief from the case records. Short (default) leads with the
+ *  story — verdict, key findings, lines of investigation, triage, coverage — and
+ *  a compact appendix; `full` appends the verbatim record dump (audit artifact). */
+function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: CasePulse; full: boolean }): BriefData {
   // capture reviewed finding statuses BEFORE memoryRecords drops the review rows
   const statusByFinding = findingStatusMap(records);
+  const allScoped = records;
   // Exclude read/meta and operational outputs (ask/brief/case/setup/doctor/etc.)
   // so briefs and memory search stay evidence-focused instead of citing setup
   // probes, doctor checks, or prior read envelopes as findings.
@@ -329,42 +442,108 @@ function buildBrief(records: OvercastRecord[], caseName: string): BriefData {
   lines.push("## TL;DR", "");
   if (synthesis.tldr) lines.push(synthesis.tldr, "");
   lines.push(`_${synthesis.verdict}_`, "");
-  lines.push("## Sources checked", "");
-  if (synthesis.sources.length) {
-    for (const src of synthesis.sources) lines.push(`- **${src.source}** — ${src.hits} hit${src.hits === 1 ? "" : "s"}`);
-  } else {
-    lines.push("- none — no scan hits in scope");
-  }
-  lines.push("", "## Matches & findings", "");
+  lines.push(`**Status:** ${opts.pulse.headline}`, "");
+
+  // Key findings — ranked, capped, with visual proof. (Suggested leads live in
+  // the Triage section below; these are open + accepted evidence.)
+  lines.push("## Key findings", "");
   if (synthesis.findings.length) {
-    for (const f of synthesis.findings) {
+    for (const f of rankFindings(synthesis.findings).slice(0, 8)) {
       const conf = f.confidence != null ? ` (confidence: ${f.confidence})` : "";
       lines.push(`- \`${f.id}\` [${f.status}]${conf} ${f.text}`);
       for (const ref of f.overlays ?? []) lines.push(`  ![match overlay](${ref})`);
     }
+    if (synthesis.findings.length > 8) lines.push(`- …and ${synthesis.findings.length - 8} more`);
   } else {
     lines.push("- none recorded");
   }
-  lines.push("", "## Summary by kind", "");
-  for (const [verb, n] of Object.entries(counts).sort()) lines.push(`- \`${verb}\`: ${n}`);
-  lines.push("", "## Timeline / findings", "");
-  for (const r of sorted) {
-    const at = r.media?.at != null ? ` @${Array.isArray(r.media.at) ? r.media.at.join("-") : r.media.at}s` : "";
-    const ref = r.media?.ref ? ` (${r.media.ref})` : "";
-    lines.push(`### \`${r.verb}\` ${r.id}${at}${ref}`, "");
-    if (r.error) {
-      lines.push(`> error: ${r.error}`, "");
-      continue;
+  lines.push("");
+
+  lines.push(...renderThreadSection(opts.pulse.threads));
+  lines.push(...renderTriageSection(allScoped, statusByFinding));
+  lines.push(...renderCoverageSection(opts.pulse, synthesis.sources));
+
+  // Appendix: the record trail. Short = a compact index with page-it pointers;
+  // full = each record's primary field embedded verbatim (the audit dump).
+  if (opts.full) {
+    lines.push("## Timeline / findings", "");
+    for (const r of sorted) {
+      const at = r.media?.at != null ? ` @${Array.isArray(r.media.at) ? r.media.at.join("-") : r.media.at}s` : "";
+      const ref = r.media?.ref ? ` (${r.media.ref})` : "";
+      lines.push(`### \`${r.verb}\` ${r.id}${at}${ref}`, "");
+      if (r.error) {
+        lines.push(`> error: ${r.error}`, "");
+        continue;
+      }
+      // Embedded record content is DATA, not markup — fence it so a line inside it
+      // that starts with #/##/###/- isn't reparsed as a heading or list item (both
+      // md viewers and our html exporter honor the fence). Use a fence longer than
+      // any backtick run in the body so the content can't close it early.
+      const body = briefBody(r);
+      const fence = fenceFor(body);
+      lines.push(fence, body, fence, "");
     }
-    // Embedded record content is DATA, not markup — fence it so a line inside it
-    // that starts with #/##/###/- isn't reparsed as a heading or list item (both
-    // md viewers and our html exporter honor the fence). Use a fence longer than
-    // any backtick run in the body so the content can't close it early.
-    const body = briefBody(r);
-    const fence = fenceFor(body);
-    lines.push(fence, body, fence, "");
+  } else {
+    lines.push("## Record trail", "");
+    lines.push(`_${sorted.length} evidence record${sorted.length === 1 ? "" : "s"} — read any in full with_ \`overcast case memory get <id>\` _· \`brief --full\` for the verbatim timeline_`, "");
+    // When a case fans out (many records per capture/sweep), group by media chain
+    // so the trail reads as "one artifact, N looks" instead of dozens of rows.
+    const byId = new Map(sorted.map((r) => [r.id, r]));
+    const groups = groupTimeline(sorted);
+    if (groups.length >= 12 && groups.length < sorted.length) {
+      for (const g of groups) {
+        const when = g.time ? g.time.replace("T", " ").replace(/\..*/, "") : "—";
+        lines.push(`- **${g.title}** · ${when} — ${groupSummary(g)}`);
+        // surface the group's most informative record inline as a one-liner
+        const lead = g.recordIds.map((id) => byId.get(id)).find((r) => r && !r.error && r.verb !== "capture");
+        if (lead) lines.push(`  - \`${lead.id}\` ${lead.verb}: ${briefStub(lead)}`);
+      }
+    } else {
+      for (const r of sorted) {
+        const when = r.meta?.time ? String(r.meta.time).replace("T", " ").replace(/\..*/, "") : "—";
+        const at = r.media?.at != null ? ` @${Array.isArray(r.media.at) ? r.media.at.join("-") : r.media.at}s` : "";
+        const stub = r.error ? `error: ${r.error}` : briefStub(r);
+        lines.push(`- \`${r.id}\` **${r.verb}**${at} · ${when} — ${stub}`);
+      }
+    }
+    lines.push("");
   }
   return { md: lines.join("\n"), counts, total: records.length, records: sorted, synthesis };
+}
+
+/** A one-line stub of a record's primary field for the compact appendix. */
+function briefStub(rec: OvercastRecord): string {
+  const body = briefBody(rec).replace(/\s+/g, " ").trim();
+  return body.length > 160 ? body.slice(0, 157) + "…" : body || "(empty)";
+}
+
+/** Compact suggested-lead rows (id/text/confidence), newest first — shared by
+ *  the markdown triage section and the CSI triage panel. */
+function suggestedFindingRows(records: OvercastRecord[], statusByFinding: Map<string, string>): Array<{ id: string; text: string; confidence?: unknown }> {
+  const p = (r: OvercastRecord): Record<string, unknown> => (typeof r.payload === "object" && r.payload != null ? (r.payload as Record<string, unknown>) : {});
+  return records
+    .filter((r) => r.verb === "finding" && r.state !== "error" && isRootFinding(r) && (statusByFinding.get(r.id) ?? "open") === "suggested")
+    .sort((a, b) => Date.parse(String(b.meta?.time ?? "")) - Date.parse(String(a.meta?.time ?? "")))
+    .map((r) => ({ id: r.id, text: String(p(r).text ?? ""), confidence: p(r).confidence }));
+}
+
+/** Fold the pulse's headline + threads + triage into the CSI synthesis header
+ *  so the exported HTML tells the same story as the markdown. */
+function enrichSynthesis(syn: BriefSynthesis, pulse: CasePulse, records: OvercastRecord[]): TimelineSynthesis {
+  const triage = suggestedFindingRows(records, findingStatusMap(records));
+  return {
+    ...syn,
+    headline: pulse.headline,
+    threads: pulse.threads.map((th) => ({
+      value: th.value,
+      stage: THREAD_STAGE_LABEL[th.stage],
+      spark: sparkline(th.activityBins) || undefined,
+      funnel: threadFunnelLine(th),
+      question: th.question,
+      note: th.status !== "active" ? th.why : undefined,
+    })),
+    triage: triage.length ? triage : undefined,
+  };
 }
 
 // Brief is an export artifact: embed each record's primary field IN FULL (not a
@@ -402,6 +581,7 @@ export const briefVerb: VerbSpec = {
   args: [],
   flags: [
     { name: "scope", summary: "Filter, e.g. since:24h or verb:watch", type: "string" },
+    { name: "full", summary: "Include the full verbatim record timeline (audit dump) instead of the compact appendix", type: "boolean" },
     { name: "export", summary: "Write a report file (.md or .html)", type: "string" },
     { name: "theme", summary: "HTML export theme: plain | csi", type: "string", choices: ["plain", "csi"], default: "plain" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
@@ -443,7 +623,8 @@ export const briefVerb: VerbSpec = {
       }
     }
     const info = ctx.case.exists() ? ctx.case.info() : { name: "case" };
-    const brief = buildBrief(records, info.name);
+    const pulse = casePulse({ records, targets: listTargets(ctx.case), sources: listSources(ctx.case) });
+    const brief = buildBrief(records, info.name, { pulse, full: ctx.opts.full === true });
     const theme = normalizeHtmlTheme(ctx.opts.theme);
     if (!theme) return [readError("brief", `invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
     if (brief.total === 0) {
@@ -470,7 +651,10 @@ export const briefVerb: VerbSpec = {
       const isHtml = isHtmlExportPath(path);
       let html: string;
       if (theme === "csi") {
-        const timeline = brief.records.map(recordToTimelineRecord);
+        // short mode caps the timeline cards to the newest slice (the story lives
+        // in the synthesis header); --full renders every evidence record.
+        const timelineRecords = ctx.opts.full === true ? brief.records : brief.records.slice(-24);
+        const timeline = timelineRecords.map(recordToTimelineRecord);
         // extract tiny poster frames for local video previews so the player can
         // stay preload="none" — a report full of large clips must not stall the
         // page loading video metadata (see attachVideoPosters).
@@ -482,7 +666,7 @@ export const briefVerb: VerbSpec = {
           records: timeline,
           counts: brief.counts,
           total: brief.total,
-          synthesis: brief.synthesis,
+          synthesis: enrichSynthesis(brief.synthesis, pulse, records),
         });
       } else {
         html = mdToPlainHtml(brief.md, `Brief — ${info.name}`);

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -359,7 +359,7 @@ function renderThreadSection(threads: TargetThread[]): string[] {
     } else if (th.stage === "cold") {
       lines.push("  - NEXT: no evidence yet — scan/capture toward this line");
     } else if (th.findings.suggested) {
-      lines.push(`  - NEXT: triage ${th.findings.suggested} suggested finding${th.findings.suggested === 1 ? "" : "s"} (\`overcast finding list --state triage\`)`);
+      lines.push(`  - NEXT: triage ${th.findings.suggested} suggested finding${th.findings.suggested === 1 ? "" : "s"} (\`overcast finding list --state suggested\`)`);
     }
   }
   lines.push("");
@@ -377,7 +377,7 @@ function renderTriageSection(records: OvercastRecord[], statusByFinding: Map<str
     lines.push(`- \`${r.id}\`${conf} ${r.text}`);
     lines.push(`  - accept: \`overcast finding accept ${r.id}\` · dismiss: \`overcast finding dismiss ${r.id}\``);
   }
-  if (suggested.length > 5) lines.push(`- …and ${suggested.length - 5} more (\`overcast finding list --state triage\`)`);
+  if (suggested.length > 5) lines.push(`- …and ${suggested.length - 5} more (\`overcast finding list --state suggested\`)`);
   lines.push("");
   return lines;
 }
@@ -416,10 +416,12 @@ function renderCoverageSection(pulse: CasePulse, swept: BriefSynthesis["sources"
 /** Build a markdown brief from the case records. Short (default) leads with the
  *  story — verdict, key findings, lines of investigation, triage, coverage — and
  *  a compact appendix; `full` appends the verbatim record dump (audit artifact). */
-function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: CasePulse; full: boolean }): BriefData {
+function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: CasePulse; full: boolean; triageRecords?: OvercastRecord[] }): BriefData {
   // capture reviewed finding statuses BEFORE memoryRecords drops the review rows
   const statusByFinding = findingStatusMap(records);
-  const allScoped = records;
+  // the triage backlog is case-wide (unscoped) — a --scope window must not hide
+  // pending suggested leads; falls back to the given records when not provided.
+  const triageRecords = opts.triageRecords ?? records;
   // Exclude read/meta and operational outputs (ask/brief/case/setup/doctor/etc.)
   // so briefs and memory search stay evidence-focused instead of citing setup
   // probes, doctor checks, or prior read envelopes as findings.
@@ -462,7 +464,7 @@ function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: 
   lines.push("");
 
   lines.push(...renderThreadSection(opts.pulse.threads));
-  lines.push(...renderTriageSection(allScoped, statusByFinding));
+  lines.push(...renderTriageSection(triageRecords, findingStatusMap(triageRecords)));
   lines.push(...renderCoverageSection(opts.pulse, synthesis.sources));
 
   // Appendix: the record trail. Short = a compact index with page-it pointers;
@@ -594,7 +596,8 @@ export const briefVerb: VerbSpec = {
   outputKind: "brief",
   providerKey: "brief",
   run: async (ctx) => {
-    let records = ctx.case.records();
+    const allRecords = ctx.case.records();
+    let records = allRecords;
     // a provided-but-blank `--scope=` is a user error (it would otherwise fall
     // through to the positional / no-filter and silently emit the FULL brief),
     // consistent with ask/face/index rejecting blank flags.
@@ -627,8 +630,12 @@ export const briefVerb: VerbSpec = {
       }
     }
     const info = ctx.case.exists() ? ctx.case.info() : { name: "case" };
-    const pulse = casePulse({ records, targets: listTargets(ctx.case), sources: listSources(ctx.case) });
-    const brief = buildBrief(records, info.name, { pulse, full: ctx.opts.full === true });
+    // pulse reflects the STANDING investigation state (threads, coverage,
+    // freshness) over the full case — computing it on scoped records would make
+    // configured sources look never-scanned and lines read cold under
+    // `--scope since:24h`. Only the brief body (synthesis + trail) is scoped.
+    const pulse = casePulse({ records: allRecords, targets: listTargets(ctx.case), sources: listSources(ctx.case) });
+    const brief = buildBrief(records, info.name, { pulse, full: ctx.opts.full === true, triageRecords: allRecords });
     const theme = normalizeHtmlTheme(ctx.opts.theme);
     if (!theme) return [readError("brief", `invalid --theme '${ctx.opts.theme}' (expected plain or csi)`)];
     if (brief.total === 0) {
@@ -670,7 +677,7 @@ export const briefVerb: VerbSpec = {
           records: timeline,
           counts: brief.counts,
           total: brief.total,
-          synthesis: enrichSynthesis(brief.synthesis, pulse, records),
+          synthesis: enrichSynthesis(brief.synthesis, pulse, allRecords),
         });
       } else {
         html = mdToPlainHtml(brief.md, `Brief — ${info.name}`);

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -6,7 +6,7 @@ import { existsSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { makeRecord, memoryRecords, type OvercastRecord } from "../record.js";
 import { collectVisualRefs, isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiTimelineReport, type TimelineRecord, type TimelineSynthesis } from "../report/html.js";
-import { sparkline } from "../report/components.js";
+import { sparkline, fmtAge } from "../report/components.js";
 import { casePulse, type CasePulse } from "../signals/pulse.js";
 import { THREAD_STAGE_LABEL, type TargetThread } from "../signals/threads.js";
 import { groupTimeline, groupSummary } from "../signals/rollup.js";
@@ -394,7 +394,7 @@ function renderCoverageSection(pulse: CasePulse, swept: BriefSynthesis["sources"
   const lines: string[] = ["## Coverage", ""];
   if (pulse.coverage.length) {
     for (const c of pulse.coverage) {
-      const age = c.lastScanAgeSeconds != null ? ` · last scan ${Math.round(c.lastScanAgeSeconds / 3600)}h` : c.gap ? " · never scanned" : "";
+      const age = c.lastScanAgeSeconds != null ? ` · last scan ${fmtAge(c.lastScanAgeSeconds)}` : c.gap ? " · never scanned" : "";
       lines.push(`- **${c.spec}**${c.enabled ? "" : " (disabled)"} — ${c.hits} hit${c.hits === 1 ? "" : "s"} → ${c.captured} captured → ${c.sensed} sensed${age}`);
     }
     lines.push("");

--- a/test/e2e/live/cases/14_face.sh
+++ b/test/e2e/live/cases/14_face.sh
@@ -28,6 +28,7 @@ assert_eq "$C.provider" "tinycloud" "$(echo "$out" | jq -r '.meta.provider')" "m
 if have_media "$IMAGE_FILE"; then
   cond "face --match <image> <video> finds the person and emits ranked matches (0-1 similarity)"
   mout="$(OC_TIMEOUT=300 oc "$CASE" face "$CLIP" --match "$IMAGE_FILE" --max-faces 5 --json)"; mrc=$?
+  mout="$(echo "$mout" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
   assert_eq "$C.match_exit" "0" "$mrc" "face --match exits 0"
   assert_eq "$C.match_op" "match" "$(echo "$mout" | jq -r '.payload.op')" "op is match"
   assert_eq "$C.match_state" "ready" "$(echo "$mout" | jq -r '.state')" "state is ready"

--- a/test/e2e/live/cases/16_visual_db.sh
+++ b/test/e2e/live/cases/16_visual_db.sh
@@ -36,11 +36,13 @@ MAX_FRAMES="${OC_LOCAL_IMAGE_MAX_FRAMES:-12}"
 IMAGE_FPS="${OC_LOCAL_IMAGE_FPS:-0.7}"
 
 match_a="$(OC_TIMEOUT=420 oc "$CASE" image match "$LOCAL_IMAGE_VIDEO_A" --index "$IMG_INDEX" --min-inliers "$MIN_INLIERS" --min-ratio "$MIN_RATIO" --fps "$IMAGE_FPS" --max-frames "$MAX_FRAMES" --draw --json)"
+match_a="$(echo "$match_a" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
 assert_eq "$C.image_match_a_state" "ready" "$(echo "$match_a" | jq -r '.state')" "video A image match state ready"
 count_a="$(echo "$match_a" | jq -r '.payload.count // 0')"
 assert_eq "$C.image_match_a_fps" "$IMAGE_FPS" "$(echo "$match_a" | jq -r '.payload.sampling.fps // empty')" "video A image match used fps sampling"
 
 match_b="$(OC_TIMEOUT=420 oc "$CASE" image match "$LOCAL_IMAGE_VIDEO_B" --index "$IMG_INDEX" --min-inliers "$MIN_INLIERS" --min-ratio "$MIN_RATIO" --fps "$IMAGE_FPS" --max-frames "$MAX_FRAMES" --draw --json)"
+match_b="$(echo "$match_b" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
 assert_eq "$C.image_match_b_state" "ready" "$(echo "$match_b" | jq -r '.state')" "video B image match state ready"
 count_b="$(echo "$match_b" | jq -r '.payload.count // 0')"
 assert_eq "$C.image_match_b_fps" "$IMAGE_FPS" "$(echo "$match_b" | jq -r '.payload.sampling.fps // empty')" "video B image match used fps sampling"
@@ -91,6 +93,7 @@ assert_nonempty "$C.face_index_id" "$FACE_INDEX" "local face index id returned"
 face_add="$(oc "$CASE" index add "$LOCAL_FACE_IMAGE" --to "$FACE_INDEX" --json)"
 assert_eq "$C.face_add_state" "ready" "$(echo "$face_add" | jq -r '.state')" "reference face added to local face index"
 face_match="$(OC_TIMEOUT=420 oc "$CASE" face "$LOCAL_FACE_VIDEO" --match "$LOCAL_FACE_IMAGE" --index "$FACE_INDEX" --min-similarity "$FACE_MIN" --fps "$FACE_FPS" --max-frames "$FACE_FRAMES" --json)"
+face_match="$(echo "$face_match" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
 assert_eq "$C.face_match_state" "ready" "$(echo "$face_match" | jq -r '.state')" "local face match state ready"
 assert_eq "$C.face_match_fps" "$FACE_FPS" "$(echo "$face_match" | jq -r '.payload.sampling.fps // empty')" "local face match used fps sampling"
 face_count="$(echo "$face_match" | jq -r '.payload.count // 0')"

--- a/test/e2e/live/cases/17_clip_db.sh
+++ b/test/e2e/live/cases/17_clip_db.sh
@@ -88,6 +88,7 @@ save_json "clip_db_text_video" "$tv" >/dev/null
 
 cond "image×video: a real frame from video A ranks video A's nearest moment first"
 iv="$(OC_TIMEOUT=420 oc "$CASE" similar match "$IMG_A_QUERY" --index "$CLIP_INDEX" --limit 8 --json)"
+iv="$(echo "$iv" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
 assert_eq "$C.image_video_state" "ready" "$(echo "$iv" | jq -r '.state')" "image×video match ready"
 assert_eq "$C.image_video_top" "$CLIP_A" "$(echo "$iv" | jq -r '.payload.matches[0].ref // empty')" "top image×video match is video A"
 iv_sim="$(echo "$iv" | jq -r '.payload.matches[0].similarity // 0')"
@@ -96,6 +97,7 @@ save_json "clip_db_image_video" "$iv" >/dev/null
 
 cond "image×image: a different frame of scene B finds the stored image member"
 ii="$(OC_TIMEOUT=420 oc "$CASE" similar match "$IMG_B_QUERY" --index "$CLIP_INDEX" --limit 8 --json)"
+ii="$(echo "$ii" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
 assert_eq "$C.image_image_state" "ready" "$(echo "$ii" | jq -r '.state')" "image×image match ready"
 ii_top="$(echo "$ii" | jq -r '.payload.matches[0].ref // empty')"
 case "$ii_top" in "$CLIP_B"|"$IMG_B_MEMBER") ok "$C.image_image_top" "top match is scene B ($(basename "$ii_top"))" ;; *) fail "$C.image_image_top" "top match is not scene B: $ii_top" ;; esac

--- a/test/e2e/live/cases/17_face_cluster.sh
+++ b/test/e2e/live/cases/17_face_cluster.sh
@@ -72,7 +72,9 @@ if [ "$have_fixtures" -eq 1 ]; then
   # HELD-OUT identify: the reference must match a Will Smith cluster, and beat the
   # other person by a wide margin (the real proof clustering separates identities).
   cond "held-out identify matches the Will Smith reference to a Will Smith cluster, far above the other person"
-  idout="$(oc "$CASE" cluster identify "$FIXDIR/willsmith_ref.jpg" --index "$ID" --json)"; save_json "identify" "$idout" >/dev/null
+  idout="$(oc "$CASE" cluster identify "$FIXDIR/willsmith_ref.jpg" --index "$ID" --json)"
+  idout="$(echo "$idout" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
+  save_json "identify" "$idout" >/dev/null
   best_cid="$(echo "$idout" | jq -r '.payload.matches[0].candidates[0].cluster_id')"
   best_sim="$(echo "$idout" | jq -r '.payload.matches[0].candidates[0].similarity')"
   second_sim="$(echo "$idout" | jq -r '.payload.matches[0].candidates[1].similarity // 0')"
@@ -111,6 +113,7 @@ else
   [ -f "$viewer" ] && cp "$viewer" "$SMOKE_DIR/cluster_gallery.html"
   if have_media "$LOCAL_FACE_IMAGE"; then
     idout="$(oc "$CASE" cluster identify "$LOCAL_FACE_IMAGE" --index "$ID" --json)"
+    idout="$(echo "$idout" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
     assert_eq "$C.identify_state" "ready" "$(echo "$idout" | jq -r '.state')" "identify ready"
   fi
 fi

--- a/test/e2e/live/cases/18_findings.sh
+++ b/test/e2e/live/cases/18_findings.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Suggested findings + threads + mission-board status + short brief, end-to-end
+# on REAL data. A real tinycloud `face --match` clears the score threshold and the
+# shared persist hook auto-emits a `suggested` finding (a lead) — quarantined from
+# ask/brief evidence until reviewed. Then: triage queue, accept -> corroborated +
+# citable evidence, a `thread:` narrative note rendered on the line card, a
+# dead-end line, and the short brief (+ --full) sections.
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib.sh
+source "$LIVE/lib.sh"
+C=findings
+require_cred "$C" CLOUDGLUE_API_KEY "skipping real suggested-findings flow" || exit 0
+
+# a face image + a video the person appears in (local face fixtures, else OC_IMAGE + a visual clip)
+FACE_IMG="$LOCAL_FACE_IMAGE"; FACE_VID="$LOCAL_FACE_VIDEO"
+have_media "$FACE_IMG" || FACE_IMG="$IMAGE_FILE"
+have_media "$FACE_VID" || FACE_VID="$VIDEO_VISUAL"
+have_media "$FACE_IMG" || { skip "$C" "no face image (OC_LOCAL_FACE_IMAGE / OC_IMAGE)"; exit 0; }
+have_media "$FACE_VID" || { skip "$C" "no video (OC_LOCAL_FACE_VIDEO / OC_VIDEO_VISUAL)"; exit 0; }
+
+CASE=$(case_dir findings)
+CLIP="$SMOKE_DIR/findings-clip.mp4"
+clip_av 8 "$FACE_VID" "$CLIP" || CLIP="$FACE_VID"
+[ -f "$CLIP" ] || CLIP="$FACE_VID"
+
+# a line of investigation (image target) with a question
+oc "$CASE" target add "$FACE_IMG" --image --question "Does the reference person appear in the clip?" >/dev/null
+
+cond "a real face --match above threshold auto-emits a quarantined 'suggested' finding via the persist hook"
+mout="$(OC_TIMEOUT=300 oc "$CASE" face "$CLIP" --match "$FACE_IMG" --json)"; mrc=$?
+assert_eq "$C.match_exit" "0" "$mrc" "face --match exits 0"
+# slurp: the batch is the face record PLUS the auto-suggested finding
+sug="$(echo "$mout" | jq -s '[.[] | select(.verb=="finding" and .payload.status=="suggested")]')"
+assert_eq "$C.suggested_count" "1" "$(echo "$sug" | jq 'length')" "exactly one suggested finding emitted"
+assert_eq "$C.trigger" "signal:face-match" "$(echo "$sug" | jq -r '.[0].payload.trigger')" "trigger is signal:face-match"
+assert_nonempty "$C.signal_score" "$(echo "$sug" | jq -r '.[0].payload.signal.score // empty')" "signal.score carried on the lead"
+assert_nonempty "$C.confidence" "$(echo "$sug" | jq -r '.[0].payload.confidence // empty')" "confidence band set (high/medium)"
+assert_nonempty "$C.lead_anchor" "$(echo "$sug" | jq -r '.[0].media.at // empty | tostring')" "lead anchored at the best-scoring moment"
+FID="$(echo "$sug" | jq -r '.[0].id')"
+
+cond "finding list --state triage queues the suggested lead newest-first"
+tri="$(oc "$CASE" finding list --state triage --json)"
+assert_eq "$C.triage_has_lead" "true" "$(echo "$tri" | jq --arg id "$FID" 'any(.payload.findings[]; .id==$id)')" "the lead is in the triage queue"
+
+cond "a suggested lead is QUARANTINED from brief evidence until reviewed"
+b0="$(oc "$CASE" brief --json)"
+assert_eq "$C.quarantined" "false" "$(echo "$b0" | jq -r --arg id "$FID" '.payload.report | contains("[accepted]") and contains($id)')" "unreviewed lead is NOT in Key findings"
+
+cond "case status is a mission board: goal headline + per-target thread at LEADS + triage queue"
+st="$(oc "$CASE" case status --json)"
+assert_eq "$C.status_headline" "true" "$(echo "$st" | jq -r '.payload.mission.headline | test("line";"i")')" "mission headline names the lines of investigation"
+assert_eq "$C.status_leads" "true" "$(echo "$st" | jq -r '[.payload.threads[].stage] | any(. == "leads")')" "the image line reads 'leads' (a suggested finding is present)"
+assert_eq "$C.status_triage" "1" "$(echo "$st" | jq -r '.payload.mission.progress.triage_pending')" "one suggestion awaiting triage"
+
+cond "finding accept promotes the lead into evidence (corroborated line + citable by ask)"
+oc "$CASE" finding accept "$FID" >/dev/null
+b1="$(oc "$CASE" brief --json)"
+assert_eq "$C.accepted_in_brief" "true" "$(echo "$b1" | jq -r --arg id "$FID" '.payload.report | contains("[accepted]") and contains($id)')" "accepted finding now appears in Key findings"
+st2="$(oc "$CASE" case status --json)"
+assert_eq "$C.corroborated" "true" "$(echo "$st2" | jq -r '[.payload.threads[].stage] | any(. == "corroborated")')" "the line is now corroborated"
+ask="$(oc "$CASE" ask "was the reference person found in the clip?" --json)"
+assert_eq "$C.ask_cites_finding" "true" "$(echo "$ask" | jq -r '[.payload.citations[].verb] | any(. == "finding")')" "ask cites the accepted finding as evidence"
+
+cond "a thread:<id> narrative note (the /debrief convention) renders on the line card"
+TID="$(oc "$CASE" target list --json | jq -r '.payload.targets[] | select(.kind=="image") | .id')"
+oc "$CASE" note "Confirmed across multiple frames; next: pull more clips from the same account." --tag "thread:$TID" >/dev/null
+b2="$(oc "$CASE" brief --json)"
+assert_eq "$C.narrative_rendered" "true" "$(echo "$b2" | jq -r '.payload.report | contains("pull more clips from the same account")')" "thread narrative note surfaces on the line card"
+
+cond "a dead-end line renders dimmed with its closing reason"
+oc "$CASE" target add "unrelated-subject-zzz" --question "control line" >/dev/null
+DID="$(oc "$CASE" target list --json | jq -r '.payload.targets[] | select(.value=="unrelated-subject-zzz") | .id')"
+oc "$CASE" target close "$DID" --as dead-end --note "no evidence after review" >/dev/null
+b3="$(oc "$CASE" brief --json)"
+assert_eq "$C.deadend_rendered" "true" "$(echo "$b3" | jq -r '.payload.report | test("DEAD-END")')" "the closed line shows the DEAD-END stage"
+assert_eq "$C.deadend_reason" "true" "$(echo "$b3" | jq -r '.payload.report | contains("no evidence after review")')" "the closing reason is shown"
+
+cond "brief is short by default (compact record trail) with --full for the verbatim audit dump"
+short="$(oc "$CASE" brief --json | jq -r '.payload.report')"
+full="$(oc "$CASE" brief --full --json | jq -r '.payload.report')"
+assert_eq "$C.short_trail" "true" "$(echo "$short" | grep -qF "## Record trail" && echo true || echo false)" "short brief has the compact record trail"
+assert_eq "$C.short_no_dump" "false" "$(echo "$short" | grep -qF "## Timeline / findings" && echo true || echo false)" "short brief omits the verbatim timeline"
+assert_eq "$C.full_dump" "true" "$(echo "$full" | grep -qF "## Timeline / findings" && echo true || echo false)" "--full appends the verbatim timeline"
+
+cond "finding dismiss quarantines a lead permanently and blocks its re-suggestion"
+# re-run the same match; a fresh suggestion for the SAME source dedups (already accepted)
+mout2="$(OC_TIMEOUT=300 oc "$CASE" face "$CLIP" --match "$FACE_IMG" --json)"
+redun="$(echo "$mout2" | jq -s '[.[] | select(.verb=="finding" and .payload.status=="suggested")] | length')"
+assert_eq "$C.no_reduplicate" "0" "$redun" "an already-reviewed match does not re-suggest the same lead"

--- a/test/e2e/live/cases/27_copycat_local.sh
+++ b/test/e2e/live/cases/27_copycat_local.sh
@@ -48,6 +48,7 @@ seg=$(( DUR > 70 ? 60 : DUR - mid - 1 )); [ "$seg" -lt 6 ] && seg=6
   -an -c:v libx264 -preset veryfast "$WORK/reskin.mp4" 2>/dev/null
 if [ ! -s "$WORK/reskin.mp4" ]; then fail "$C.reskin_build" "ffmpeg could not build the reskin clip"; exit 0; fi
 mr="$(OC_TIMEOUT=420 oc "$CASE" image match "$WORK/reskin.mp4" --index "$IDX" --max-frames 40 --draw --json)"
+mr="$(echo "$mr" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
 save_json "27_match_reskin" "$mr" >/dev/null
 assert_eq "$C.reskin_state" "ready" "$(echo "$mr" | jq -r '.state')" "reskin match ran"
 rc="$(echo "$mr" | jq -r '.payload.count // 0')"
@@ -70,6 +71,7 @@ else
 fi
 if [ -s "$WORK/unrelated.mp4" ]; then
   mu="$(OC_TIMEOUT=420 oc "$CASE" image match "$WORK/unrelated.mp4" --index "$IDX" --max-frames 40 --json)"
+  mu="$(echo "$mu" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
   save_json "27_match_unrelated" "$mu" >/dev/null
   uc="$(echo "$mu" | jq -r '.payload.count // 0')"
   if [ "${uc:-0}" -eq 0 ]; then

--- a/test/e2e/live/cases/31_visualization.sh
+++ b/test/e2e/live/cases/31_visualization.sh
@@ -41,6 +41,7 @@ then
   img_add="$(oc "$CASE" image add "$LOCAL_IMAGE_REF" --index "$IMG_INDEX" --json)"
   assert_eq "$C.starbucks.add" "ready" "$(echo "$img_add" | jq -r '.state')" "Starbucks reference added"
   img_match="$(OC_TIMEOUT=420 oc "$CASE" image match "$LOCAL_IMAGE_VIDEO_A" --index "$IMG_INDEX" --min-inliers "${OC_LOCAL_IMAGE_MIN_INLIERS:-8}" --min-ratio "${OC_LOCAL_IMAGE_MIN_RATIO:-0.25}" --fps "${OC_LOCAL_IMAGE_FPS:-0.7}" --max-frames "${OC_LOCAL_IMAGE_MAX_FRAMES:-12}" --draw --json)"
+  img_match="$(echo "$img_match" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
   starbucks_state="$(echo "$img_match" | jq -r '.state // empty' 2>/dev/null || true)"
   starbucks_count="$(echo "$img_match" | jq -r '.payload.count // 0' 2>/dev/null || echo 0)"
   if [ "$starbucks_state" = "ready" ]; then
@@ -72,6 +73,7 @@ then
   face_add="$(oc "$CASE" index add "$LOCAL_FACE_IMAGE" --to "$FACE_INDEX" --json)"
   assert_eq "$C.will.add" "ready" "$(echo "$face_add" | jq -r '.state')" "Will reference added"
   face_match="$(OC_TIMEOUT=420 oc "$CASE" face "$LOCAL_FACE_VIDEO" --match "$LOCAL_FACE_IMAGE" --index "$FACE_INDEX" --profile local --min-similarity "${OC_LOCAL_FACE_MIN_SIMILARITY:-45}" --fps "${OC_LOCAL_FACE_FPS:-0.5}" --max-frames "${OC_LOCAL_FACE_MAX_FRAMES:-24}" --json)"
+  face_match="$(echo "$face_match" | primary_rec)"  # drop any auto-suggested finding the persist hook appended
   will_state="$(echo "$face_match" | jq -r '.state // empty' 2>/dev/null || true)"
   will_count="$(echo "$face_match" | jq -r '.payload.count // 0' 2>/dev/null || echo 0)"
   if [ "$will_state" = "ready" ]; then

--- a/test/e2e/live/lib.sh
+++ b/test/e2e/live/lib.sh
@@ -122,6 +122,15 @@ oc() {
   printf '%s' "$out"
 }
 
+# primary_rec — from a verb's --json output, keep ONLY the primary (first
+# non-finding) record. A real match/identify (face --match, image match, similar
+# match, cluster identify) now clears a score threshold and the shared persist
+# hook APPENDS an auto-suggested `finding` record after the verb's own record, so
+# the raw output has 2+ JSON values; pipe through this before a single-record
+# `jq -r '.field'` assert. (The finding itself is asserted separately in
+# 18_findings.sh.) Reads stdin, emits one compact JSON record.
+primary_rec() { jq -s '[.[] | select(.verb != "finding")][0]'; }
+
 # ocg <args...> — run the binary directly (no case dir; for version/commands/help)
 ocg() {
   local out; out="$(perl -e 'alarm shift; exec @ARGV or exit 127' "${OC_TIMEOUT:-60}" $OVERCAST "$@" 2>/dev/null)"

--- a/test/unit/case-verb.test.ts
+++ b/test/unit/case-verb.test.ts
@@ -73,6 +73,24 @@ test("case status returns combined status payload", async () => {
   });
 });
 
+test("case status next-action: triage hint count matches its command (--state suggested)", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    addTarget(c, "acme");
+    // a suggested lead + an OPEN manual finding: triage_pending counts only the
+    // suggested one, so the hint must point at --state suggested (not triage,
+    // which would also return the open finding and mismatch the count)
+    c.writeRecord(makeRecord({ verb: "finding", payload: { text: "lead", target: "acme", source_record: "s", source_verb: "face", trigger: "signal:face-match", status: "suggested" }, state: "ready" }));
+    c.writeRecord(makeRecord({ verb: "finding", payload: { text: "manual", target: "acme", source_record: "manual", source_verb: "manual", trigger: "human", status: "open" }, state: "ready" }));
+    const [rec] = await caseVerb.run(ctx(dir, "status"));
+    const payload = rec.payload as Record<string, unknown>;
+    assert.equal((payload.mission as { progress: Record<string, number> }).progress.triage_pending, 1);
+    const next = (payload.next_actions as string[]).join("\n");
+    assert.match(next, /Triage 1 suggested finding\(s\): `overcast finding list --state suggested`/);
+    assert.doesNotMatch(next, /--state triage/);
+  });
+});
+
 test("case status --export html --theme csi writes report", async () => {
   await withCase(async (dir) => {
     const c = openCase(dir);

--- a/test/unit/case-verb.test.ts
+++ b/test/unit/case-verb.test.ts
@@ -60,7 +60,13 @@ test("case status returns combined status payload", async () => {
     assert.equal(((payload.registries as Record<string, unknown>).sources), 1);
     assert.equal(((payload.registries as Record<string, unknown>).indexes), 1);
     assert.ok(Array.isArray(payload.memory_index));
-    assert.match(String((payload.tldr as Record<string, unknown>).headline), /tracking subject/);
+    // mission board: goal-progress headline + per-target threads + coverage
+    const mission = payload.mission as { headline: string; progress: Record<string, number> };
+    assert.match(mission.headline, /2 lines active/);
+    assert.equal(mission.progress.targets_total, 2);
+    assert.equal((payload.threads as unknown[]).length, 2);
+    assert.ok(Array.isArray(payload.coverage));
+    assert.match(String((payload.tldr as Record<string, unknown>).headline), /2 lines active/);
     assert.equal((payload.targets as unknown[]).length, 2);
     assert.equal((payload.sources as unknown[]).length, 1);
     assert.equal((payload.match_visualizations as unknown[]).length, 1);

--- a/test/unit/case-verb.test.ts
+++ b/test/unit/case-verb.test.ts
@@ -91,6 +91,33 @@ test("case status next-action: triage hint count matches its command (--state su
   });
 });
 
+test("case status triage header shows the TRUE backlog count (not the capped rows)", async () => {
+  await withCase(async (dir) => {
+    const c = openCase(dir);
+    addTarget(c, "acme");
+    // 11 suggested leads — payload.triage caps rows at 8, so the header must use
+    // the full triage_pending count, and md + CSI must show an "…and N more" line
+    for (let i = 0; i < 11; i++) {
+      c.writeRecord(makeRecord({ verb: "finding", payload: { text: `lead ${i}`, target: "acme", source_record: `s${i}`, source_verb: "face", trigger: "signal:face-match", status: "suggested" }, state: "ready" }));
+    }
+    const [rec] = await caseVerb.run(ctx(dir, "status"));
+    const payload = rec.payload as Record<string, unknown>;
+    assert.equal((payload.mission as { progress: Record<string, number> }).progress.triage_pending, 11);
+    // markdown
+    const mdPath = join(dir, "s.md");
+    await caseVerb.run(ctx(dir, "status", [], { export: mdPath }));
+    const md = readFileSync(mdPath, "utf8");
+    assert.match(md, /## Triage — 11 awaiting review/);
+    assert.match(md, /…and 3 more/); // 11 total − 8 shown
+    // CSI html
+    const htmlPath = join(dir, "s.html");
+    await caseVerb.run(ctx(dir, "status", [], { export: htmlPath, theme: "csi" }));
+    const html = readFileSync(htmlPath, "utf8");
+    assert.match(html, /Triage — 11 awaiting review/);
+    assert.match(html, /…and 6 more/); // CSI shows 5, so 11 − 5
+  });
+});
+
 test("case status --export html --theme csi writes report", async () => {
   await withCase(async (dir) => {
     const c = openCase(dir);

--- a/test/unit/components.test.ts
+++ b/test/unit/components.test.ts
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fmtAge, fmtTime, sparkline, chip, coverageBadges } from "../../src/report/components.ts";
+
+test("fmtAge: compact units, — for unknown", () => {
+  assert.equal(fmtAge(null), "—");
+  assert.equal(fmtAge(undefined), "—");
+  assert.equal(fmtAge(NaN), "—");
+  assert.equal(fmtAge(30), "30s");
+  assert.equal(fmtAge(90), "2m");
+  assert.equal(fmtAge(3 * 3600), "3h");
+  assert.equal(fmtAge(6 * 86400), "6d");
+});
+
+test("fmtTime: m:ss and h:mm:ss", () => {
+  assert.equal(fmtTime(65), "1:05");
+  assert.equal(fmtTime(3661), "1:01:01");
+});
+
+test("sparkline: scales bins across the block ramp; empty flat", () => {
+  assert.equal(sparkline([]), "");
+  assert.equal(sparkline([0, 0, 0]), "▁▁▁");
+  const s = sparkline([0, 4, 8]);
+  assert.equal(s.length, 3);
+  assert.equal(s[0], "▁");
+  assert.equal(s[2], "█");
+});
+
+test("chip: tone class + escaping", () => {
+  assert.equal(chip("OK"), '<span class="chip">OK</span>');
+  assert.equal(chip("HOT", "amber"), '<span class="chip amber">HOT</span>');
+  assert.match(chip("<x>"), /&lt;x&gt;/);
+});
+
+test("coverageBadges: lit letters for present modalities", () => {
+  const b = coverageBadges({ watch: true, face: true });
+  assert.match(b, /<b class="on">W<\/b>/);
+  assert.match(b, /<b class="">L<\/b>/);
+  assert.match(b, /<b class="on">F<\/b>/);
+});

--- a/test/unit/doc-references.test.ts
+++ b/test/unit/doc-references.test.ts
@@ -23,6 +23,7 @@ const DOC_FILES = [
   "docs/providers.md",
   "prompts/ask.md",
   "prompts/brief.md",
+  "prompts/debrief.md",
   "examples/profiles/install-profiles.sh",
 ].map((f) => join(ROOT, f));
 

--- a/test/unit/note.test.ts
+++ b/test/unit/note.test.ts
@@ -129,7 +129,8 @@ test("note records are searchable and included in briefs", async () => {
 
     const [brief] = await briefVerb.run(ctx(dir, ""));
     const report = (brief.payload as Record<string, unknown>).report as string;
+    // the note surfaces in the (short-mode) record trail as a note-verb row
     assert.match(report, /Human observation: driver switches jackets/);
-    assert.match(report, /`note`/);
+    assert.match(report, /\*\*note\*\*/);
   });
 });

--- a/test/unit/osint-verbs.test.ts
+++ b/test/unit/osint-verbs.test.ts
@@ -11,7 +11,7 @@ import { scanVerb, captureVerb, monitorVerb } from "../../src/verbs/osint.ts";
 import { exitCodeForRecords } from "../../src/cli.ts";
 import { addSource } from "../../src/state/source.ts";
 import { saveSeen } from "../../src/state/seen.ts";
-import { addTarget } from "../../src/state/target.ts";
+import { addTarget, setTargetStatus } from "../../src/state/target.ts";
 import { addIndex, addMember } from "../../src/state/index.ts";
 import { emptySetup, saveSetup } from "../../src/state/setup.ts";
 import { FFMPEG_PATH } from "../../src/media/ffmpeg.ts";
@@ -98,6 +98,36 @@ test("scan falls back to local case media and face index when no sources exist",
     assert.deepEqual((summary.payload as Record<string, unknown>).media, [video]);
     assert.match(JSON.stringify((summary.payload as Record<string, unknown>).suggested_commands), /face --match/);
     assert.equal(recs.some((r) => r.verb === "face" && (r.payload as Record<string, unknown>).op === "search"), true);
+  } finally {
+    if (prev === undefined) delete process.env.OVERCAST_TINYCLOUD_CMD;
+    else process.env.OVERCAST_TINYCLOUD_CMD = prev;
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("scan --local skips CLOSED image lines (no match candidates / suggestions)", async () => {
+  const d = mkdtempSync(join(tmpdir(), "oc-localscan-closed-"));
+  const prev = process.env.OVERCAST_TINYCLOUD_CMD;
+  try {
+    const c = openCase(d);
+    c.ensure();
+    const img = join(d, "face.jpg");
+    const video = join(d, "clip.mp4");
+    writeFileSync(img, "fake image");
+    writeFileSync(video, "fake video");
+    const t = addTarget(c, img, { image: true });
+    addIndex(c, { id: "idx_face", name: "faces", type: "face-analysis" });
+    addMember(c, "idx_face", { ref: video });
+    process.env.OVERCAST_TINYCLOUD_CMD = `bash ${FAKE_TINYCLOUD}`;
+    // dead-end the only image line — it must stop auto-producing match work
+    setTargetStatus(c, t.id, "dead-end", "no hits");
+
+    const recs = await scanVerb.run({ input: undefined, rest: [], opts: {}, case: c, profile: defaultProfile() });
+    const summary = recs.find((r) => r.verb === "scan")!;
+    assert.equal((summary.payload as Record<string, unknown>).op, "local");
+    // no face --match suggestion and no auto face search against a closed line
+    assert.doesNotMatch(JSON.stringify((summary.payload as Record<string, unknown>).suggested_commands), /face --match/);
+    assert.equal(recs.some((r) => r.verb === "face"), false);
   } finally {
     if (prev === undefined) delete process.env.OVERCAST_TINYCLOUD_CMD;
     else process.env.OVERCAST_TINYCLOUD_CMD = prev;

--- a/test/unit/pulse.test.ts
+++ b/test/unit/pulse.test.ts
@@ -52,6 +52,20 @@ test("casePulse: coverage funnel joins source → hits → captures → sensed",
   assert.equal(pulse.media.unsensed, 0);
 });
 
+test("casePulse: per-source freshness uses the source's OWN hits, not the platform", () => {
+  // two X sources scanned at different times must not share a freshness age
+  const a = source({ id: "src_a", type: "x", ref: "@old" });
+  const b = source({ id: "src_b", type: "x", ref: "@new" });
+  const hitOld = makeRecord({ verb: "scan", format: "json", payload: { source: "x", source_id: "src_a", url: "http://x/old" }, meta: { time: iso(5 * HOUR) } });
+  const hitNew = makeRecord({ verb: "scan", format: "json", payload: { source: "x", source_id: "src_b", url: "http://x/new" }, meta: { time: iso(1 * HOUR) } });
+  const pulse = casePulse({ records: [hitOld, hitNew], targets: [], sources: [a, b], now: NOW });
+  const covA = pulse.coverage.find((c) => c.id === "src_a")!;
+  const covB = pulse.coverage.find((c) => c.id === "src_b")!;
+  assert.equal(Math.round(covA.lastScanAgeSeconds!), (5 * HOUR) / 1000);
+  assert.equal(Math.round(covB.lastScanAgeSeconds!), (1 * HOUR) / 1000);
+  assert.notEqual(covA.lastScanAgeSeconds, covB.lastScanAgeSeconds);
+});
+
 test("casePulse: enabled-but-never-scanned source is a coverage gap", () => {
   const src = source({ id: "src_b", type: "x", ref: "@h" });
   const pulse = casePulse({ records: [], targets: [], sources: [src], now: NOW });

--- a/test/unit/pulse.test.ts
+++ b/test/unit/pulse.test.ts
@@ -78,6 +78,19 @@ test("casePulse: coverage counts scan hits lacking source_id via platform-type f
   assert.equal(Math.round(cov.lastScanAgeSeconds!), HOUR / 1000);
 });
 
+test("casePulse: an unstamped hit is NOT attributed when the type has multiple sources", () => {
+  // two web sources: an unstamped web hit is ambiguous, so it must attribute to
+  // neither (attributing to both would double-count + falsely clear gaps)
+  const a = source({ id: "src_a", type: "web", ref: "q1" });
+  const b = source({ id: "src_b", type: "web", ref: "q2" });
+  const unstamped = makeRecord({ verb: "scan", format: "json", payload: { source: "web", url: "http://x/1" }, meta: { time: iso(HOUR) } });
+  const pulse = casePulse({ records: [unstamped], targets: [], sources: [a, b], now: NOW });
+  assert.equal(pulse.coverage.find((c) => c.id === "src_a")!.hits, 0);
+  assert.equal(pulse.coverage.find((c) => c.id === "src_b")!.hits, 0);
+  // both remain gaps (neither can claim the ambiguous hit)
+  assert.ok(pulse.coverage.every((c) => c.gap));
+});
+
 test("casePulse: enabled-but-never-scanned source is a coverage gap", () => {
   const src = source({ id: "src_b", type: "x", ref: "@h" });
   const pulse = casePulse({ records: [], targets: [], sources: [src], now: NOW });

--- a/test/unit/pulse.test.ts
+++ b/test/unit/pulse.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeRecord, type OvercastRecord } from "../../src/record.ts";
+import { casePulse, triageCounts, sourceScanFreshness } from "../../src/signals/pulse.ts";
+import type { TargetEntry } from "../../src/state/target.ts";
+import type { SourceEntry } from "../../src/state/source.ts";
+
+const NOW = Date.parse("2026-07-02T00:00:00Z");
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+const HOUR = 3600_000;
+
+function source(over: Partial<SourceEntry> & { id: string }): SourceEntry {
+  return { type: "web", ref: "q", enabled: true, created: "2026-07-01T00:00:00Z", ...over };
+}
+
+test("sourceScanFreshness: newest ready scan per source, pull_progress + failures excluded", () => {
+  const records: OvercastRecord[] = [
+    makeRecord({ verb: "scan", format: "json", payload: { source: "web", url: "u1" }, meta: { time: iso(5 * HOUR) } }),
+    makeRecord({ verb: "scan", format: "json", payload: { source: "web", url: "u2" }, meta: { time: iso(1 * HOUR) } }),
+    makeRecord({ verb: "scan", format: "json", payload: { source: "web", op: "pull_progress" }, meta: { time: iso(1000) } }),
+    makeRecord({ verb: "scan", format: "json", payload: { source: "youtube" }, error: "boom", state: "error", meta: { time: iso(1000) } }),
+  ];
+  const fresh = sourceScanFreshness(records, NOW);
+  assert.equal(fresh.length, 1);
+  assert.equal(fresh[0].source, "web");
+  assert.equal(Math.round(fresh[0].ageSeconds), HOUR / 1000);
+});
+
+test("triageCounts: buckets by effective status", () => {
+  const open = makeRecord({ verb: "finding", format: "json", payload: { text: "a", target: "", source_record: "x", source_verb: "watch", trigger: "human", status: "open" } });
+  const suggested = makeRecord({ verb: "finding", format: "json", payload: { text: "b", target: "", source_record: "y", source_verb: "face", trigger: "signal:face-match", status: "suggested" } });
+  const accept = makeRecord({ verb: "finding", format: "json", payload: { finding_id: suggested.id, status: "accepted", reviewed_at: iso(0) } });
+  const t = triageCounts([open, suggested, accept]);
+  assert.equal(t.open, 1);
+  assert.equal(t.accepted, 1);
+  assert.equal(t.suggested, 0); // promoted
+});
+
+test("casePulse: coverage funnel joins source → hits → captures → sensed", () => {
+  const src = source({ id: "src_a", type: "web", ref: "pier" });
+  const hit = makeRecord({ verb: "scan", format: "json", payload: { source: "web", source_id: "src_a", url: "http://x/1" }, meta: { time: iso(2 * HOUR) } });
+  const cap = makeRecord({ verb: "capture", format: "json", payload: { path: "c.mp4", source_record: hit.id }, media: { ref: "c.mp4" }, meta: { time: iso(1 * HOUR) } });
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "scene" }, media: { ref: "c.mp4" }, meta: { time: iso(30 * 60 * 1000) } });
+  const pulse = casePulse({ records: [hit, cap, watch], targets: [], sources: [src], now: NOW });
+  const cov = pulse.coverage[0];
+  assert.equal(cov.hits, 1);
+  assert.equal(cov.captured, 1);
+  assert.equal(cov.sensed, 1);
+  assert.equal(cov.gap, false);
+  assert.equal(pulse.media.captured, 1);
+  assert.equal(pulse.media.sensed, 1);
+  assert.equal(pulse.media.unsensed, 0);
+});
+
+test("casePulse: enabled-but-never-scanned source is a coverage gap", () => {
+  const src = source({ id: "src_b", type: "x", ref: "@h" });
+  const pulse = casePulse({ records: [], targets: [], sources: [src], now: NOW });
+  assert.equal(pulse.coverage[0].gap, true);
+  assert.ok(pulse.gaps.some((g) => g.includes("x:@h enabled but never scanned")));
+});
+
+test("casePulse: unsensed captures surface as a backlog gap", () => {
+  const cap = makeRecord({ verb: "capture", format: "json", payload: { path: "c.mp4" }, media: { ref: "c.mp4" }, meta: { time: iso(HOUR) } });
+  const pulse = casePulse({ records: [cap], targets: [], sources: [], now: NOW });
+  assert.equal(pulse.media.unsensed, 1);
+  assert.ok(pulse.gaps.some((g) => /1 capture pulled but never sensed/.test(g)));
+});
+
+test("casePulse: progress + headline reflect targets and triage", () => {
+  const targets: TargetEntry[] = [
+    { id: "tgt_a", kind: "name", value: "acme", created: iso(0) },
+    { id: "tgt_b", kind: "name", value: "beta", created: iso(0), status: "answered" },
+  ];
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme spotted" }, media: { ref: "v.mp4" }, meta: { time: iso(HOUR) } });
+  const suggested = makeRecord({ verb: "finding", format: "json", payload: { text: "lead", target: "acme", target_id: "tgt_a", source_record: "x", source_verb: "face", trigger: "signal:face-match", status: "suggested" }, meta: { time: iso(HOUR) } });
+  const pulse = casePulse({ records: [watch, suggested], targets, sources: [], now: NOW });
+  assert.equal(pulse.progress.targets_total, 2);
+  assert.equal(pulse.progress.targets_open, 1);
+  assert.equal(pulse.progress.targets_answered, 1);
+  assert.equal(pulse.progress.triage_pending, 1);
+  assert.match(pulse.headline, /1 line active/);
+  assert.match(pulse.headline, /1 answered/);
+  assert.match(pulse.headline, /1 suggestion awaiting triage/);
+});

--- a/test/unit/pulse.test.ts
+++ b/test/unit/pulse.test.ts
@@ -66,6 +66,18 @@ test("casePulse: per-source freshness uses the source's OWN hits, not the platfo
   assert.notEqual(covA.lastScanAgeSeconds, covB.lastScanAgeSeconds);
 });
 
+test("casePulse: coverage counts scan hits lacking source_id via platform-type fallback", () => {
+  // a legacy/adhoc hit with no source_id must still attribute to its platform's
+  // enabled source — not read as "never scanned"
+  const src = source({ id: "src_w", type: "web", ref: "pier" });
+  const unstamped = makeRecord({ verb: "scan", format: "json", payload: { source: "web", url: "http://x/1" }, meta: { time: iso(HOUR) } });
+  const pulse = casePulse({ records: [unstamped], targets: [], sources: [src], now: NOW });
+  const cov = pulse.coverage[0];
+  assert.equal(cov.hits, 1);
+  assert.equal(cov.gap, false);
+  assert.equal(Math.round(cov.lastScanAgeSeconds!), HOUR / 1000);
+});
+
 test("casePulse: enabled-but-never-scanned source is a coverage gap", () => {
   const src = source({ id: "src_b", type: "x", ref: "@h" });
   const pulse = casePulse({ records: [], targets: [], sources: [src], now: NOW });

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -7,6 +7,7 @@ import { openCase } from "../../src/case.ts";
 import { defaultProfile } from "../../src/profile.ts";
 import { makeRecord } from "../../src/record.ts";
 import { makeFinding } from "../../src/verbs/finding.ts";
+import { addTarget } from "../../src/state/target.ts";
 import { LocalMemoryProvider, recordText } from "../../src/providers/memory/local.ts";
 import { resolveMemory, fanOutAnswer } from "../../src/providers/memory/index.ts";
 import { QmdMemoryProvider, DEFAULT_QMD_MODEL } from "../../src/providers/memory/qmd.ts";
@@ -765,11 +766,13 @@ test("brief synthesis: TL;DR note, sources-checked rollup, and findings surface 
     // markdown: newest tldr note wins, verdict line, rollup, and finding row
     assert.match(report, /## TL;DR/);
     assert.match(report, /SWEEP_NARRATIVE: checked x \+ youtube/);
-    assert.ok(!/old narrative/.test(report.split("## Sources checked")[0]), "older tldr note must not head the brief");
+    // the newest tldr note heads the brief; the older one must not (it may still
+    // appear later as an ordinary note in the record trail — it IS evidence)
+    assert.ok(!/old narrative/.test(report.split("## Key findings")[0]), "older tldr note must not head the brief");
     assert.match(report, /2 sources checked \(3 hits\), 1 media check — 1 finding recorded/);
     assert.match(report, /- \*\*x\*\* — 2 hits/);
     assert.match(report, /- \*\*youtube\*\* — 1 hit/);
-    assert.match(report, /## Matches & findings/);
+    assert.match(report, /## Key findings/);
     assert.match(report, /\[open\] \(confidence: high\) copycat: reskin by @codez/);
     // the finding's overlay (from its cited image-match record) is embedded in md
     assert.match(report, /!\[match overlay\]\(.*match_draw_orig65\.png\)/);
@@ -809,7 +812,7 @@ test("brief synthesis: a clean sweep says so explicitly (checked, found none)", 
     const [rec] = await briefVerb.run({ input: undefined, rest: [], opts: {}, case: c, profile: defaultProfile() });
     const report = (rec.payload as Record<string, unknown>).report as string;
     assert.match(report, /1 source checked \(1 hit\) — no findings recorded/);
-    assert.match(report, /## Matches & findings\n\n- none recorded/);
+    assert.match(report, /## Key findings\n\n- none recorded/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -925,17 +928,41 @@ test("brief on an empty evidence set is transient and does not export", async ()
   }
 });
 
-test("brief embeds the FULL primary field, not a 160-char stub", async () => {
+test("brief --full embeds the FULL primary field; short stubs it", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-brieffull-"));
   try {
     const c = openCase(dir); c.ensure();
     // a marker only reachable if the field is NOT truncated at ~160 chars
     const content = "lead ".repeat(60) + "DEEP_TAIL_MARKER";
     c.writeRecord(makeRecord({ verb: "watch", payload: { content }, media: { ref: "v.mp4" } }));
+    assert.ok(content.length > 200, "fixture should exceed the old 160-char cap");
+    // --full: the whole field is embedded verbatim under the audit timeline
+    const [full] = await briefVerb.run(ctx(c, undefined, { full: true }));
+    const fullReport = (full.payload as Record<string, unknown>).report as string;
+    assert.match(fullReport, /## Timeline \/ findings/);
+    assert.match(fullReport, /DEEP_TAIL_MARKER/);
+    // short (default): the record trail stubs the field, tail marker not present
+    const [short] = await briefVerb.run(ctx(c, undefined, {}));
+    const shortReport = (short.payload as Record<string, unknown>).report as string;
+    assert.match(shortReport, /## Record trail/);
+    assert.doesNotMatch(shortReport, /DEEP_TAIL_MARKER/);
+    assert.doesNotMatch(shortReport, /## Timeline \/ findings/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("brief short mode leads with the story: threads, and a compact record trail", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-briefshort-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    addTarget(c, "acme");
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "acme spotted at the pier" }, media: { ref: "v.mp4" }, meta: { time: "2026-06-20T10:00:00Z" } }));
     const [rec] = await briefVerb.run(ctx(c, undefined, {}));
     const report = (rec.payload as Record<string, unknown>).report as string;
-    assert.ok(content.length > 200, "fixture should exceed the old 160-char cap");
-    assert.match(report, /DEEP_TAIL_MARKER/); // full content embedded
+    assert.match(report, /## Lines of investigation/);
+    assert.match(report, /\*\*acme\*\* — \[COLLECTING\]/);
+    assert.match(report, /## Coverage/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -988,7 +1015,7 @@ test("brief html export does not reparse embedded content as markup", async () =
     const c = openCase(dir); c.ensure();
     c.writeRecord(makeRecord({ verb: "watch", payload: { content: "intro line\n### Scene 5 heading\n- bullet inside content" }, media: { ref: "v.mp4" } }));
     const htmlPath = join(dir, "b.html");
-    await briefVerb.run(ctx(c, undefined, { export: htmlPath }));
+    await briefVerb.run(ctx(c, undefined, { export: htmlPath, full: true }));
     const html = readFileSync(htmlPath, "utf8");
     assert.doesNotMatch(html, /<h3>Scene 5 heading<\/h3>/); // embedded line NOT a heading
     assert.match(html, /### Scene 5 heading/); // present as escaped literal text

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -1014,6 +1014,35 @@ test("brief --scope with an empty window still renders + exports (active case ha
   }
 });
 
+test("brief CSI export ranks + caps Key findings like the markdown (accepted first, max 8)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-briefrank-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    // 10 open findings + 1 accepted (created earliest, so chronological order
+    // would bury it) — ranking must float the accepted one to the top and cap 8
+    const acc = makeRecord({ verb: "finding", payload: { text: "ACCEPTED_LEAD", status: "open", source_record: "manual", source_verb: "manual", trigger: "human" }, meta: { time: "2020-01-01T00:00:00Z" }, state: "ready" });
+    c.writeRecord(acc);
+    c.writeRecord(makeRecord({ verb: "finding", payload: { finding_id: acc.id, status: "accepted", reviewed_at: "2020-01-02T00:00:00Z" }, state: "ready" }));
+    for (let i = 0; i < 10; i++) {
+      c.writeRecord(makeRecord({ verb: "finding", payload: { text: `open finding ${i}`, status: "open", source_record: "manual", source_verb: "manual", trigger: "human" }, meta: { time: `2026-07-0${(i % 9) + 1}T00:00:00Z` }, state: "ready" }));
+    }
+    const html = join(dir, "b.html");
+    const [rec] = await briefVerb.run(ctx(c, undefined, { export: html, theme: "csi" }));
+    const out = readFileSync(html, "utf8");
+    // the accepted finding is present (ranked to the top), and the panel is capped
+    assert.match(out, /ACCEPTED_LEAD/);
+    assert.match(out, /\[accepted\]/);
+    // exactly 8 finding rows in the Key-findings panel (cap), not all 11
+    const panel = out.split('class="findings"')[1]?.split("</ul>")[0] ?? "";
+    assert.equal((panel.match(/<li>/g) || []).length, 8, "CSI Key-findings panel capped at 8");
+    // markdown (same record payload) also caps at 8 + floats accepted first
+    const md = (rec.payload as Record<string, unknown>).report as string;
+    assert.ok(md.indexOf("ACCEPTED_LEAD") < md.indexOf("open finding"), "accepted floats above open in md too");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("brief coverage shows sub-hour freshness via shared fmtAge (not '0h')", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-briefage-"));
   try {

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -994,6 +994,26 @@ test("brief --scope: finding status resolves case-wide (accept row outside the w
   }
 });
 
+test("brief --scope with an empty window still renders + exports (active case has a body)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-scopeexport-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    addTarget(c, "acme");
+    // all evidence is OLD (out of the since-window); the case is still active
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "acme at pier" }, media: { ref: "old.mp4" }, meta: { time: "2020-01-01T00:00:00Z" } }));
+    const out = join(dir, "scoped.html");
+    const [rec] = await briefVerb.run(ctx(c, "since:2026-01-01", { export: out, theme: "csi" }));
+    const payload = rec.payload as Record<string, unknown>;
+    // NOT pending: an active case with a pulse body must export despite 0 in-window evidence
+    assert.equal(rec.state, "ready");
+    assert.equal(payload.export, out);
+    assert.equal(existsSync(out), true);
+    assert.match(readFileSync(out, "utf8"), /Lines of investigation/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("brief coverage shows sub-hour freshness via shared fmtAge (not '0h')", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-briefage-"));
   try {

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -952,6 +952,29 @@ test("brief --full embeds the FULL primary field; short stubs it", async () => {
   }
 });
 
+test("brief --scope: pulse (threads/coverage/triage) reflects the FULL case, not the scoped window", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-briefscope-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    addTarget(c, "acme");
+    // old (out-of-scope) evidence linking the target + an old suggested lead
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "acme at the pier" }, media: { ref: "old.mp4" }, meta: { time: "2020-01-01T00:00:00Z" } }));
+    c.writeRecord(makeRecord({ verb: "finding", payload: { text: "old lead", target: "acme", target_id: "x", source_record: "y", source_verb: "face", trigger: "signal:face-match", status: "suggested" }, meta: { time: "2020-01-01T00:00:00Z" } }));
+    // a recent in-scope record so the scoped brief still renders
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "fresh note" }, media: { ref: "n.txt" }, meta: { time: "2026-07-03T00:00:00Z" } }));
+    const [rec] = await briefVerb.run(ctx(c, "since:2026-07-01", {}));
+    const report = (rec.payload as Record<string, unknown>).report as string;
+    // the thread must read LEADS (the out-of-scope suggested finding links it),
+    // not COLD, despite the --scope window excluding those records from the body
+    assert.match(report, /\*\*acme\*\* — \[LEADS\]/);
+    assert.match(report, /1 line active \(1 with leads\)/);
+    // the old suggested lead must still appear in the case-wide triage backlog
+    assert.match(report, /## Triage — 1 suggestion awaiting review/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("brief short mode leads with the story: threads, and a compact record trail", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-briefshort-"));
   try {

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -976,6 +976,24 @@ test("brief --scope: pulse (threads/coverage/triage) reflects the FULL case, not
   }
 });
 
+test("brief --scope: finding status resolves case-wide (accept row outside the window still shows [accepted])", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-scopestatus-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    // an undated root finding (kept in any since-scope) accepted by a review row
+    // dated BEFORE the scope cutoff (so it's dropped from the scoped record set)
+    const finding = makeRecord({ verb: "finding", payload: { text: "copycat by @codez", status: "open", source_record: "manual", source_verb: "manual", trigger: "human" }, state: "ready" });
+    c.writeRecord(finding);
+    c.writeRecord(makeRecord({ verb: "finding", payload: { finding_id: finding.id, status: "accepted", reviewed_at: "2020-01-01T00:00:00Z" }, meta: { time: "2020-01-01T00:00:00Z" }, state: "ready" }));
+    const [rec] = await briefVerb.run(ctx(c, "since:2026-01-01", {}));
+    const report = (rec.payload as Record<string, unknown>).report as string;
+    assert.match(report, /\[accepted\][^\n]*copycat by @codez/);
+    assert.doesNotMatch(report, /\[open\][^\n]*copycat by @codez/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("brief coverage shows sub-hour freshness via shared fmtAge (not '0h')", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-briefage-"));
   try {

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -8,6 +8,7 @@ import { defaultProfile } from "../../src/profile.ts";
 import { makeRecord } from "../../src/record.ts";
 import { makeFinding } from "../../src/verbs/finding.ts";
 import { addTarget } from "../../src/state/target.ts";
+import { addSource, listSources } from "../../src/state/source.ts";
 import { LocalMemoryProvider, recordText } from "../../src/providers/memory/local.ts";
 import { resolveMemory, fanOutAnswer } from "../../src/providers/memory/index.ts";
 import { QmdMemoryProvider, DEFAULT_QMD_MODEL } from "../../src/providers/memory/qmd.ts";
@@ -970,6 +971,24 @@ test("brief --scope: pulse (threads/coverage/triage) reflects the FULL case, not
     assert.match(report, /1 line active \(1 with leads\)/);
     // the old suggested lead must still appear in the case-wide triage backlog
     assert.match(report, /## Triage — 1 suggestion awaiting review/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("brief coverage shows sub-hour freshness via shared fmtAge (not '0h')", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-briefage-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    addSource(c, "web:pier");
+    const src = listSources(c)[0];
+    // a scan hit ~10 minutes ago — must read "10m", never "0h"
+    const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    c.writeRecord(makeRecord({ verb: "scan", payload: { source: "web", source_id: src.id, url: "http://x/1" }, meta: { time: tenMinAgo } }));
+    const [rec] = await briefVerb.run(ctx(c, undefined, {}));
+    const report = (rec.payload as Record<string, unknown>).report as string;
+    assert.match(report, /last scan \d+m/);
+    assert.doesNotMatch(report, /last scan 0h/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/rollup.test.ts
+++ b/test/unit/rollup.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeRecord, type OvercastRecord } from "../../src/record.ts";
+import { groupTimeline, groupSummary } from "../../src/signals/rollup.ts";
+
+test("groupTimeline: records on the same media.ref collapse into one artifact group", () => {
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "x" }, media: { ref: "clip.mp4" }, meta: { time: "2026-06-20T10:00:00Z" } });
+  const listen = makeRecord({ verb: "listen", format: "json", payload: { transcript: "y" }, media: { ref: "clip.mp4" }, meta: { time: "2026-06-20T10:01:00Z" } });
+  const face = makeRecord({ verb: "face", format: "json", payload: { op: "match" }, media: { ref: "clip.mp4" }, meta: { time: "2026-06-20T10:02:00Z" } });
+  const groups = groupTimeline([watch, listen, face]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].kind, "artifact");
+  assert.equal(groups[0].title, "clip.mp4");
+  assert.deepEqual(groups[0].counts, { watch: 1, listen: 1, face: 1 });
+  assert.equal(groups[0].time, "2026-06-20T10:02:00.000Z");
+});
+
+test("groupTimeline: a child citing a parent by source_record folds into the parent artifact", () => {
+  const face = makeRecord({ verb: "face", format: "json", payload: { op: "match" }, media: { ref: "clip.mp4" }, meta: { time: "2026-06-20T10:00:00Z" } });
+  // a crop record has no media.ref of its own but cites the face record
+  const crop = makeRecord({ verb: "crop", format: "json", payload: { source_record: face.id }, meta: { time: "2026-06-20T10:03:00Z" } });
+  const groups = groupTimeline([face, crop]);
+  assert.equal(groups.length, 1);
+  assert.deepEqual(groups[0].counts, { face: 1, crop: 1 });
+});
+
+test("groupTimeline: meta.run wins — a whole sweep collapses to one group", () => {
+  const a = makeRecord({ verb: "scan", format: "json", payload: { url: "u1" }, media: { ref: "a.mp4" }, meta: { time: "2026-06-20T10:00:00Z", run: "run_abc" } });
+  const b = makeRecord({ verb: "watch", format: "json", payload: { content: "z" }, media: { ref: "b.mp4" }, meta: { time: "2026-06-20T10:01:00Z", run: "run_abc" } });
+  const groups = groupTimeline([a, b]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].kind, "sweep");
+  assert.match(groups[0].title, /^sweep run_abc/);
+});
+
+test("groupTimeline: refless unrelated records stay singletons; order preserved", () => {
+  const n1 = makeRecord({ verb: "note", format: "json", payload: { text: "a" }, meta: { time: "2026-06-20T10:00:00Z" } });
+  const n2 = makeRecord({ verb: "note", format: "json", payload: { text: "b" }, meta: { time: "2026-06-20T10:01:00Z" } });
+  const groups = groupTimeline([n1, n2]);
+  assert.equal(groups.length, 2);
+  assert.ok(groups.every((g) => g.kind === "record"));
+  assert.deepEqual(groups.map((g) => g.recordIds[0]), [n1.id, n2.id]);
+});
+
+test("groupSummary: verb ×n formatting", () => {
+  const g = { key: "ref:x", kind: "artifact" as const, title: "x", counts: { watch: 1, crop: 3 }, recordIds: [] };
+  assert.equal(groupSummary(g), "crop ×3, watch");
+});

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -465,9 +465,11 @@ test("case status counts similar records as evidence (#B6-1)", async () => {
       state: "ready",
     }));
     const [status] = await caseVerb.run(mk(dir, "status"));
-    const tldr = (status.payload as Record<string, unknown>).tldr as Record<string, unknown>;
+    const payload = status.payload as Record<string, unknown>;
+    const tldr = payload.tldr as Record<string, unknown>;
     const findings = (tldr.findings as string[]).join("\n");
-    assert.match(findings, /Evidence present:.*similar 1/, "similar counted in the evidence summary");
+    // similar is evidence: it counts in the store and surfaces in recent evidence
+    assert.equal((payload.store as { counts: Record<string, number> }).counts.similar, 1, "similar counted in the store");
     assert.match(findings, /similar: 2 semantic matches/, "similar record surfaces in recent evidence");
   });
 });

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openCase } from "../../src/case.ts";
+import { makeRecord, type OvercastRecord } from "../../src/record.ts";
+import { buildThreads, threadsHeadline } from "../../src/signals/threads.ts";
+import { addTarget, listTargets, setTargetStatus, primaryTarget, isTargetClosed } from "../../src/state/target.ts";
+import { targetVerb } from "../../src/verbs/osint.ts";
+import type { TargetEntry } from "../../src/state/target.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+const NOW = Date.parse("2026-07-02T00:00:00Z");
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+function target(over: Partial<TargetEntry> & { id: string; value: string }): TargetEntry {
+  return { kind: "name", created: "2026-07-01T00:00:00Z", ...over } as TargetEntry;
+}
+
+test("buildThreads: stage ladder from cold → collecting → leads → corroborated", () => {
+  const t = target({ id: "tgt_a", value: "acme" });
+  // cold
+  assert.equal(buildThreads([], [t], NOW)[0].stage, "cold");
+  // collecting: an evidence record mentions the target
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme spotted at pier" }, media: { ref: "v.mp4" }, meta: { time: iso(3600_000) } });
+  assert.equal(buildThreads([watch], [t], NOW)[0].stage, "collecting");
+  // leads: an open finding on the target
+  const open = makeRecord({ verb: "finding", format: "json", payload: { text: "lead", target: "acme", source_record: watch.id, source_verb: "watch", trigger: "human", status: "open" }, meta: { time: iso(1800_000) } });
+  assert.equal(buildThreads([watch, open], [t], NOW)[0].stage, "leads");
+  // corroborated: an accepted finding (via review record)
+  const accept = makeRecord({ verb: "finding", format: "json", payload: { finding_id: open.id, status: "accepted", reviewed_at: iso(900_000) } });
+  assert.equal(buildThreads([watch, open, accept], [t], NOW)[0].stage, "corroborated");
+});
+
+test("buildThreads: declared status wins over evidence stage", () => {
+  const t = target({ id: "tgt_a", value: "acme", status: "dead-end", status_note: "handle deleted" });
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme" }, media: { ref: "v.mp4" } });
+  const th = buildThreads([watch], [t], NOW)[0];
+  assert.equal(th.stage, "dead-end");
+  assert.equal(th.status, "dead-end");
+  assert.equal(th.why, "handle deleted");
+});
+
+test("buildThreads: image targets link via reference-path match, not text", () => {
+  const t = target({ id: "tgt_img", value: "refs/probe.jpg", kind: "image" });
+  const faceHit = makeRecord({ verb: "face", format: "json", payload: { op: "match", reference: "refs/probe.jpg", faces: [{ at: 5, similarity: 88 }], count: 1 }, media: { ref: "clip.mp4" }, meta: { time: iso(1000) } });
+  const unrelated = makeRecord({ verb: "watch", format: "json", payload: { content: "mentions probe.jpg in text" }, media: { ref: "x.mp4" } });
+  const th = buildThreads([faceHit, unrelated], [t], NOW)[0];
+  assert.equal(th.funnel.matches, 1);
+  assert.equal(th.stage, "collecting");
+  // the text-only watch must NOT link to an image target
+  assert.equal(th.evidence.watch, undefined);
+});
+
+test("buildThreads: finding counts, funnel, and momentum", () => {
+  const t = target({ id: "tgt_a", value: "acme" });
+  const records: OvercastRecord[] = [
+    makeRecord({ verb: "scan", format: "json", payload: { source: "web", url: "http://x/1", title: "acme post" }, meta: { time: iso(6 * 24 * 3600_000) } }),
+    makeRecord({ verb: "capture", format: "json", payload: { text: "acme capture" }, media: { ref: "c.mp4" }, meta: { time: iso(2 * 24 * 3600_000) } }),
+    makeRecord({ verb: "watch", format: "json", payload: { content: "acme in view" }, media: { ref: "c.mp4" }, meta: { time: iso(3600_000) } }),
+    makeRecord({ verb: "finding", format: "json", payload: { text: "s", target: "acme", source_record: "x", source_verb: "face", trigger: "signal:face-match", status: "suggested" }, meta: { time: iso(1800_000) } }),
+  ];
+  const th = buildThreads(records, [t], NOW)[0];
+  assert.equal(th.funnel.scan, 1);
+  assert.equal(th.funnel.captures, 1);
+  assert.equal(th.funnel.senses, 1);
+  assert.equal(th.findings.suggested, 1);
+  assert.equal(th.stage, "leads");
+  assert.equal(th.recent.day, 2); // watch + suggested finding within 24h
+  assert.equal(th.recent.week, 4);
+  assert.equal(th.activityBins.length, 8);
+  assert.ok(th.activityBins.reduce((a, b) => a + b, 0) === 4);
+});
+
+test("buildThreads: notes tagged thread:<id> link even without value match", () => {
+  const t = target({ id: "tgt_z", value: "acme" });
+  const note = makeRecord({ verb: "note", format: "json", payload: { text: "this line is cold", tags: ["thread:tgt_z"] }, meta: { time: iso(100) } });
+  const th = buildThreads([note], [t], NOW)[0];
+  assert.equal(th.evidence.note, 1);
+});
+
+test("threadsHeadline: honest progress sentence", () => {
+  const threads = [
+    { status: "active", stage: "leads" },
+    { status: "active", stage: "collecting" },
+    { status: "answered", stage: "answered" },
+    { status: "dead-end", stage: "dead-end" },
+  ] as Parameters<typeof threadsHeadline>[0];
+  const line = threadsHeadline(threads, 3);
+  assert.match(line, /2 lines active \(1 with leads\)/);
+  assert.match(line, /1 answered/);
+  assert.match(line, /1 dead-end/);
+  assert.match(line, /3 suggestions awaiting triage/);
+  assert.equal(threadsHeadline([], 0), "No lines of investigation yet");
+});
+
+// ---- target state persistence + verb ----
+
+function withCase(fn: (c: ReturnType<typeof openCase>) => void | Promise<void>) {
+  const dir = mkdtempSync(join(tmpdir(), "oc-threads-"));
+  const c = openCase(dir);
+  c.ensure();
+  return Promise.resolve(fn(c)).finally(() => rmSync(dir, { recursive: true, force: true }));
+}
+
+function ctxFor(c: ReturnType<typeof openCase>, input: string | undefined, rest: string[] = [], opts: Record<string, unknown> = {}): VerbContext {
+  return { input, rest, opts, case: c, profile: { name: "test", providers: {} }, profileName: "test" } as unknown as VerbContext;
+}
+
+test("setTargetStatus: close + reopen round-trips; primaryTarget skips closed", () =>
+  withCase((c) => {
+    const a = addTarget(c, "alpha");
+    const b = addTarget(c, "bravo");
+    assert.equal(primaryTarget(c)?.id, b.id);
+    setTargetStatus(c, b.id, "dead-end", "no hits");
+    assert.equal(primaryTarget(c)?.id, a.id); // skips the closed newest
+    assert.ok(isTargetClosed(listTargets(c).find((t) => t.id === b.id)!));
+    setTargetStatus(c, b.id, "active");
+    assert.equal(primaryTarget(c)?.id, b.id);
+    assert.equal(listTargets(c).find((t) => t.id === b.id)!.status, undefined);
+  }));
+
+test("target verb: add --question, close --as, reopen", () =>
+  withCase(async (c) => {
+    const add = await targetVerb.run(ctxFor(c, "add", ["mystery"], { question: "who runs it?" }));
+    const id = (add[0].payload as { id: string }).id;
+    assert.equal(listTargets(c)[0].question, "who runs it?");
+    const close = await targetVerb.run(ctxFor(c, "close", [id], { as: "answered", note: "identified" }));
+    assert.equal((close[0].payload as { status: string }).status, "answered");
+    assert.equal(listTargets(c)[0].status_note, "identified");
+    const reopen = await targetVerb.run(ctxFor(c, "reopen", [id]));
+    assert.equal((reopen[0].payload as { status?: string }).status, undefined);
+    // bad --as is a user error
+    const bad = await targetVerb.run(ctxFor(c, "close", [id], { as: "maybe" }));
+    assert.equal(bad[0].state, "error");
+  }));

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -129,6 +129,16 @@ test("setTargetStatus: close + reopen round-trips; primaryTarget skips closed", 
     assert.equal(listTargets(c).find((t) => t.id === b.id)!.status, undefined);
   }));
 
+test("primaryTarget: returns undefined when EVERY line is closed (no seeding dead lines)", () =>
+  withCase((c) => {
+    const a = addTarget(c, "alpha");
+    const b = addTarget(c, "bravo");
+    setTargetStatus(c, a.id, "answered");
+    setTargetStatus(c, b.id, "dead-end");
+    // all lines closed → no active target seeds a query-less scan
+    assert.equal(primaryTarget(c), undefined);
+  }));
+
 test("target verb: add --question, close --as, reopen", () =>
   withCase(async (c) => {
     const add = await targetVerb.run(ctxFor(c, "add", ["mystery"], { question: "who runs it?" }));

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -80,6 +80,14 @@ test("buildThreads: notes tagged thread:<id> link even without value match", () 
   assert.equal(th.evidence.note, 1);
 });
 
+test("buildThreads: newest thread:<id> note surfaces as the line narrative", () => {
+  const t = target({ id: "tgt_n", value: "acme" });
+  const older = makeRecord({ verb: "note", format: "json", payload: { text: "early read on this line", tags: ["thread:tgt_n"] }, meta: { time: iso(2 * 24 * 3600_000) } });
+  const newer = makeRecord({ verb: "note", format: "json", payload: { text: "reups traced to @codez; next: subpoena the reseller", tags: ["thread:tgt_n"] }, meta: { time: iso(3600_000) } });
+  const th = buildThreads([older, newer], [t], NOW)[0];
+  assert.equal(th.narrative, "reups traced to @codez; next: subpoena the reseller");
+});
+
 test("threadsHeadline: honest progress sentence", () => {
   const threads = [
     { status: "active", stage: "leads" },

--- a/test/unit/triggers.test.ts
+++ b/test/unit/triggers.test.ts
@@ -111,6 +111,16 @@ test("evaluateTriggers: text-target — suggested in suggest mode, legacy open i
   assert.equal((legacy[0].payload as Record<string, unknown>).trigger, "scan:watch");
 });
 
+test("evaluateTriggers: analyst notes do NOT self-suggest (only machine-analyzed content)", () => {
+  // a /debrief thread/tldr note routinely names the target — auto-suggesting a
+  // finding that cites the analyst's own note is triage noise, so notes are out
+  const note = makeRecord({ verb: "note", format: "json", payload: { text: "acme handle reups traced to @codez", tags: ["thread:tgt_a"] }, media: { ref: "n.txt" } });
+  assert.equal(evaluateTriggers({ fresh: [note], existing: [], targets: [nameTarget], policy: SUGGEST }).length, 0);
+  // the same phrase in a machine transcript still leads
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme handle reups traced to @codez" }, media: { ref: "v.mp4" } });
+  assert.equal(evaluateTriggers({ fresh: [watch], existing: [], targets: [nameTarget], policy: SUGGEST }).length, 1);
+});
+
 test("evaluateTriggers: text-target fires on content verbs, NOT scan hits or captures", () => {
   // a scan hit whose title mentions the target must NOT create a text lead —
   // otherwise the same item leads once from its hit and again from its watch

--- a/test/unit/triggers.test.ts
+++ b/test/unit/triggers.test.ts
@@ -131,6 +131,20 @@ test("evaluateTriggers: two senses on the same clip fold to one text lead (share
   assert.equal(evaluateTriggers({ fresh: [listen], existing: first, targets: [nameTarget], policy: SUGGEST }).length, 0);
 });
 
+test("evaluateTriggers: CLOSED lines accumulate no new suggestions (text + score)", () => {
+  const closedName: TargetEntry = { ...nameTarget, status: "dead-end" };
+  const closedImg: TargetEntry = { ...imageTarget, status: "answered" };
+  // text-target against a closed name line: no lead
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "the acme handle appears here" }, media: { ref: "v.mp4" } });
+  assert.equal(evaluateTriggers({ fresh: [watch], existing: [], targets: [closedName], policy: SUGGEST }).length, 0);
+  // score match whose reference IS a closed image line: still fires (the match is
+  // intrinsically interesting) but is NOT attributed to the dead line
+  const [f] = evaluateTriggers({ fresh: [faceMatch(90, { reference: imageTarget.value })], existing: [], targets: [closedImg], policy: SUGGEST });
+  assert.ok(f);
+  assert.equal((f.payload as Record<string, unknown>).target, "");
+  assert.equal((f.payload as Record<string, unknown>).target_id, undefined);
+});
+
 test("evaluateTriggers: mode off fires nothing; score triggers stay off in review mode", () => {
   assert.equal(evaluateTriggers({ fresh: [faceMatch(99)], existing: [], targets: [], policy: { mode: "off" } }).length, 0);
   assert.equal(evaluateTriggers({ fresh: [faceMatch(99)], existing: [], targets: [], policy: { mode: "review" } }).length, 0);

--- a/test/unit/triggers.test.ts
+++ b/test/unit/triggers.test.ts
@@ -1,0 +1,239 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openCase } from "../../src/case.ts";
+import { makeRecord, memoryRecords, type OvercastRecord } from "../../src/record.ts";
+import { evaluateTriggers, extractSignal, resolveFindingsPolicy, DEFAULT_TRIGGER_THRESHOLDS } from "../../src/signals/triggers.ts";
+import { persistRecords } from "../../src/registry/persist.ts";
+import { findingVerb } from "../../src/verbs/finding.ts";
+import { emptySetup, saveSetup, loadSetup } from "../../src/state/setup.ts";
+import { addTarget } from "../../src/state/target.ts";
+import type { TargetEntry } from "../../src/state/target.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+const T = DEFAULT_TRIGGER_THRESHOLDS;
+
+function faceMatch(similarity: number, opts: { ref?: string; at?: number; reference?: string } = {}): OvercastRecord {
+  return makeRecord({
+    verb: "face",
+    format: "json",
+    payload: {
+      op: "match",
+      reference: opts.reference ?? "probe.jpg",
+      faces: [{ at: opts.at ?? 41, similarity }, { at: 3, similarity: Math.max(0, similarity - 20) }],
+      count: 2,
+    },
+    media: { ref: opts.ref ?? "clip.mp4", at: 0 },
+  });
+}
+
+function imageMatch(inliers: number): OvercastRecord {
+  return makeRecord({
+    verb: "image",
+    format: "json",
+    payload: { op: "match", matches: [{ ref: "db.jpg", num_inliers: inliers, at: 12 }], count: 1 },
+    media: { ref: "probe.mp4" },
+  });
+}
+
+function similarMatch(similarity: number, op = "match"): OvercastRecord {
+  return makeRecord({
+    verb: "similar",
+    format: "json",
+    payload: { op, matches: [{ ref: "member.mp4", similarity, at: 7 }], count: 1 },
+    media: { ref: "query.jpg" },
+  });
+}
+
+function clusterIdentify(similarity: number): OvercastRecord {
+  return makeRecord({
+    verb: "cluster",
+    format: "json",
+    payload: { op: "identify", matches: [{ at: 5, confident: true, candidates: [{ label: "person_1", similarity }] }], count: 1 },
+    media: { ref: "probe.jpg" },
+  });
+}
+
+const nameTarget: TargetEntry = { id: "tgt_a", kind: "name", value: "acme handle", created: "2026-07-01T00:00:00Z" };
+const imageTarget: TargetEntry = { id: "tgt_b", kind: "image", value: "refs/probe.jpg", created: "2026-07-01T00:00:00Z" };
+const SUGGEST = { mode: "suggest" as const };
+
+test("extractSignal: face match clears floor, picks best moment", () => {
+  const sig = extractSignal(faceMatch(87.2, { at: 41 }), T);
+  assert.ok(sig);
+  assert.equal(sig.kind, "face-match");
+  assert.equal(sig.score, 87.2);
+  assert.equal(sig.at, 41);
+});
+
+test("extractSignal: below-floor scores and non-match ops return nothing", () => {
+  assert.equal(extractSignal(faceMatch(60), T), undefined);
+  assert.equal(extractSignal(similarMatch(95, "search"), T), undefined);
+  assert.equal(extractSignal(similarMatch(80), T), undefined);
+  assert.equal(extractSignal(clusterIdentify(60), T), undefined);
+});
+
+test("evaluateTriggers: face match emits a quarantined suggested finding with confidence bands", () => {
+  const high = evaluateTriggers({ fresh: [faceMatch(87.2)], existing: [], targets: [imageTarget], policy: SUGGEST });
+  assert.equal(high.length, 1);
+  const p = high[0].payload as Record<string, unknown>;
+  assert.equal(p.status, "suggested");
+  assert.equal(p.trigger, "signal:face-match");
+  assert.equal(p.confidence, "high");
+  assert.equal(p.target, imageTarget.value); // linked by reference basename
+  assert.equal(p.target_id, imageTarget.id);
+  assert.equal(high[0].media?.at, 41); // anchored at the best-scoring moment
+
+  const medium = evaluateTriggers({ fresh: [faceMatch(78)], existing: [], targets: [], policy: SUGGEST });
+  assert.equal((medium[0].payload as Record<string, unknown>).confidence, "medium");
+});
+
+test("evaluateTriggers: image / similar / cluster triggers fire per table", () => {
+  const img = evaluateTriggers({ fresh: [imageMatch(50)], existing: [], targets: [], policy: SUGGEST });
+  assert.equal((img[0].payload as Record<string, unknown>).confidence, "high");
+  const imgMed = evaluateTriggers({ fresh: [imageMatch(20)], existing: [], targets: [], policy: SUGGEST });
+  assert.equal((imgMed[0].payload as Record<string, unknown>).confidence, "medium");
+  const sim = evaluateTriggers({ fresh: [similarMatch(91)], existing: [], targets: [], policy: SUGGEST });
+  assert.equal((sim[0].payload as Record<string, unknown>).trigger, "signal:similar-match");
+  const cl = evaluateTriggers({ fresh: [clusterIdentify(82)], existing: [], targets: [], policy: SUGGEST });
+  assert.equal((cl[0].payload as Record<string, unknown>).confidence, "high");
+  assert.match(String((cl[0].payload as Record<string, unknown>).text), /person_1/);
+});
+
+test("evaluateTriggers: text-target — suggested in suggest mode, legacy open in review mode", () => {
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "the acme handle appears here" }, media: { ref: "v.mp4" } });
+  const suggested = evaluateTriggers({ fresh: [watch], existing: [], targets: [nameTarget], policy: SUGGEST });
+  assert.equal((suggested[0].payload as Record<string, unknown>).status, "suggested");
+  const legacy = evaluateTriggers({ fresh: [watch], existing: [], targets: [nameTarget], policy: { mode: "review" }, via: "scan:watch" });
+  assert.equal((legacy[0].payload as Record<string, unknown>).status, "open");
+  assert.equal((legacy[0].payload as Record<string, unknown>).trigger, "scan:watch");
+});
+
+test("evaluateTriggers: mode off fires nothing; score triggers stay off in review mode", () => {
+  assert.equal(evaluateTriggers({ fresh: [faceMatch(99)], existing: [], targets: [], policy: { mode: "off" } }).length, 0);
+  assert.equal(evaluateTriggers({ fresh: [faceMatch(99)], existing: [], targets: [], policy: { mode: "review" } }).length, 0);
+});
+
+test("evaluateTriggers: dedup — existing suggestion blocks, dismissed blocks in suggest mode", () => {
+  const rec = faceMatch(90);
+  const first = evaluateTriggers({ fresh: [rec], existing: [], targets: [], policy: SUGGEST });
+  assert.equal(first.length, 1);
+  // same source again → no re-fire
+  assert.equal(evaluateTriggers({ fresh: [rec], existing: first, targets: [], policy: SUGGEST }).length, 0);
+  // dismissed → still no re-fire (suggest semantics)
+  const dismissal = makeRecord({ verb: "finding", format: "json", payload: { finding_id: first[0].id, status: "dismissed", reviewed_at: "2026-07-02T00:00:00Z" } });
+  assert.equal(evaluateTriggers({ fresh: [rec], existing: [...first, dismissal], targets: [], policy: SUGGEST }).length, 0);
+});
+
+test("evaluateTriggers: review mode keeps legacy dismissed-refire semantics", () => {
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme handle sighting" }, media: { ref: "v.mp4" } });
+  const first = evaluateTriggers({ fresh: [watch], existing: [], targets: [nameTarget], policy: { mode: "review" } });
+  const dismissal = makeRecord({ verb: "finding", format: "json", payload: { finding_id: first[0].id, status: "dismissed", reviewed_at: "2026-07-02T00:00:00Z" } });
+  const again = evaluateTriggers({ fresh: [watch], existing: [...first, dismissal], targets: [nameTarget], policy: { mode: "review" } });
+  assert.equal(again.length, 1);
+});
+
+test("evaluateTriggers: a manual finding citing the record blocks a score re-suggestion", () => {
+  const rec = imageMatch(60);
+  const manual = makeRecord({ verb: "finding", format: "json", payload: { text: "confirmed reupload", target: "", source_record: rec.id, source_verb: "image", trigger: "human", status: "open" } });
+  assert.equal(evaluateTriggers({ fresh: [rec], existing: [manual], targets: [], policy: SUGGEST }).length, 0);
+});
+
+test("memoryRecords: suggested findings are quarantined until accepted", () => {
+  const rec = faceMatch(90);
+  const [suggested] = evaluateTriggers({ fresh: [rec], existing: [], targets: [], policy: SUGGEST });
+  assert.equal(memoryRecords([rec, suggested]).some((r) => r.id === suggested.id), false);
+  const accept = makeRecord({ verb: "finding", format: "json", payload: { finding_id: suggested.id, status: "accepted", reviewed_at: "2026-07-02T00:00:00Z" } });
+  assert.equal(memoryRecords([rec, suggested, accept]).some((r) => r.id === suggested.id), true);
+  const dismiss = makeRecord({ verb: "finding", format: "json", payload: { finding_id: suggested.id, status: "dismissed", reviewed_at: "2026-07-03T00:00:00Z" } });
+  assert.equal(memoryRecords([rec, suggested, accept, dismiss]).some((r) => r.id === suggested.id), false);
+});
+
+test("resolveFindingsPolicy: missing setup / policy defaults to suggest", () => {
+  assert.equal(resolveFindingsPolicy(undefined).mode, "suggest");
+  const setup = emptySetup("t");
+  assert.equal(resolveFindingsPolicy(setup).mode, "suggest");
+});
+
+function withCase(fn: (c: ReturnType<typeof openCase>) => void | Promise<void>) {
+  const dir = mkdtempSync(join(tmpdir(), "oc-triggers-"));
+  const c = openCase(dir);
+  c.ensure();
+  return Promise.resolve(fn(c)).finally(() => rmSync(dir, { recursive: true, force: true }));
+}
+
+test("persistRecords: a standalone match run persists + returns a suggested lead exactly once", () =>
+  withCase((c) => {
+    const rec = faceMatch(90);
+    const suggestions = persistRecords(c, [rec]);
+    assert.equal(suggestions.length, 1);
+    assert.equal((suggestions[0].payload as Record<string, unknown>).status, "suggested");
+    const stored = c.records();
+    assert.ok(stored.some((r) => r.id === rec.id));
+    assert.ok(stored.some((r) => r.id === suggestions[0].id));
+    // idempotent: persisting more output for the same media doesn't re-suggest
+    const again = persistRecords(c, [faceMatch(90)]);
+    assert.equal(again.length, 0);
+  }));
+
+test("persistRecords: saved setup with findings off suppresses suggestions", () =>
+  withCase((c) => {
+    const setup = emptySetup("t");
+    setup.findings = { mode: "off" };
+    saveSetup(c, setup);
+    assert.equal(persistRecords(c, [faceMatch(95)]).length, 0);
+  }));
+
+test("persistRecords: custom threshold from setup gates the trigger", () =>
+  withCase((c) => {
+    const setup = emptySetup("t");
+    setup.findings = { mode: "suggest", thresholds: { face: 95 } };
+    saveSetup(c, setup);
+    assert.equal(persistRecords(c, [faceMatch(90)]).length, 0);
+    assert.equal(persistRecords(c, [faceMatch(96, { ref: "other.mp4" })]).length, 1);
+  }));
+
+test("loadSetup: legacy setup without findings policy resolves to suggest", () =>
+  withCase((c) => {
+    const setup = emptySetup("t");
+    delete (setup as Partial<typeof setup>).findings;
+    saveSetup(c, setup as typeof setup);
+    assert.equal(loadSetup(c)?.findings?.mode, "suggest");
+  }));
+
+function ctxFor(c: ReturnType<typeof openCase>, input: string | undefined, rest: string[] = [], opts: Record<string, unknown> = {}): VerbContext {
+  return { input, rest, opts, case: c, profile: { name: "test", providers: {} }, profileName: "test" } as unknown as VerbContext;
+}
+
+test("finding list: --state triage queues open + suggested newest first with provenance", () =>
+  withCase(async (c) => {
+    addTarget(c, "acme handle");
+    const scanHit = makeRecord({
+      verb: "scan",
+      format: "json",
+      payload: { source: "x", url: "https://x.com/p/1", source_url: "https://x.com/p/1", source_text: "acme handle posted again", title: "post" },
+      meta: { time: "2026-07-01T10:00:00Z" },
+    });
+    persistRecords(c, [scanHit]);
+    const manual = await findingVerb.run(ctxFor(c, "create", ["manual", "observation"], { target: "acme handle" }));
+    persistRecords(c, manual, { signals: false });
+    const listed = await findingVerb.run(ctxFor(c, "list", [], { state: "triage" }));
+    const payload = listed[0].payload as { findings: Array<Record<string, unknown>> };
+    assert.equal(payload.findings.length, 2);
+    const statuses = payload.findings.map((f) => f.review_status);
+    assert.ok(statuses.includes("suggested") && statuses.includes("open"));
+    const suggestedRow = payload.findings.find((f) => f.review_status === "suggested");
+    assert.equal(suggestedRow?.source_url, "https://x.com/p/1");
+    assert.match(String(suggestedRow?.source_excerpt), /acme handle/);
+  }));
+
+test("finding accept/dismiss work on suggested roots", () =>
+  withCase(async (c) => {
+    const [suggested] = persistRecords(c, [faceMatch(90)]);
+    const accepted = await findingVerb.run(ctxFor(c, "accept", [suggested.id]));
+    persistRecords(c, accepted, { signals: false });
+    const listed = await findingVerb.run(ctxFor(c, "list", [], { state: "accepted" }));
+    assert.equal((listed[0].payload as { findings: unknown[] }).findings.length, 1);
+  }));

--- a/test/unit/triggers.test.ts
+++ b/test/unit/triggers.test.ts
@@ -111,6 +111,26 @@ test("evaluateTriggers: text-target — suggested in suggest mode, legacy open i
   assert.equal((legacy[0].payload as Record<string, unknown>).trigger, "scan:watch");
 });
 
+test("evaluateTriggers: text-target fires on content verbs, NOT scan hits or captures", () => {
+  // a scan hit whose title mentions the target must NOT create a text lead —
+  // otherwise the same item leads once from its hit and again from its watch
+  const scanHit = makeRecord({ verb: "scan", format: "json", payload: { source: "x", url: "http://x/1", title: "acme handle reup", source_id: "s1" }, media: { ref: "http://x/1" } });
+  const capture = makeRecord({ verb: "capture", format: "json", payload: { path: "c.mp4", source_text: "acme handle" }, media: { ref: "c.mp4" } });
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme handle on screen" }, media: { ref: "c.mp4" } });
+  assert.equal(evaluateTriggers({ fresh: [scanHit], existing: [], targets: [nameTarget], policy: SUGGEST }).length, 0);
+  assert.equal(evaluateTriggers({ fresh: [capture], existing: [], targets: [nameTarget], policy: SUGGEST }).length, 0);
+  assert.equal(evaluateTriggers({ fresh: [watch], existing: [], targets: [nameTarget], policy: SUGGEST }).length, 1);
+});
+
+test("evaluateTriggers: two senses on the same clip fold to one text lead (shared media.ref)", () => {
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme handle appears" }, media: { ref: "c.mp4" } });
+  const listen = makeRecord({ verb: "listen", format: "json", payload: { transcript: "someone says acme handle" }, media: { ref: "c.mp4" } });
+  const first = evaluateTriggers({ fresh: [watch], existing: [], targets: [nameTarget], policy: SUGGEST });
+  assert.equal(first.length, 1);
+  // listen on the same clip must dedup via the shared media.ref, not re-lead
+  assert.equal(evaluateTriggers({ fresh: [listen], existing: first, targets: [nameTarget], policy: SUGGEST }).length, 0);
+});
+
 test("evaluateTriggers: mode off fires nothing; score triggers stay off in review mode", () => {
   assert.equal(evaluateTriggers({ fresh: [faceMatch(99)], existing: [], targets: [], policy: { mode: "off" } }).length, 0);
   assert.equal(evaluateTriggers({ fresh: [faceMatch(99)], existing: [], targets: [], policy: { mode: "review" } }).length, 0);
@@ -210,13 +230,16 @@ function ctxFor(c: ReturnType<typeof openCase>, input: string | undefined, rest:
 test("finding list: --state triage queues open + suggested newest first with provenance", () =>
   withCase(async (c) => {
     addTarget(c, "acme handle");
-    const scanHit = makeRecord({
-      verb: "scan",
+    // a watch record (sensed from a captured post) carrying its source provenance
+    // — text-target fires on content verbs; triage rows walk source_* for context
+    const watch = makeRecord({
+      verb: "watch",
       format: "json",
-      payload: { source: "x", url: "https://x.com/p/1", source_url: "https://x.com/p/1", source_text: "acme handle posted again", title: "post" },
+      payload: { content: "acme handle posted again", source_url: "https://x.com/p/1", source_text: "acme handle posted again" },
+      media: { ref: "c.mp4" },
       meta: { time: "2026-07-01T10:00:00Z" },
     });
-    persistRecords(c, [scanHit]);
+    persistRecords(c, [watch]);
     const manual = await findingVerb.run(ctxFor(c, "create", ["manual", "observation"], { target: "acme handle" }));
     persistRecords(c, manual, { signals: false });
     const listed = await findingVerb.run(ctxFor(c, "list", [], { state: "triage" }));


### PR DESCRIPTION
## Why

The case experience was lackluster: findings almost never triggered, the case drowned in small records, `brief` was a verbatim dump, and `case status` never said how close the investigation was to its goal. This makes it useful **at a glance** (details on demand): findings that trigger, status that shows goal progress, briefs that tell a story, and visible lines of investigation / dead ends.

## What

**Signals layer (`src/signals/`)**
- **`triggers.ts`** — suggested findings from match scores (face ≥75, image RANSAC inliers, similar ≥85, cluster ≥70) + target text hits. Runs on a shared persist seam (`registry/persist.ts`, wired into CLI + agent-tool + slash) so a standalone `face --match` / `image match` / `similar match` / `cluster identify` finally surfaces a lead. Default findings mode flips `off → suggest`; suggested leads are **quarantined** from ask/brief until `finding accept`; `finding list --state triage` queues them; dismiss blocks re-suggestion.
- **`threads.ts`** — targets become *lines of investigation* with a stage ladder (cold → collecting → leads → corroborated → answered/dead-end). New `target add --question`, `close --as answered|dead-end --note`, `reopen`; closed lines stop seeding scans.
- **`pulse.ts`** — `casePulse` (per-source coverage funnel, freshness, triage counts, threads), extracted from wall's `buildHud` so wall/brief/status share one source of truth.
- **`rollup.ts`** — `groupTimeline` collapses fan-out by media chain.

**Presentation**
- `brief` is **short by default**: verdict → goal status → key findings (ranked, capped, visual proof) → lines of investigation (thread cards w/ stage + activity sparkline + evidence funnel) → triage queue → coverage gaps → compact record trail. `--full` restores the verbatim audit dump.
- `case status` is a **mission board** (goal headline, thread stages, triage queue, coverage) in md + CSI HTML.
- `report/components.ts` — shared `fmtAge`/`sparkline`/`chip`/`coverageBadges`.
- `/debrief` prompt drives the analyst loop: triage leads → narrate each thread → close resolved lines → refresh `tldr` → export. Keeps the LLM outside the deterministic verbs.

## Behavior changes to note
- findings default `off → suggest` (incl. missing-setup case); suggested findings excluded from memory/brief until accepted; dismissed blocks re-suggestion.
- `brief` default output is short (`--full` for the dump).
- `primaryTarget` skips closed targets (affects scan seeding).

## Verification
- typecheck clean · **600/600** unit · **164/164** offline e2e
- registry `commands --json` + regenerated skill docs carry the new surface (invariant #5); README / CLAUDE.md / docs/flows / prompts / skills updated for the new surface
- **Real-data live e2e**: new `test/e2e/live/cases/18_findings.sh` (21/21) drives the whole lifecycle on real media — a real tinycloud `face --match` (99.9%) auto-suggests a lead → triage → quarantine-until-accept → corroborated + citable-by-`ask` → `thread:` narrative on the line card → dead-end line → short brief (+`--full`). Also exercised real `image match` (64 RANSAC inliers → high) and text-target (real transcript). Every affected live case (14/16/17/18/27/31/32/33) passes.
- The persist hook appends a suggested-finding record after match/identify verbs, which broke single-record `jq` parsing in existing live cases (invisible offline — fixture matches return count 0); fixed with a shared `primary_rec` helper.
- Cleared **7 Bugbot review rounds** (per-source freshness, thread-note rendering, text-lead dedup, closed-line invariant across all seeding paths, scoped-brief pulse/status, notes self-suggesting, unstamped-hit coverage, CSI finding ranking).

## Deferred
- `meta.run` stamping across scan/monitor hot paths (risky); `groupTimeline` already groups by media chain and will honor `meta.run` if stamped later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default findings automation and the memory/brief evidence boundary (quarantined suggested leads), plus scan/monitor seeding when targets are closed—high user-visible impact, though scoped to case workflow rather than auth or external APIs.
> 
> **Overview**
> Introduces **`src/signals/`** (`triggers`, `threads`, `pulse`, `rollup`) so match scores and target text can auto-emit **`suggested`** findings, targets render as **lines of investigation** with stages, and **`casePulse`** drives coverage/freshness/triage consistently (including the wall HUD).
> 
> **Persistence & evidence:** CLI, agent tools, and TUI slash commands now persist via **`persistRecords`**, which runs finding triggers on every fresh evidence record (standalone `face --match` / `image match` etc. surface leads like scan chains). Default setup findings mode becomes **`suggest`** (with **`--findings-threshold`**); **`suggested`** and dismissed findings stay out of **`ask`/`brief`** until **`finding accept`**. **`finding list --state triage`** and richer list rows support review.
> 
> **Targets & scans:** **`target add --question`**, **`close --as answered|dead-end`**, **`reopen`**; closed lines are skipped for **`primaryTarget`**, local scan seeding, and new suggestions on closed targets.
> 
> **Reports:** **`brief`** is **short by default** (verdict, threads, triage, coverage, grouped record trail); **`--full`** keeps the verbatim timeline. **`case status`** becomes a mission-board payload and markdown/HTML layout. Shared **`report/components`** and CSI HTML panels for threads/triage. New **`/debrief`** prompt documents the analyst loop.
> 
> Docs, prompts, skill-gen, and registry reference strings are aligned with the new defaults and flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95843cba94e07717d9c2ccf4307f7c6185c7bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

