### PR TITLE
grid verb + 5 temporal/spatial-localization skills (visual CoT)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,9 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `--square`), `grid` (tile timestamped video frames into ONE labeled contact
   sheet for a single-call VLM triage pass — the "grid trick" for temporal search;
   `--count`/`--at`/`--start`/`--end`/`--cols`/`--width`; emits `media.grid` with a
-  cell-number→timestamp map; labels burned only when ffmpeg has `drawtext`),
+  cell-number→timestamp map; labels burned only when ffmpeg has `drawtext`, else
+  positional; `--view` renders a clickable HTML board — CSS-labeled numbered cells
+  that seek the source clip — the human counterpart to the VLM-facing PNG),
   `wall` (control-room monitor wall: case videos muted + looping at
   their evidence moments — open finding > face hit > record anchor — with
   coverage badges and scan/monitor/brief freshness overlaid; `--limit`,
@@ -174,7 +176,7 @@ Case memory is **evidence-only**. `ask` / `brief` read primary evidence
 bound memory providers — `local-grep` (always on) and optional `qmd` (semantic;
 `setup memory qmd`, then rebuild before querying). Read/meta and operational
 records (`ask brief case setup doctor provider skills index target source
-prebrief wall`, finding review-rows, dismissed findings, cluster DB
+prebrief wall grid`, finding review-rows, dismissed findings, cluster DB
 reads/maintenance `list/show/view/label/recluster`) are excluded even when they
 match the query. `face`/`see`/`image`/`similar`/`cluster` detections index only
 compact summaries / counts / moments / matched refs — raw boxes, thumbnails,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,11 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
 - **Inspect** — `view` (self-contained HTML media player; `--at`, `--spectrogram`,
   `--no-open`), `crop` (materialize `face`/`see` detection boxes into cropped
   image evidence records via ffmpeg — `--all/--id/--class/--kind`, `--pad`,
-  `--square`), `wall` (control-room monitor wall: case videos muted + looping at
+  `--square`), `grid` (tile timestamped video frames into ONE labeled contact
+  sheet for a single-call VLM triage pass — the "grid trick" for temporal search;
+  `--count`/`--at`/`--start`/`--end`/`--cols`/`--width`; emits `media.grid` with a
+  cell-number→timestamp map; labels burned only when ffmpeg has `drawtext`),
+  `wall` (control-room monitor wall: case videos muted + looping at
   their evidence moments — open finding > face hit > record anchor — with
   coverage badges and scan/monitor/brief freshness overlaid; `--limit`,
   `--source`/`--since`, `--refresh`, `--infinite` endless repeat-to-fill wall,

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ overcast setup provider see "exec:python3 examples/providers/detect/detect.py"
 overcast see ./clip.mp4 --detect "person, car, license plate" --json
 overcast crop <see-record-id> --all --class person --json
 
+# 6b) when did X happen? tile the clip, ask a VLM which cell, then verify the frame
+overcast grid ./clip.mp4 --count 16 --json               # one contact sheet + cell→timestamp map
+overcast see <montage-path> --prompt "which numbered cells show X?" --json
+overcast see frame://<watch-record>@<seconds> --prompt "is X happening here?" --json  # verify at the frame
+overcast grid ./clip.mp4 --view                          # clickable numbered board that seeks the clip
+
 # 7) index the target's videos, then search across ALL of them
 overcast index create faces --type face --json
 overcast index attach existing-face-index --type face --json       # or bind an existing remote index
@@ -232,6 +238,7 @@ surface + env vars.)
 |---|---|
 | `view` | open media in a scrubbable local HTML player (timeline markers, spectrogram) |
 | `crop` | materialize face/object detections as cropped image records with provenance |
+| `grid` | tile timestamped frames into one contact sheet for single-call VLM triage (cell → timestamp map); `--view` for a clickable, numbered HTML board that seeks the clip |
 | `wall` | control-room monitor wall — every case video muted + looping its best evidence moment, case state overlaid |
 
 **OSINT** — search / capture / monitor

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -114,7 +114,8 @@ The durable local store under `.overcast/records`, plus media/state/index files.
   object-detection records.
 - **Read/meta records:** `ask`, `brief`, `case`.
 - **Operational/setup records:** `setup`, `doctor`, `provider`, `skills`,
-  `index`, `target`, `source`, `prebrief`, and finding review-rows.
+  `index`, `target`, `source`, `prebrief`, `wall`, `grid`, and finding
+  review-rows. (`grid`/`wall` are triage/viewing artifacts — not evidence.)
 - **Media files:** captured/copied/enhanced media and crops under
   `.overcast/media`.
 - **State files:** targets, sources, index mirrors, seen sets, and memory-index
@@ -153,9 +154,9 @@ Eligible fields when allowed by the signal filter:
 
 Excluded from memory and briefs: prior read/meta output (`ask`, `brief`,
 `case`); setup/operational output (`setup`, `doctor`, `provider`, `skills`,
-`index`, `target`, `source`, `prebrief`); finding review-rows, finding-command
-errors, `finding list` envelopes, and dismissed root findings (still auditable in
-records/logs).
+`index`, `target`, `source`, `prebrief`, `wall`, `grid`); finding review-rows,
+finding-command errors, `finding list` envelopes, and dismissed root findings
+(still auditable in records/logs).
 
 Raw detection payloads are intentionally not searchable. Use exact record reads
 (`case memory get <id>`) or `crop <record-id>` for boxes/images.
@@ -508,6 +509,29 @@ overcast watch ./clip.mp4
 overcast see frame://<watch-record-id>@42 --prompt "Describe signage and visible objects"
 overcast ask "What signage appears around 42 seconds?"
 ```
+
+### 15b. Temporal localization — *when* did X happen (coarse → fine)
+
+Triage the whole clip in one vision call, then verify the exact moment at the
+frame. Every timestamp traces back to a frame the model actually looked at — a
+low-res tile invites a plausible-but-wrong read, so the frame check decides.
+
+```bash
+overcast watch ./clip.mp4                                   # -> record REC (media on disk)
+overcast grid ./clip.mp4 --count 16 --json                  # one contact sheet; payload.cells maps cell -> timestamp
+overcast see <montage-path> --prompt "which numbered cells show X? give cell numbers"
+# map the chosen cell number through payload.cells[n].at (never a time the model typed)
+overcast see frame://REC@<that-second> --prompt "is X happening here?"   # verify at full resolution
+overcast grid ./clip.mp4 --start <a> --end <b> --json       # re-grid tighter to zoom in
+overcast note "X occurs" --ref REC --at <t1-t2> --confidence medium
+```
+
+`grid` is a triage artifact (operational — excluded from case memory), not
+evidence; cite the verified `see` frame, and report a window, not a false-precise
+frame. `overcast grid ./clip.mp4 --view` opens a clickable HTML board (numbered,
+timestamped cells that seek the clip) for eyeballing the same sheet by hand. The
+`overcast-pinpoint`, `overcast-frame-grid`, `overcast-event-bisect`,
+`overcast-where`, and `overcast-presence-window` skills wrap these loops.
 
 ### 16. Human observation / analyst flagging
 

--- a/skills/overcast-event-bisect/SKILL.md
+++ b/skills/overcast-event-bisect/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: overcast-event-bisect
+description: >-
+  Localize the exact instant of a one-way state change (light on, door opens,
+  poster removed) by binary-searching frames — ~log2(N) VLM calls.
+---
+
+# overcast-event-bisect
+
+Use this skill when a video contains a single MONOTONE transition — a condition
+that is false before some instant and true after it (or vice versa), and does not
+flip back. Binary search finds it in about log2(window/precision) vision calls
+(~12 calls localizes to ~1s inside an hour). Use the broad `overcast` skill and
+`overcast/reference/verbs.md` for exact flags.
+
+## Workflow
+
+1. Local clip + record id (`see frame://` needs media on disk):
+
+\`\`\`bash
+overcast doctor --json
+overcast case init --json
+overcast watch ./clip.mp4 --json        # -> record id REC (also gives shot context)
+\`\`\`
+
+2. Confirm the transition is bracketed AND monotone — the two endpoints must
+   disagree on the predicate:
+
+\`\`\`bash
+overcast see frame://REC@<lo> --prompt "Is <predicate> true? answer only yes or no" --json
+overcast see frame://REC@<hi> --prompt "Is <predicate> true? answer only yes or no" --json
+\`\`\`
+
+   If both give the same answer, the flip isn't in `[lo,hi]`. If the predicate
+   toggles more than once, it isn't monotone — use `overcast-pinpoint` instead.
+
+3. Bisect: test the midpoint, keep the half that still straddles the flip, repeat
+   until `hi - lo` is within your precision:
+
+\`\`\`bash
+overcast see frame://REC@<mid> --prompt "Is <predicate> true? answer only yes or no" --json
+# yes at mid  -> the flip is in [lo, mid]; no at mid -> it's in [mid, hi]
+\`\`\`
+
+4. Report the transition window and show it:
+
+\`\`\`bash
+overcast note "<predicate> becomes true" --ref REC --at <lastFalse-firstTrue> --confidence high --json
+overcast view REC --at <lastFalse-firstTrue> --json
+overcast brief --export ./transition.md --json
+\`\`\`
+
+## Output
+
+The bracket `[last-false, first-true]`, the two `see` frames that straddle it
+(their `record.id`s + `media.at`), and the call count. That bracket IS the
+answer window — don't over-claim a single frame.
+
+## Caveats
+
+Bisection is only valid for a one-way change; a light that blinks or a person who
+comes and goes will mislead it — verify monotonicity at step 2, and fall back to
+`overcast-pinpoint` (peak search) or `overcast-presence-window` for recurring or
+interval events. Needs the video local.

--- a/skills/overcast-event-bisect/SKILL.md
+++ b/skills/overcast-event-bisect/SKILL.md
@@ -39,22 +39,23 @@ overcast see frame://REC@<hi> --prompt "Is <predicate> true? answer only yes or 
 
 \`\`\`bash
 overcast see frame://REC@<mid> --prompt "Is <predicate> true? answer only yes or no" --json
-# yes at mid  -> the flip is in [lo, mid]; no at mid -> it's in [mid, hi]
+# keep the straddling half: if mid's answer == lo's answer, set lo=mid; else hi=mid
+# (correct whichever way it flips — false->true OR true->false)
 \`\`\`
 
 4. Report the transition window and show it:
 
 \`\`\`bash
-overcast note "<predicate> becomes true" --ref REC --at <lastFalse-firstTrue> --confidence high --json
-overcast view REC --at <lastFalse-firstTrue> --json
+overcast note "<predicate> flips" --ref REC --at <lo-hi> --confidence high --json
+overcast view REC --at <lo-hi> --json
 overcast brief --export ./transition.md --json
 \`\`\`
 
 ## Output
 
-The bracket `[last-false, first-true]`, the two `see` frames that straddle it
-(their `record.id`s + `media.at`), and the call count. That bracket IS the
-answer window — don't over-claim a single frame.
+The converged `[lo, hi]` bracket — the two adjacent `see` frames that straddle
+the flip (their `record.id`s + `media.at`) — and the call count. That bracket IS
+the answer window — don't over-claim a single frame.
 
 ## Caveats
 

--- a/skills/overcast-frame-grid/SKILL.md
+++ b/skills/overcast-frame-grid/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: overcast-frame-grid
+description: >-
+  Triage a whole clip in one VLM call — tile sampled frames into a labeled
+  contact sheet, ask which cells show the target, then zoom in.
+---
+
+# overcast-frame-grid
+
+Use this skill to find roughly WHERE in a clip something appears with a single
+vision call, before spending per-frame calls. It's the "grid trick" from
+temporal-search research (frames tiled into one image; Set-of-Mark numbering over
+time). Pairs with `overcast-pinpoint` for the frame-precise follow-up. Use the
+broad `overcast` skill and `overcast/reference/verbs.md` for exact flags.
+
+## Workflow
+
+\`\`\`bash
+overcast doctor --json
+overcast case init --json
+overcast grid ./clip.mp4 --count 16 --json     # -> media.grid: payload.montage + payload.cells + payload.cols
+overcast see <montage-path> --prompt "Which numbered cells show <X>? Reply with cell numbers and why." --json
+\`\`\`
+
+- If the grid record's `payload.labeled` is `false` (this ffmpeg build has no
+  `drawtext`), tell `see` it's a `<cols>`-column grid numbered left-to-right,
+  top-to-bottom (`cols` is in the record), so it can reference cells by position.
+- Always map the chosen cell number back through `payload.cells[n].at` to get the
+  real timestamp — never use a time the model typed out.
+
+Zoom in on the winning region (narrow the window, or hand the timestamp to
+`overcast-pinpoint`):
+
+\`\`\`bash
+overcast grid ./clip.mp4 --start <a> --end <b> --count 16 --json   # finer sheet around the hit
+overcast see frame://<watch-record>@<t> --prompt "Is <X> here? yes/no + detail" --json
+overcast note "<X> first visible" --ref <record> --at <t1-t2> --json
+overcast brief --export ./grid-triage.md --json
+\`\`\`
+
+Use `--at "s1,s2,s3"` instead of `--count` when you already have candidate
+timestamps to compare side by side; `--start/--end` to focus a window; `--cols`
+/ `--width` to shape the sheet.
+
+## Output
+
+The cell(s) that matched, the timestamp each maps to (via `payload.cells`), and
+the grid `record.id`. Treat grid hits as coarse (one frame per cell) — confirm
+the exact moment by `see`-ing that frame before citing it as evidence.
+
+## Caveats
+
+One contact sheet samples sparsely, so a brief event between cells can be missed —
+raise `--count` or re-grid a tighter `--start/--end`. The montage is a still, so
+motion/audio cues are gone; use `watch`/`listen` when those matter. Video can be
+local or a URL, but the `see frame://` zoom-in step needs it local.

--- a/skills/overcast-frame-grid/SKILL.md
+++ b/skills/overcast-frame-grid/SKILL.md
@@ -25,6 +25,9 @@ overcast see <montage-path> --prompt "Which numbered cells show <X>? Reply with 
 - If the grid record's `payload.labeled` is `false` (this ffmpeg build has no
   `drawtext`), tell `see` it's a `<cols>`-column grid numbered left-to-right,
   top-to-bottom (`cols` is in the record), so it can reference cells by position.
+- Only the first `count` cells hold frames; the last row may be blank padding
+  (those `payload.cells[].at` are `null`), so have `see` pick from 1..`count`
+  and ignore blank tiles.
 - Always map the chosen cell number back through `payload.cells[n].at` to get the
   real timestamp — never use a time the model typed out.
 

--- a/skills/overcast-frame-grid/SKILL.md
+++ b/skills/overcast-frame-grid/SKILL.md
@@ -43,7 +43,10 @@ overcast brief --export ./grid-triage.md --json
 
 Use `--at "s1,s2,s3"` instead of `--count` when you already have candidate
 timestamps to compare side by side; `--start/--end` to focus a window; `--cols`
-/ `--width` to shape the sheet.
+/ `--width` to shape the sheet. Add `--view` (`--no-open` in a headless run) to
+also write a clickable HTML board — numbered, timestamped cells that seek the
+source clip — for eyeballing the sheet by hand; the montage PNG stays the input
+you hand to `see`.
 
 ## Output
 

--- a/skills/overcast-pinpoint/SKILL.md
+++ b/skills/overcast-pinpoint/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: overcast-pinpoint
+description: >-
+  Pinpoint WHEN a specific thing happens in a video — funnel from cheap
+  coarse candidates (shots / CLIP / grid) to a frame-verified time window.
+---
+
+# overcast-pinpoint
+
+Use this skill to answer "exactly when does X happen?" in a clip and back it
+with evidence the model actually looked at. It mirrors the temporal-search
+pattern from the VLM video literature (T\* / VideoAgent): score cheaply over the
+whole clip, then spend expensive VLM calls only on a few candidate frames and
+zoom in. Use the broad `overcast` skill and `overcast/reference/verbs.md` for
+exact flags.
+
+Two rules that make the answer trustworthy:
+
+- **Report a window, not a frame.** Frame-exact localization is unreliable; emit
+  `[t1-t2]` plus one verified keyframe.
+- **Every timestamp must trace to a frame you `see`-verified.** Never emit a
+  time the model merely guessed — models answer correctly while grounding on the
+  wrong moment, so confirm by looking at the frame.
+
+## Workflow
+
+1. Make the clip local and get a record id (`see frame://` needs media on disk —
+   capture a remote clip first). `watch` also gives per-shot timestamped content
+   to search:
+
+\`\`\`bash
+overcast doctor --json
+overcast case init --json
+overcast watch ./clip.mp4 --json         # -> video.analysis record id (REC)
+\`\`\`
+
+2. Get COARSE candidates cheaply (pick what's available):
+
+\`\`\`bash
+overcast ask "moments where <X> happens, with timestamps" --json      # over watch shots/notes
+overcast grid ./clip.mp4 --count 16 --json                            # one contact sheet ...
+overcast see <montage-path> --prompt "which numbered cells show <X>? give cell numbers" --json
+overcast similar search "<X>" --index <basic-clip-id> --json          # if a local CLIP index exists
+overcast ask "moments <X> happens" --index <media-descriptions-id> --probe --json  # remote index
+\`\`\`
+
+   For `grid`, translate the chosen cell number to a time via the grid record's
+   `payload.cells[n].at` (don't trust a model-guessed time). CLIP/shots only
+   SHORTLIST — CLIP is weak on actions/order — so verify next.
+
+3. VERIFY + zoom on each candidate time T (expensive, precise):
+
+\`\`\`bash
+overcast see frame://REC@T --prompt "Is <X> happening here? answer yes/no and what you see" --json
+# refine: sample T-d and T+d, halve d each round until adjacent frames flip yes<->no
+overcast see frame://REC@<T-2> --prompt "Is <X> happening?" --json
+overcast see frame://REC@<T+2> --prompt "Is <X> happening?" --json
+\`\`\`
+
+4. Record the verified window and eyeball it:
+
+\`\`\`bash
+overcast note "<X> occurs" --ref REC --at <t1-t2> --confidence medium --json
+overcast view REC --at <t1-t2> --json
+overcast brief --export ./pinpoint.md --json
+\`\`\`
+
+## Output
+
+The tightest `[t1-t2]` window, the single `see` keyframe that confirms it (its
+`record.id`), and how it was found (shots / grid / CLIP / probe). Cite
+`record.id` + `media.at` for every claim; state the window, not a false-precise
+single frame.
+
+## Caveats
+
+Needs the video local (a URL-only `watch` record can't extract frames). CLIP and
+shot text shortlist but don't decide — the `see` frame check does. If `X` recurs,
+pinpoint each occurrence separately; don't collapse them into one window.

--- a/skills/overcast-presence-window/SKILL.md
+++ b/skills/overcast-presence-window/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: overcast-presence-window
+description: >-
+  Find the interval a person or object is present — anchor one appearance, then
+  sweep outward with face-match / detect until it drops off both sides.
+---
+
+# overcast-presence-window
+
+Use this skill to answer "from when to when is <target> on screen?" — a first/last
+appearance interval, not a single instant. It anchors one confirmed appearance and
+expands until the target stops appearing, the presence-tracking analog of a
+temporal search. Use the broad `overcast` skill and
+`overcast/reference/verbs.md` for exact flags.
+
+## Workflow
+
+1. Local clip + record id:
+
+\`\`\`bash
+overcast doctor --json
+overcast case init --json
+overcast watch ./clip.mp4 --json        # -> record id REC
+\`\`\`
+
+2. Anchor one appearance (whichever fits the target):
+
+\`\`\`bash
+overcast face ./clip.mp4 --match ./person.jpg --json          # a specific person (similarity 0-100)
+overcast grid ./clip.mp4 --count 16 --json                    # then see the montage for an object
+\`\`\`
+
+3. Sweep outward from the anchor until K consecutive misses on each side:
+
+\`\`\`bash
+# person: widen the window; --fps controls sample density (precision vs cost)
+overcast face ./clip.mp4 --match ./person.jpg --start <a> --end <b> --fps 1 --min-similarity 55 --json
+# object: step frames outward and check presence
+overcast see frame://REC@<t> --prompt "Is <target> present? answer only yes or no" --json
+\`\`\`
+
+4. Emit the presence interval(s) and show them:
+
+\`\`\`bash
+overcast note "<target> present" --ref REC --at <first-last> --confidence medium --json
+overcast view REC --at <first-last> --json
+overcast brief --export ./presence.md --json
+\`\`\`
+
+## Output
+
+One or more `[first-last]` intervals with the per-hit citations (`record.id` +
+`media.at`) that bound them, and the sample density used. If the target leaves
+and returns, report each interval separately rather than one span covering the
+gap.
+
+## Caveats
+
+Sampled detections are per-frame, not continuous — presence between samples is
+inferred; raise `--fps` to tighten boundaries at higher cost. Occlusion or an
+off-camera moment splits one presence into several intervals — that's a real
+result, not noise. Face similarity is 0-100. Needs the video local.

--- a/skills/overcast-where/SKILL.md
+++ b/skills/overcast-where/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: overcast-where
+description: >-
+  Locate WHERE in a frame a target is — open-vocab detect, crop the box, then
+  VLM-verify the crop so hallucinated boxes don't survive.
+---
+
+# overcast-where
+
+Use this skill to turn a moment into spatial evidence: a bounding box on the
+target plus a verified crop. It follows the detector-proposes / VLM-verifies
+pattern (open-vocab detection like OWLv2, then confirm the crop) — because chat
+VLMs are unreliable at emitting raw coordinates, so a real detector draws the box
+and the VLM only judges the crop. Use the broad `overcast` skill and
+`overcast/reference/verbs.md` for exact flags.
+
+## Setup
+
+`see --detect` needs a detection provider bound (boxes come from OWLv2, not the
+brain LLM):
+
+\`\`\`bash
+overcast setup provider see "exec:python3 examples/providers/detect/detect.py" --json
+# or the catalog: overcast provider setup apply --preset owl-local --yes --json
+\`\`\`
+
+## Workflow
+
+1. Have the moment (use `overcast-pinpoint` / `overcast-frame-grid`): timestamp
+   T on record REC.
+
+2. Detect the target in that frame, then materialize + verify the box:
+
+\`\`\`bash
+overcast see frame://REC@T --detect "<target phrase>" --json      # -> see record with detections[]
+overcast crop <see-record-id> --all --class "<target phrase>" --pad 0.15 --json
+overcast see <crop-path> --prompt "Does this crop show <target>? yes/no + describe" --json
+\`\`\`
+
+   The re-`see` of each crop is what kills false positives — open-vocab detectors
+   emit confident boxes for almost any phrase at low thresholds.
+
+3. Optionally sharpen the exhibit and record the finding:
+
+\`\`\`bash
+overcast enhance <crop-path> --ops upscale,denoise --json
+overcast finding create "<target> located at T" --ref <see-record-id> --confidence medium --json
+overcast brief --export ./where.md --json
+\`\`\`
+
+## Output
+
+Per confirmed target: the timestamp, the box (from the `see --detect` record),
+the crop path, and the verification verdict. Cite the `see` detection
+`record.id` + `media.at`; note the crop is the durable, memory-friendly evidence
+artifact.
+
+## Caveats
+
+Never ask the brain LLM for coordinates directly — bind a detector and verify
+crops. Detector confidence is not calibrated across free-form phrases: a high
+score on a rare phrase can still be wrong, so the crop re-check decides. For a
+specific PERSON, use `face --match` instead of `--detect`. Boxes are per sampled
+frame, not tracks.

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -28,6 +28,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `enhance` — Produce better media (denoise/normalize/upscale/...) via ffmpeg or a bound model provider.
 - `view` — Open media in a lightweight local viewer (scrubbable player) or hand off to the OS.
 - `crop` — Materialize face/object detections as cropped image records with provenance.
+- `grid` — Tile timestamped video frames into a labeled contact sheet for one-shot VLM triage.
 - `wall` — Open a control-room monitor wall: case videos looping at their evidence moments.
 - `scan` — Sweep sources, or local case media/indexes when no sources exist; emit scan.hit records (--pull to capture+sense).
 - `capture` — Fetch a resource (URL / scan.hit / local path) into the case as a capture record.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -285,6 +285,34 @@ Options:
 
 Emits `media.crop` records.
 
+### `overcast grid`
+
+Samples frames from a video — uniformly across a --start/--end window (default the whole clip, --count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact timestamp. Chain it: `overcast see <montage-path> --prompt "which numbered cell best shows X? give the cell number"` then read payload.cells to recover the source time — one VLM call triages a long clip before a frame-precise zoom-in (see frame://<record>@<sec>).
+
+```
+overcast grid <input> [options]
+
+  Tile timestamped video frames into a labeled contact sheet for one-shot VLM triage.
+
+  Samples frames from a video — uniformly across a --start/--end window (default the whole clip, --count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact timestamp. Chain it: `overcast see <montage-path> --prompt "which numbered cell best shows X? give the cell number"` then read payload.cells to recover the source time — one VLM call triages a long clip before a frame-precise zoom-in (see frame://<record>@<sec>).
+
+Arguments:
+  input            Video file path or case record id
+
+Options:
+  --count <number>       Number of frames to sample across the window (default 16)
+  --at <string>          Explicit comma list of timestamps (SS or MM:SS), overrides --count/window
+  --start <string>       Window start (SS or MM:SS)
+  --end <string>         Window end (SS or MM:SS)
+  --cols <number>        Grid columns (default ceil(sqrt(count)), max 12)
+  --width <number>       Cell width in px (default 320)
+  --out <string>         Output image path (default .overcast/media/)
+  --format <string>      Output surface: json | md | txt
+  --json                 Shorthand for --format json
+```
+
+Emits `media.grid` records.
+
 ### `overcast wall`
 
 Generates a self-contained HTML wall of muted, looping video tiles — each anchored to its best evidence moment (open finding > face hit > record anchor) — overlaid with case state: sense-coverage badges, findings, per-source scan / monitor / brief freshness. Local media is referenced by file:// URL (not embedded); missing or browser-hostile media renders a NO SIGNAL / STILL tile (with an ffmpeg poster frame when extractable). Click a tile to open the media at its anchor; hover for the intel card. --infinite repeats the real feeds to fill the screen and keeps extending the grid as it scrolls — an endless monitor bank even from a handful of feeds. --no-open writes the wall and emits a record with its path instead of launching.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -287,14 +287,14 @@ Emits `media.crop` records.
 
 ### `overcast grid`
 
-Samples frames from a video — uniformly across a --start/--end window (default the whole clip, --count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact timestamp. Chain it: `overcast see <montage-path> --prompt "which numbered cell best shows X? give the cell number"` then read payload.cells to recover the source time — one VLM call triages a long clip before a frame-precise zoom-in (see frame://<record>@<sec>).
+Samples frames from a video — uniformly across a --start/--end window (default the whole clip, --count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact timestamp. Chain it: `overcast see <montage-path> --prompt "which numbered cell best shows X? give the cell number"` then read payload.cells to recover the source time — one VLM call triages a long clip before a frame-precise zoom-in (see frame://<record>@<sec>). Add --view for a clickable HTML contact sheet (cells labeled with their timestamp even when ffmpeg can't burn labels, each seeking the source video on click); --no-open writes it without launching.
 
 ```
 overcast grid <input> [options]
 
   Tile timestamped video frames into a labeled contact sheet for one-shot VLM triage.
 
-  Samples frames from a video — uniformly across a --start/--end window (default the whole clip, --count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact timestamp. Chain it: `overcast see <montage-path> --prompt "which numbered cell best shows X? give the cell number"` then read payload.cells to recover the source time — one VLM call triages a long clip before a frame-precise zoom-in (see frame://<record>@<sec>).
+  Samples frames from a video — uniformly across a --start/--end window (default the whole clip, --count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact timestamp. Chain it: `overcast see <montage-path> --prompt "which numbered cell best shows X? give the cell number"` then read payload.cells to recover the source time — one VLM call triages a long clip before a frame-precise zoom-in (see frame://<record>@<sec>). Add --view for a clickable HTML contact sheet (cells labeled with their timestamp even when ffmpeg can't burn labels, each seeking the source video on click); --no-open writes it without launching.
 
 Arguments:
   input            Video file path or case record id
@@ -307,6 +307,8 @@ Options:
   --cols <number>        Grid columns (default ceil(sqrt(count)), max 12)
   --width <number>       Cell width in px (default 320)
   --out <string>         Output image path (default .overcast/media/)
+  --view                 Also render a clickable HTML contact sheet (numbered cells seek the source video)
+  --no-open              With --view, write the HTML board but don't launch it
   --format <string>      Output surface: json | md | txt
   --json                 Shorthand for --format json
 ```

--- a/src/media/ffmpeg.ts
+++ b/src/media/ffmpeg.ts
@@ -5,7 +5,8 @@
 // verifies it's installed and recent enough.
 
 import { dirname, join, extname, basename } from "node:path";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, copyFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
@@ -213,6 +214,172 @@ export async function cropStill(
   );
   await execFileP(FFMPEG_PATH, args, { maxBuffer: 32 * 1024 * 1024 });
   return out;
+}
+
+// ---- contact sheet (frame grid) --------------------------------------------
+// Tile N timestamped frames into ONE labeled image for a single-call VLM triage
+// pass (the "grid trick": T*/temporal-search + Set-of-Mark over time). Labels are
+// burned per cell ONLY when this ffmpeg build has `drawtext` (needs libfreetype)
+// AND a usable font is found; otherwise the sheet is unlabeled and the caller
+// falls back to positional numbering. Either way the cell→timestamp map is exact
+// and returned in `cells` — the burned label is a convenience, not the record.
+
+let drawtextCache: boolean | undefined;
+
+/** Does this ffmpeg build have the `drawtext` filter? (cached; libfreetype-gated) */
+export async function hasDrawtext(): Promise<boolean> {
+  if (drawtextCache !== undefined) return drawtextCache;
+  try {
+    const { stdout } = await execFileP(FFMPEG_PATH, ["-hide_banner", "-filters"], {
+      timeout: 10_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    drawtextCache = /\bdrawtext\b/.test(stdout);
+  } catch {
+    drawtextCache = false;
+  }
+  return drawtextCache;
+}
+
+// Common TTF locations across macOS + Linux; OVERCAST_GRID_FONT overrides. `.ttc`
+// collections are skipped (drawtext needs a face index for those).
+const FONT_CANDIDATES = [
+  process.env.OVERCAST_GRID_FONT,
+  "/System/Library/Fonts/Supplemental/Arial.ttf",
+  "/Library/Fonts/Arial.ttf",
+  "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+  "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+  "/usr/share/fonts/TTF/DejaVuSans.ttf",
+  "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+];
+
+/** First usable TTF for drawtext labels, or undefined. */
+export function findGridFont(): string | undefined {
+  return FONT_CANDIDATES.find((f): f is string => !!f && existsSync(f));
+}
+
+const clampInt = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, Math.round(v)));
+
+export interface GridCell {
+  /** 1-based cell number, left-to-right then top-to-bottom */
+  n: number;
+  /** source timestamp (seconds) this cell was sampled from */
+  at: number;
+}
+
+export interface ContactSheetResult {
+  output: string;
+  cells: GridCell[];
+  cols: number;
+  rows: number;
+  cellWidth: number;
+  cellHeight: number;
+  /** whether cell numbers/timestamps were burned into the image */
+  labeled: boolean;
+}
+
+export interface ContactSheetOpts {
+  cols?: number;
+  cellWidth?: number;
+  outPath?: string;
+  /** force labels off even when drawtext is available */
+  label?: boolean;
+}
+
+/**
+ * Build a labeled contact sheet from a video at the given `seconds`. Extracts one
+ * uniformly-sized cell per timestamp (letterboxed to preserve aspect), burns a
+ * `<n>  <t>s` label when drawtext is available, pads the final row with blank
+ * cells so `tile` gets an exact grid, then tiles them into one image.
+ */
+export async function contactSheet(
+  input: string,
+  seconds: number[],
+  outDir: string,
+  opts: ContactSheetOpts = {},
+): Promise<ContactSheetResult> {
+  if (seconds.length === 0) throw new Error("contact sheet needs at least one timestamp");
+  ensureDir(outDir);
+
+  const cellWidth = clampInt(opts.cellWidth ?? 320, 120, 960);
+  const p = await probe(input).catch(() => undefined);
+  const aspect = p?.width && p?.height ? p.height / p.width : 9 / 16;
+  let cellHeight = Math.round(cellWidth * aspect);
+  if (cellHeight % 2) cellHeight += 1; // keep even for codec friendliness
+
+  const n = seconds.length;
+  const cols = clampInt(opts.cols ?? Math.ceil(Math.sqrt(n)), 1, 12);
+  const rows = Math.ceil(n / cols);
+  const slots = cols * rows;
+
+  const labeled = opts.label !== false && (await hasDrawtext()) && !!findGridFont();
+  const font = findGridFont();
+  const fontSize = clampInt(cellWidth / 14, 14, 40);
+
+  const base = basename(input, extname(input));
+  const out = opts.outPath ?? join(outDir, `${safeName(base)}_grid_${n}.png`);
+  const work = mkdtempSync(join(tmpdir(), "oc-grid-"));
+  try {
+    const scalePad =
+      `scale=${cellWidth}:${cellHeight}:force_original_aspect_ratio=decrease,` +
+      `pad=${cellWidth}:${cellHeight}:(ow-iw)/2:(oh-ih)/2:color=black`;
+    for (let i = 0; i < n; i++) {
+      const cell = join(work, `cell_${String(i + 1).padStart(3, "0")}.jpg`);
+      let vf = scalePad;
+      if (labeled && font) {
+        // label text is number + rounded seconds only (no ':'/',' — those are
+        // filtergraph separators; avoiding them means no escaping is needed).
+        const label = `${i + 1}  ${Math.round(seconds[i])}s`;
+        vf +=
+          `,drawtext=fontfile=${font}:text=${label}:x=10:y=10:` +
+          `fontsize=${fontSize}:fontcolor=white:box=1:boxcolor=black@0.6:boxborderw=6`;
+      }
+      await execFileP(
+        FFMPEG_PATH,
+        ["-y", "-ss", String(seconds[i]), "-i", input, "-frames:v", "1", "-q:v", "3", "-vf", vf, cell],
+        { maxBuffer: 16 * 1024 * 1024 },
+      );
+    }
+    // pad the last row so `tile` receives an exact cols×rows sequence — the
+    // partial-tile-at-EOF behavior varies across ffmpeg versions; a full grid is
+    // deterministic. Fillers reuse the tile background color.
+    if (n < slots) {
+      const filler = join(work, "filler.jpg");
+      await execFileP(
+        FFMPEG_PATH,
+        ["-y", "-f", "lavfi", "-i", `color=c=0x101418:s=${cellWidth}x${cellHeight}`, "-frames:v", "1", filler],
+        { maxBuffer: 8 * 1024 * 1024 },
+      );
+      for (let i = n; i < slots; i++) {
+        copyFileSync(filler, join(work, `cell_${String(i + 1).padStart(3, "0")}.jpg`));
+      }
+    }
+    await execFileP(
+      FFMPEG_PATH,
+      [
+        "-y", "-framerate", "1", "-i", join(work, "cell_%03d.jpg"),
+        "-frames:v", "1", "-vf", `tile=${cols}x${rows}:padding=6:margin=6:color=0x101418`, out,
+      ],
+      { maxBuffer: 64 * 1024 * 1024 },
+    );
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+
+  return {
+    output: out,
+    cells: seconds.map((at, i) => ({ n: i + 1, at })),
+    cols,
+    rows,
+    cellWidth,
+    cellHeight,
+    labeled,
+  };
+}
+
+/** Filesystem-safe filename part. */
+function safeName(s: string): string {
+  return s.replace(/[^a-z0-9_.-]+/gi, "_").replace(/^_+|_+$/g, "").slice(0, 80) || "grid";
 }
 
 /** Render an audio spectrogram to a PNG via ffmpeg's native showspectrumpic. */

--- a/src/media/ffmpeg.ts
+++ b/src/media/ffmpeg.ts
@@ -8,6 +8,7 @@ import { dirname, join, extname, basename } from "node:path";
 import { existsSync, mkdirSync, mkdtempSync, copyFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { promisify } from "node:util";
 
 const execFileP = promisify(execFile);
@@ -318,7 +319,11 @@ export async function contactSheet(
   const fontSize = clampInt(cellWidth / 14, 14, 40);
 
   const base = basename(input, extname(input));
-  const out = opts.outPath ?? join(outDir, `${safeName(base)}_grid_${n}.png`);
+  // include a hash of the actual samples + layout so two grids of the same clip
+  // with the same frame count but different windows/--at lists don't reuse (and
+  // overwrite) one path — which would strand earlier records on a stale montage.
+  const sig = shortHash({ seconds, cols, cellWidth, cellHeight, labeled });
+  const out = opts.outPath ?? join(outDir, `${safeName(base)}_grid_${n}_${sig}.png`);
   ensureDir(dirname(out)); // a caller-supplied nested --out needs its parent created first
   const work = mkdtempSync(join(tmpdir(), "oc-grid-"));
   try {
@@ -383,6 +388,14 @@ export async function contactSheet(
 /** Filesystem-safe filename part. */
 function safeName(s: string): string {
   return s.replace(/[^a-z0-9_.-]+/gi, "_").replace(/^_+|_+$/g, "").slice(0, 80) || "grid";
+}
+
+/** Short deterministic content hash for a collision-free default output name:
+ *  same inputs → same name (idempotent), different inputs → different name (so a
+ *  second run with a different window/op set can't overwrite the first's file and
+ *  leave an earlier record pointing at a montage/output that no longer matches). */
+function shortHash(parts: unknown): string {
+  return createHash("sha1").update(JSON.stringify(parts)).digest("hex").slice(0, 10);
 }
 
 /** Escape a value (e.g. a font path) for an ffmpeg filtergraph option: backslash
@@ -490,8 +503,12 @@ export async function enhance(
   }
 
   const ext = modality === "image" ? ".png" : extname(input) || ".mp4";
+  // key the default name on the applied ops so enhancing one file two different
+  // ways (e.g. grayscale then denoise) doesn't overwrite the first output and
+  // leave its record pointing at the wrong media — same ops still map to one file.
   const out =
-    outPath ?? join(ensureDir(outDir), `${basename(input, extname(input))}_enhanced${ext}`);
+    outPath ??
+    join(ensureDir(outDir), `${basename(input, extname(input))}_enhanced_${shortHash(applied)}${ext}`);
   ensureDir(dirname(out)); // a caller-supplied nested --out needs its parent created too
 
   const args = ["-y", "-i", input];

--- a/src/media/ffmpeg.ts
+++ b/src/media/ffmpeg.ts
@@ -318,6 +318,7 @@ export async function contactSheet(
 
   const base = basename(input, extname(input));
   const out = opts.outPath ?? join(outDir, `${safeName(base)}_grid_${n}.png`);
+  ensureDir(dirname(out)); // a caller-supplied nested --out needs its parent created first
   const work = mkdtempSync(join(tmpdir(), "oc-grid-"));
   try {
     const scalePad =
@@ -328,10 +329,12 @@ export async function contactSheet(
       let vf = scalePad;
       if (labeled && font) {
         // label text is number + rounded seconds only (no ':'/',' — those are
-        // filtergraph separators; avoiding them means no escaping is needed).
+        // filtergraph separators, so the text itself needs no escaping). The font
+        // path CAN contain them (a Windows `C:\...` or OVERCAST_GRID_FONT), so it
+        // must be escaped for the filtergraph.
         const label = `${i + 1}  ${Math.round(seconds[i])}s`;
         vf +=
-          `,drawtext=fontfile=${font}:text=${label}:x=10:y=10:` +
+          `,drawtext=fontfile=${escFilterValue(font)}:text=${label}:x=10:y=10:` +
           `fontsize=${fontSize}:fontcolor=white:box=1:boxcolor=black@0.6:boxborderw=6`;
       }
       await execFileP(
@@ -380,6 +383,18 @@ export async function contactSheet(
 /** Filesystem-safe filename part. */
 function safeName(s: string): string {
   return s.replace(/[^a-z0-9_.-]+/gi, "_").replace(/^_+|_+$/g, "").slice(0, 80) || "grid";
+}
+
+/** Escape a value (e.g. a font path) for an ffmpeg filtergraph option: backslash
+ *  first, then the ':' option / ',' filter separators and the "'" quote — so a
+ *  Windows `C:\Fonts\Arial.ttf` becomes `C\:\\Fonts\\Arial.ttf` instead of
+ *  splitting the drawtext options. */
+function escFilterValue(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/:/g, "\\:")
+    .replace(/,/g, "\\,")
+    .replace(/'/g, "\\'");
 }
 
 /** Render an audio spectrogram to a PNG via ffmpeg's native showspectrumpic. */
@@ -477,6 +492,7 @@ export async function enhance(
   const ext = modality === "image" ? ".png" : extname(input) || ".mp4";
   const out =
     outPath ?? join(ensureDir(outDir), `${basename(input, extname(input))}_enhanced${ext}`);
+  ensureDir(dirname(out)); // a caller-supplied nested --out needs its parent created too
 
   const args = ["-y", "-i", input];
   if (vFilters.length) args.push("-vf", vFilters.join(","));

--- a/src/media/ffmpeg.ts
+++ b/src/media/ffmpeg.ts
@@ -263,8 +263,9 @@ const clampInt = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi
 export interface GridCell {
   /** 1-based cell number, left-to-right then top-to-bottom */
   n: number;
-  /** source timestamp (seconds) this cell was sampled from */
-  at: number;
+  /** source timestamp (seconds) this cell was sampled from, or null for a blank
+   *  padding tile that fills out the last row (so every tile position maps). */
+  at: number | null;
 }
 
 export interface ContactSheetResult {
@@ -369,15 +370,14 @@ export async function contactSheet(
     rmSync(work, { recursive: true, force: true });
   }
 
-  return {
-    output: out,
-    cells: seconds.map((at, i) => ({ n: i + 1, at })),
-    cols,
-    rows,
-    cellWidth,
-    cellHeight,
-    labeled,
-  };
+  // map EVERY tile position (cols×rows), not just the sampled ones — the trailing
+  // blank fillers get at:null, so a cell number read off the montage always
+  // resolves (to a timestamp, or to null = blank) instead of falling off the map.
+  const cells: GridCell[] = Array.from({ length: slots }, (_, i) => ({
+    n: i + 1,
+    at: i < n ? seconds[i] : null,
+  }));
+  return { output: out, cells, cols, rows, cellWidth, cellHeight, labeled };
 }
 
 /** Filesystem-safe filename part. */

--- a/src/media/ffmpeg.ts
+++ b/src/media/ffmpeg.ts
@@ -508,6 +508,22 @@ export interface FrameRef {
   second: number;
 }
 
+/** Parse a seek/timestamp value: plain seconds ("42", "42.5") or a timecode
+ *  ("1:02", "1:02:14"). Returns undefined for anything unparseable or negative —
+ *  the single implementation shared by `grid` window flags and `view --at` so the
+ *  two can't disagree on a malformed string. */
+export function parseTimecode(s: string): number | undefined {
+  const str = s.trim();
+  if (!str) return undefined;
+  if (str.includes(":")) {
+    const parts = str.split(":").map((p) => Number(p));
+    if (parts.some((p) => !Number.isFinite(p) || p < 0)) return undefined;
+    return parts.reduce((acc, p) => acc * 60 + p, 0);
+  }
+  const n = Number(str);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
 /** Parse a `frame://rec_xxx@134` reference. Returns null if not a frame ref. */
 export function parseFrameRef(ref: string): FrameRef | null {
   const m = ref.match(/^frame:\/\/([^@]+)@(\d+(?:\.\d+)?)$/);

--- a/src/record.ts
+++ b/src/record.ts
@@ -59,6 +59,7 @@ export const META_VERBS: ReadonlySet<string> = new Set(["ask", "brief", "case"])
 export const OPERATIONAL_VERBS: ReadonlySet<string> = new Set([
   "collection",
   "doctor",
+  "grid",
   "index",
   "prebrief",
   "provider",

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -13,6 +13,7 @@ import { imageVerb } from "../verbs/image.js";
 import { clusterVerb } from "../verbs/cluster.js";
 import { similarVerb } from "../verbs/similar.js";
 import { cropVerb } from "../verbs/crop.js";
+import { gridVerb } from "../verbs/grid.js";
 import { wallVerb } from "../verbs/wall.js";
 import { resolveVideoArg } from "../verbs/media-ref.js";
 import {
@@ -97,6 +98,7 @@ export const VERBS: VerbSpec[] = [
   enhanceVerb,
   viewVerb,
   cropVerb,
+  gridVerb,
   wallVerb,
   scanVerb,
   captureVerb,

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -896,22 +896,23 @@ overcast see frame://REC@<hi> --prompt "Is <predicate> true? answer only yes or 
 
 \\\`\\\`\\\`bash
 overcast see frame://REC@<mid> --prompt "Is <predicate> true? answer only yes or no" --json
-# yes at mid  -> the flip is in [lo, mid]; no at mid -> it's in [mid, hi]
+# keep the straddling half: if mid's answer == lo's answer, set lo=mid; else hi=mid
+# (correct whichever way it flips — false->true OR true->false)
 \\\`\\\`\\\`
 
 4. Report the transition window and show it:
 
 \\\`\\\`\\\`bash
-overcast note "<predicate> becomes true" --ref REC --at <lastFalse-firstTrue> --confidence high --json
-overcast view REC --at <lastFalse-firstTrue> --json
+overcast note "<predicate> flips" --ref REC --at <lo-hi> --confidence high --json
+overcast view REC --at <lo-hi> --json
 overcast brief --export ./transition.md --json
 \\\`\\\`\\\`
 
 ## Output
 
-The bracket \`[last-false, first-true]\`, the two \`see\` frames that straddle it
-(their \`record.id\`s + \`media.at\`), and the call count. That bracket IS the
-answer window — don't over-claim a single frame.
+The converged \`[lo, hi]\` bracket — the two adjacent \`see\` frames that straddle
+the flip (their \`record.id\`s + \`media.at\`) — and the call count. That bracket IS
+the answer window — don't over-claim a single frame.
 
 ## Caveats
 

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -821,6 +821,9 @@ overcast see <montage-path> --prompt "Which numbered cells show <X>? Reply with 
 - If the grid record's \`payload.labeled\` is \`false\` (this ffmpeg build has no
   \`drawtext\`), tell \`see\` it's a \`<cols>\`-column grid numbered left-to-right,
   top-to-bottom (\`cols\` is in the record), so it can reference cells by position.
+- Only the first \`count\` cells hold frames; the last row may be blank padding
+  (those \`payload.cells[].at\` are \`null\`), so have \`see\` pick from 1..\`count\`
+  and ignore blank tiles.
 - Always map the chosen cell number back through \`payload.cells[n].at\` to get the
   real timestamp — never use a time the model typed out.
 

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -707,3 +707,353 @@ correspondences vs lines collapsing to a point). Call a video a confirmed rip
 only when the gated match survives AND the transcript/face agree.
 `;
 }
+
+/** Skill: pinpoint WHEN something happens — coarse→fine temporal search. */
+export function generatePinpointSkill(): string {
+  return `---
+name: overcast-pinpoint
+description: >-
+  Pinpoint WHEN a specific thing happens in a video — funnel from cheap
+  coarse candidates (shots / CLIP / grid) to a frame-verified time window.
+---
+
+# overcast-pinpoint
+
+Use this skill to answer "exactly when does X happen?" in a clip and back it
+with evidence the model actually looked at. It mirrors the temporal-search
+pattern from the VLM video literature (T\\* / VideoAgent): score cheaply over the
+whole clip, then spend expensive VLM calls only on a few candidate frames and
+zoom in. Use the broad \`overcast\` skill and \`overcast/reference/verbs.md\` for
+exact flags.
+
+Two rules that make the answer trustworthy:
+
+- **Report a window, not a frame.** Frame-exact localization is unreliable; emit
+  \`[t1-t2]\` plus one verified keyframe.
+- **Every timestamp must trace to a frame you \`see\`-verified.** Never emit a
+  time the model merely guessed — models answer correctly while grounding on the
+  wrong moment, so confirm by looking at the frame.
+
+## Workflow
+
+1. Make the clip local and get a record id (\`see frame://\` needs media on disk —
+   capture a remote clip first). \`watch\` also gives per-shot timestamped content
+   to search:
+
+\\\`\\\`\\\`bash
+overcast doctor --json
+overcast case init --json
+overcast watch ./clip.mp4 --json         # -> video.analysis record id (REC)
+\\\`\\\`\\\`
+
+2. Get COARSE candidates cheaply (pick what's available):
+
+\\\`\\\`\\\`bash
+overcast ask "moments where <X> happens, with timestamps" --json      # over watch shots/notes
+overcast grid ./clip.mp4 --count 16 --json                            # one contact sheet ...
+overcast see <montage-path> --prompt "which numbered cells show <X>? give cell numbers" --json
+overcast similar search "<X>" --index <basic-clip-id> --json          # if a local CLIP index exists
+overcast ask "moments <X> happens" --index <media-descriptions-id> --probe --json  # remote index
+\\\`\\\`\\\`
+
+   For \`grid\`, translate the chosen cell number to a time via the grid record's
+   \`payload.cells[n].at\` (don't trust a model-guessed time). CLIP/shots only
+   SHORTLIST — CLIP is weak on actions/order — so verify next.
+
+3. VERIFY + zoom on each candidate time T (expensive, precise):
+
+\\\`\\\`\\\`bash
+overcast see frame://REC@T --prompt "Is <X> happening here? answer yes/no and what you see" --json
+# refine: sample T-d and T+d, halve d each round until adjacent frames flip yes<->no
+overcast see frame://REC@<T-2> --prompt "Is <X> happening?" --json
+overcast see frame://REC@<T+2> --prompt "Is <X> happening?" --json
+\\\`\\\`\\\`
+
+4. Record the verified window and eyeball it:
+
+\\\`\\\`\\\`bash
+overcast note "<X> occurs" --ref REC --at <t1-t2> --confidence medium --json
+overcast view REC --at <t1-t2> --json
+overcast brief --export ./pinpoint.md --json
+\\\`\\\`\\\`
+
+## Output
+
+The tightest \`[t1-t2]\` window, the single \`see\` keyframe that confirms it (its
+\`record.id\`), and how it was found (shots / grid / CLIP / probe). Cite
+\`record.id\` + \`media.at\` for every claim; state the window, not a false-precise
+single frame.
+
+## Caveats
+
+Needs the video local (a URL-only \`watch\` record can't extract frames). CLIP and
+shot text shortlist but don't decide — the \`see\` frame check does. If \`X\` recurs,
+pinpoint each occurrence separately; don't collapse them into one window.
+`;
+}
+
+/** Skill: one-call contact-sheet triage over a clip (the grid trick). */
+export function generateFrameGridSkill(): string {
+  return `---
+name: overcast-frame-grid
+description: >-
+  Triage a whole clip in one VLM call — tile sampled frames into a labeled
+  contact sheet, ask which cells show the target, then zoom in.
+---
+
+# overcast-frame-grid
+
+Use this skill to find roughly WHERE in a clip something appears with a single
+vision call, before spending per-frame calls. It's the "grid trick" from
+temporal-search research (frames tiled into one image; Set-of-Mark numbering over
+time). Pairs with \`overcast-pinpoint\` for the frame-precise follow-up. Use the
+broad \`overcast\` skill and \`overcast/reference/verbs.md\` for exact flags.
+
+## Workflow
+
+\\\`\\\`\\\`bash
+overcast doctor --json
+overcast case init --json
+overcast grid ./clip.mp4 --count 16 --json     # -> media.grid: payload.montage + payload.cells + payload.cols
+overcast see <montage-path> --prompt "Which numbered cells show <X>? Reply with cell numbers and why." --json
+\\\`\\\`\\\`
+
+- If the grid record's \`payload.labeled\` is \`false\` (this ffmpeg build has no
+  \`drawtext\`), tell \`see\` it's a \`<cols>\`-column grid numbered left-to-right,
+  top-to-bottom (\`cols\` is in the record), so it can reference cells by position.
+- Always map the chosen cell number back through \`payload.cells[n].at\` to get the
+  real timestamp — never use a time the model typed out.
+
+Zoom in on the winning region (narrow the window, or hand the timestamp to
+\`overcast-pinpoint\`):
+
+\\\`\\\`\\\`bash
+overcast grid ./clip.mp4 --start <a> --end <b> --count 16 --json   # finer sheet around the hit
+overcast see frame://<watch-record>@<t> --prompt "Is <X> here? yes/no + detail" --json
+overcast note "<X> first visible" --ref <record> --at <t1-t2> --json
+overcast brief --export ./grid-triage.md --json
+\\\`\\\`\\\`
+
+Use \`--at "s1,s2,s3"\` instead of \`--count\` when you already have candidate
+timestamps to compare side by side; \`--start/--end\` to focus a window; \`--cols\`
+/ \`--width\` to shape the sheet.
+
+## Output
+
+The cell(s) that matched, the timestamp each maps to (via \`payload.cells\`), and
+the grid \`record.id\`. Treat grid hits as coarse (one frame per cell) — confirm
+the exact moment by \`see\`-ing that frame before citing it as evidence.
+
+## Caveats
+
+One contact sheet samples sparsely, so a brief event between cells can be missed —
+raise \`--count\` or re-grid a tighter \`--start/--end\`. The montage is a still, so
+motion/audio cues are gone; use \`watch\`/\`listen\` when those matter. Video can be
+local or a URL, but the \`see frame://\` zoom-in step needs it local.
+`;
+}
+
+/** Skill: bisect the exact instant of a monotone state change. */
+export function generateEventBisectSkill(): string {
+  return `---
+name: overcast-event-bisect
+description: >-
+  Localize the exact instant of a one-way state change (light on, door opens,
+  poster removed) by binary-searching frames — ~log2(N) VLM calls.
+---
+
+# overcast-event-bisect
+
+Use this skill when a video contains a single MONOTONE transition — a condition
+that is false before some instant and true after it (or vice versa), and does not
+flip back. Binary search finds it in about log2(window/precision) vision calls
+(~12 calls localizes to ~1s inside an hour). Use the broad \`overcast\` skill and
+\`overcast/reference/verbs.md\` for exact flags.
+
+## Workflow
+
+1. Local clip + record id (\`see frame://\` needs media on disk):
+
+\\\`\\\`\\\`bash
+overcast doctor --json
+overcast case init --json
+overcast watch ./clip.mp4 --json        # -> record id REC (also gives shot context)
+\\\`\\\`\\\`
+
+2. Confirm the transition is bracketed AND monotone — the two endpoints must
+   disagree on the predicate:
+
+\\\`\\\`\\\`bash
+overcast see frame://REC@<lo> --prompt "Is <predicate> true? answer only yes or no" --json
+overcast see frame://REC@<hi> --prompt "Is <predicate> true? answer only yes or no" --json
+\\\`\\\`\\\`
+
+   If both give the same answer, the flip isn't in \`[lo,hi]\`. If the predicate
+   toggles more than once, it isn't monotone — use \`overcast-pinpoint\` instead.
+
+3. Bisect: test the midpoint, keep the half that still straddles the flip, repeat
+   until \`hi - lo\` is within your precision:
+
+\\\`\\\`\\\`bash
+overcast see frame://REC@<mid> --prompt "Is <predicate> true? answer only yes or no" --json
+# yes at mid  -> the flip is in [lo, mid]; no at mid -> it's in [mid, hi]
+\\\`\\\`\\\`
+
+4. Report the transition window and show it:
+
+\\\`\\\`\\\`bash
+overcast note "<predicate> becomes true" --ref REC --at <lastFalse-firstTrue> --confidence high --json
+overcast view REC --at <lastFalse-firstTrue> --json
+overcast brief --export ./transition.md --json
+\\\`\\\`\\\`
+
+## Output
+
+The bracket \`[last-false, first-true]\`, the two \`see\` frames that straddle it
+(their \`record.id\`s + \`media.at\`), and the call count. That bracket IS the
+answer window — don't over-claim a single frame.
+
+## Caveats
+
+Bisection is only valid for a one-way change; a light that blinks or a person who
+comes and goes will mislead it — verify monotonicity at step 2, and fall back to
+\`overcast-pinpoint\` (peak search) or \`overcast-presence-window\` for recurring or
+interval events. Needs the video local.
+`;
+}
+
+/** Skill: locate WHERE in the frame — detector-propose, VLM-verify. */
+export function generateWhereSkill(): string {
+  return `---
+name: overcast-where
+description: >-
+  Locate WHERE in a frame a target is — open-vocab detect, crop the box, then
+  VLM-verify the crop so hallucinated boxes don't survive.
+---
+
+# overcast-where
+
+Use this skill to turn a moment into spatial evidence: a bounding box on the
+target plus a verified crop. It follows the detector-proposes / VLM-verifies
+pattern (open-vocab detection like OWLv2, then confirm the crop) — because chat
+VLMs are unreliable at emitting raw coordinates, so a real detector draws the box
+and the VLM only judges the crop. Use the broad \`overcast\` skill and
+\`overcast/reference/verbs.md\` for exact flags.
+
+## Setup
+
+\`see --detect\` needs a detection provider bound (boxes come from OWLv2, not the
+brain LLM):
+
+\\\`\\\`\\\`bash
+overcast setup provider see "exec:python3 examples/providers/detect/detect.py" --json
+# or the catalog: overcast provider setup apply --preset owl-local --yes --json
+\\\`\\\`\\\`
+
+## Workflow
+
+1. Have the moment (use \`overcast-pinpoint\` / \`overcast-frame-grid\`): timestamp
+   T on record REC.
+
+2. Detect the target in that frame, then materialize + verify the box:
+
+\\\`\\\`\\\`bash
+overcast see frame://REC@T --detect "<target phrase>" --json      # -> see record with detections[]
+overcast crop <see-record-id> --all --class "<target phrase>" --pad 0.15 --json
+overcast see <crop-path> --prompt "Does this crop show <target>? yes/no + describe" --json
+\\\`\\\`\\\`
+
+   The re-\`see\` of each crop is what kills false positives — open-vocab detectors
+   emit confident boxes for almost any phrase at low thresholds.
+
+3. Optionally sharpen the exhibit and record the finding:
+
+\\\`\\\`\\\`bash
+overcast enhance <crop-path> --ops upscale,denoise --json
+overcast finding create "<target> located at T" --ref <see-record-id> --confidence medium --json
+overcast brief --export ./where.md --json
+\\\`\\\`\\\`
+
+## Output
+
+Per confirmed target: the timestamp, the box (from the \`see --detect\` record),
+the crop path, and the verification verdict. Cite the \`see\` detection
+\`record.id\` + \`media.at\`; note the crop is the durable, memory-friendly evidence
+artifact.
+
+## Caveats
+
+Never ask the brain LLM for coordinates directly — bind a detector and verify
+crops. Detector confidence is not calibrated across free-form phrases: a high
+score on a rare phrase can still be wrong, so the crop re-check decides. For a
+specific PERSON, use \`face --match\` instead of \`--detect\`. Boxes are per sampled
+frame, not tracks.
+`;
+}
+
+/** Skill: first/last appearance interval by sweeping outward from an anchor. */
+export function generatePresenceWindowSkill(): string {
+  return `---
+name: overcast-presence-window
+description: >-
+  Find the interval a person or object is present — anchor one appearance, then
+  sweep outward with face-match / detect until it drops off both sides.
+---
+
+# overcast-presence-window
+
+Use this skill to answer "from when to when is <target> on screen?" — a first/last
+appearance interval, not a single instant. It anchors one confirmed appearance and
+expands until the target stops appearing, the presence-tracking analog of a
+temporal search. Use the broad \`overcast\` skill and
+\`overcast/reference/verbs.md\` for exact flags.
+
+## Workflow
+
+1. Local clip + record id:
+
+\\\`\\\`\\\`bash
+overcast doctor --json
+overcast case init --json
+overcast watch ./clip.mp4 --json        # -> record id REC
+\\\`\\\`\\\`
+
+2. Anchor one appearance (whichever fits the target):
+
+\\\`\\\`\\\`bash
+overcast face ./clip.mp4 --match ./person.jpg --json          # a specific person (similarity 0-100)
+overcast grid ./clip.mp4 --count 16 --json                    # then see the montage for an object
+\\\`\\\`\\\`
+
+3. Sweep outward from the anchor until K consecutive misses on each side:
+
+\\\`\\\`\\\`bash
+# person: widen the window; --fps controls sample density (precision vs cost)
+overcast face ./clip.mp4 --match ./person.jpg --start <a> --end <b> --fps 1 --min-similarity 55 --json
+# object: step frames outward and check presence
+overcast see frame://REC@<t> --prompt "Is <target> present? answer only yes or no" --json
+\\\`\\\`\\\`
+
+4. Emit the presence interval(s) and show them:
+
+\\\`\\\`\\\`bash
+overcast note "<target> present" --ref REC --at <first-last> --confidence medium --json
+overcast view REC --at <first-last> --json
+overcast brief --export ./presence.md --json
+\\\`\\\`\\\`
+
+## Output
+
+One or more \`[first-last]\` intervals with the per-hit citations (\`record.id\` +
+\`media.at\`) that bound them, and the sample density used. If the target leaves
+and returns, report each interval separately rather than one span covering the
+gap.
+
+## Caveats
+
+Sampled detections are per-frame, not continuous — presence between samples is
+inferred; raise \`--fps\` to tighten boundaries at higher cost. Occlusion or an
+off-camera moment splits one presence into several intervals — that's a real
+result, not noise. Face similarity is 0-100. Needs the video local.
+`;
+}

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -839,7 +839,10 @@ overcast brief --export ./grid-triage.md --json
 
 Use \`--at "s1,s2,s3"\` instead of \`--count\` when you already have candidate
 timestamps to compare side by side; \`--start/--end\` to focus a window; \`--cols\`
-/ \`--width\` to shape the sheet.
+/ \`--width\` to shape the sheet. Add \`--view\` (\`--no-open\` in a headless run) to
+also write a clickable HTML board — numbered, timestamped cells that seek the
+source clip — for eyeballing the sheet by hand; the montage PNG stays the input
+you hand to \`see\`.
 
 ## Output
 

--- a/src/verbs/grid.ts
+++ b/src/verbs/grid.ts
@@ -8,26 +8,13 @@
 
 import { basename, join } from "node:path";
 import { makeRecord, type OvercastRecord } from "../record.js";
-import { contactSheet, probe } from "../media/ffmpeg.js";
+import { contactSheet, probe, parseTimecode } from "../media/ffmpeg.js";
 import { resolveVideoArg } from "./media-ref.js";
 import { badNumber } from "./validate.js";
 import type { VerbSpec } from "../registry/types.js";
 
 function err(message: string): OvercastRecord {
   return makeRecord({ verb: "grid", format: "json", payload: { error: message }, error: message, state: "error" });
-}
-
-/** Parse a seek value: plain seconds ("42", "42.5") or a timecode ("1:02", "1:02:14"). */
-function parseTimecode(s: string): number | undefined {
-  const str = s.trim();
-  if (!str) return undefined;
-  if (str.includes(":")) {
-    const parts = str.split(":").map((p) => Number(p));
-    if (parts.some((p) => !Number.isFinite(p) || p < 0)) return undefined;
-    return parts.reduce((acc, p) => acc * 60 + p, 0);
-  }
-  const n = Number(str);
-  return Number.isFinite(n) && n >= 0 ? n : undefined;
 }
 
 const MAX_CELLS = 64;
@@ -62,12 +49,15 @@ export const gridVerb: VerbSpec = {
   run: async (ctx) => {
     if (!ctx.input) return [err("grid requires a video input (path or record id)")];
     const numErr =
-      badNumber(ctx.opts, "cols", (n) => n >= 1 && n <= 12, "1–12") ??
+      // count/cols set array lengths + the grid shape, so they must be whole
+      // numbers — a fractional count truncates the samples while the step math
+      // still divides by the float, skewing the window.
+      badNumber(ctx.opts, "cols", (n) => Number.isInteger(n) && n >= 1 && n <= 12, "a whole number 1–12") ??
       badNumber(ctx.opts, "width", (n) => n >= 120 && n <= 960, "120–960") ??
       // --count only drives window sampling; an explicit --at overrides it, so
       // don't reject a count the user isn't actually using.
       (ctx.opts.at == null
-        ? badNumber(ctx.opts, "count", (n) => n >= 1 && n <= MAX_CELLS, `1–${MAX_CELLS}`)
+        ? badNumber(ctx.opts, "count", (n) => Number.isInteger(n) && n >= 1 && n <= MAX_CELLS, `a whole number 1–${MAX_CELLS}`)
         : undefined);
     if (numErr) return [err(numErr)];
 
@@ -75,6 +65,14 @@ export const gridVerb: VerbSpec = {
     const resolved = resolveVideoArg(ctx.case, ctx.input, "grid input", { requireReady: false });
     if (resolved.error) return [err(resolved.error)];
     const input = resolved.ref ?? ctx.input;
+
+    // grid tiles VIDEO frames — reject audio-only media that passes the AV gate
+    // (resolveVideoArg accepts audio too). Probe once here and reuse it for the
+    // window duration below. Lenient on a probe failure (proceed rather than block).
+    const probed = await probe(input).catch(() => undefined);
+    if (probed && !probed.hasVideo) {
+      return [err(`grid needs a video — ${basename(input)} has no video stream`)];
+    }
 
     // decide the timestamps: explicit --at wins; otherwise sample the window.
     let seconds: number[];
@@ -97,8 +95,7 @@ export const gridVerb: VerbSpec = {
       let end = ctx.opts.end != null ? parseTimecode(String(ctx.opts.end)) : undefined;
       if (ctx.opts.end != null && end === undefined) return [err(`invalid --end: ${ctx.opts.end}`)];
       if (end === undefined) {
-        const p = await probe(input).catch(() => undefined);
-        end = p?.durationSeconds;
+        end = probed?.durationSeconds;
         if (end === undefined) {
           return [err("could not read video duration — pass --end or an explicit --at list")];
         }

--- a/src/verbs/grid.ts
+++ b/src/verbs/grid.ts
@@ -48,6 +48,10 @@ export const gridVerb: VerbSpec = {
   providerKey: "grid",
   run: async (ctx) => {
     if (!ctx.input) return [err("grid requires a video input (path or record id)")];
+    // one notion of "is --at in use" for BOTH the validation gate and the branch
+    // below — a `--at=` (empty string) is not null but is falsy, so keying the two
+    // off different checks let an unvalidated --count slip into window sampling.
+    const hasAt = typeof ctx.opts.at === "string" && ctx.opts.at.trim() !== "";
     const numErr =
       // count/cols set array lengths + the grid shape, so they must be whole
       // numbers — a fractional count truncates the samples while the step math
@@ -56,9 +60,9 @@ export const gridVerb: VerbSpec = {
       badNumber(ctx.opts, "width", (n) => n >= 120 && n <= 960, "120–960") ??
       // --count only drives window sampling; an explicit --at overrides it, so
       // don't reject a count the user isn't actually using.
-      (ctx.opts.at == null
-        ? badNumber(ctx.opts, "count", (n) => Number.isInteger(n) && n >= 1 && n <= MAX_CELLS, `a whole number 1–${MAX_CELLS}`)
-        : undefined);
+      (hasAt
+        ? undefined
+        : badNumber(ctx.opts, "count", (n) => Number.isInteger(n) && n >= 1 && n <= MAX_CELLS, `a whole number 1–${MAX_CELLS}`));
     if (numErr) return [err(numErr)];
 
     // accept a path / URL / case record id, and validate it's real AV media.
@@ -75,9 +79,10 @@ export const gridVerb: VerbSpec = {
     }
 
     // decide the timestamps: explicit --at wins; otherwise sample the window.
+    const dur = probed?.durationSeconds; // known clip length, or undefined
     let seconds: number[];
     let window: { start: number; end: number } | undefined;
-    if (ctx.opts.at) {
+    if (hasAt) {
       const parts = String(ctx.opts.at).split(",").map((s) => parseTimecode(s));
       if (parts.some((p) => p === undefined)) {
         return [err(`invalid --at: ${ctx.opts.at} (use comma-separated SS or MM:SS)`)];
@@ -89,16 +94,28 @@ export const gridVerb: VerbSpec = {
       if (seconds.length > MAX_CELLS) {
         return [err(`too many --at timestamps (${seconds.length}); max ${MAX_CELLS}`)];
       }
+      // a --at past EOF would extract a repeated last frame while cells[].at still
+      // claims that (never-sampled) second — reject it instead of lying.
+      if (dur !== undefined) {
+        const past = seconds.filter((t) => t > dur);
+        if (past.length) {
+          return [err(`--at past the video duration (${dur.toFixed(1)}s): ${past.join(", ")}`)];
+        }
+      }
     } else {
       const start = ctx.opts.start != null ? parseTimecode(String(ctx.opts.start)) : 0;
       if (start === undefined) return [err(`invalid --start: ${ctx.opts.start}`)];
       let end = ctx.opts.end != null ? parseTimecode(String(ctx.opts.end)) : undefined;
       if (ctx.opts.end != null && end === undefined) return [err(`invalid --end: ${ctx.opts.end}`)];
       if (end === undefined) {
-        end = probed?.durationSeconds;
+        end = dur;
         if (end === undefined) {
           return [err("could not read video duration — pass --end or an explicit --at list")];
         }
+      } else if (dur !== undefined && end > dur) {
+        // never sample past EOF — clamp an over-long --end to the real clip length
+        // so midpoints stay inside the video (and cells[].at stays truthful).
+        end = dur;
       }
       if (!(end > start)) return [err(`empty window: --start ${start} is not before --end ${end}`)];
       const count = ctx.opts.count != null ? Number(ctx.opts.count) : 16;
@@ -115,23 +132,26 @@ export const gridVerb: VerbSpec = {
         outPath: ctx.opts.out ? String(ctx.opts.out) : undefined,
       });
       const grid = `${sheet.cols}x${sheet.rows}`;
+      const blanks = sheet.cells.length - seconds.length; // trailing padding tiles
       return [
         makeRecord({
           verb: "grid",
           format: "json",
           payload: {
             summary:
-              `contact sheet: ${sheet.cells.length} frames from ${basename(input)} ` +
-              `(${grid}${sheet.labeled ? ", labeled" : ", unlabeled — cells numbered left-to-right, top-to-bottom"})`,
+              `contact sheet: ${seconds.length} frames from ${basename(input)} ` +
+              `(${grid}${blanks > 0 ? `, last ${blanks} cell(s) blank` : ""}` +
+              `${sheet.labeled ? ", labeled" : ", unlabeled — cells numbered left-to-right, top-to-bottom"})`,
             source: input,
             source_record: resolved.recordId,
             montage: sheet.output,
             grid,
             cols: sheet.cols,
             rows: sheet.rows,
-            count: sheet.cells.length,
+            count: seconds.length,
             labeled: sheet.labeled,
             window,
+            // full tile map (cols×rows); entries with at:null are blank padding.
             cells: sheet.cells,
           },
           media: { ref: sheet.output },

--- a/src/verbs/grid.ts
+++ b/src/verbs/grid.ts
@@ -1,0 +1,140 @@
+// `grid` verb: tile timestamped video frames into ONE labeled contact sheet for a
+// single-call VLM triage pass (the "grid trick" — temporal search reframed as
+// spatial search, per T*/LV-Haystack, plus Set-of-Mark numbering over time). The
+// emitted media.grid record's media.ref is the montage image and payload.cells is
+// the exact cell-number → timestamp map, so a follow-up
+// `see <montage> --prompt "which numbered cell shows X?"` answer can be translated
+// straight back to a source time. Pure internal ffmpeg (invariant #7), like crop.
+
+import { basename, join } from "node:path";
+import { makeRecord, type OvercastRecord } from "../record.js";
+import { contactSheet, probe } from "../media/ffmpeg.js";
+import { resolveVideoArg } from "./media-ref.js";
+import { badNumber } from "./validate.js";
+import type { VerbSpec } from "../registry/types.js";
+
+function err(message: string): OvercastRecord {
+  return makeRecord({ verb: "grid", format: "json", payload: { error: message }, error: message, state: "error" });
+}
+
+/** Parse a seek value: plain seconds ("42", "42.5") or a timecode ("1:02", "1:02:14"). */
+function parseTimecode(s: string): number | undefined {
+  const str = s.trim();
+  if (!str) return undefined;
+  if (str.includes(":")) {
+    const parts = str.split(":").map((p) => Number(p));
+    if (parts.some((p) => !Number.isFinite(p) || p < 0)) return undefined;
+    return parts.reduce((acc, p) => acc * 60 + p, 0);
+  }
+  const n = Number(str);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+const MAX_CELLS = 64;
+
+export const gridVerb: VerbSpec = {
+  name: "grid",
+  group: "inspect",
+  summary: "Tile timestamped video frames into a labeled contact sheet for one-shot VLM triage.",
+  description:
+    "Samples frames from a video — uniformly across a --start/--end window (default the whole clip, " +
+    "--count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image " +
+    "via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has " +
+    "drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a " +
+    "media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact " +
+    "timestamp. Chain it: `overcast see <montage-path> --prompt \"which numbered cell best shows X? give the " +
+    "cell number\"` then read payload.cells to recover the source time — one VLM call triages a long clip " +
+    "before a frame-precise zoom-in (see frame://<record>@<sec>).",
+  args: [{ name: "input", summary: "Video file path or case record id", required: true }],
+  flags: [
+    { name: "count", summary: "Number of frames to sample across the window (default 16)", type: "number" },
+    { name: "at", summary: "Explicit comma list of timestamps (SS or MM:SS), overrides --count/window", type: "string" },
+    { name: "start", summary: "Window start (SS or MM:SS)", type: "string" },
+    { name: "end", summary: "Window end (SS or MM:SS)", type: "string" },
+    { name: "cols", summary: "Grid columns (default ceil(sqrt(count)), max 12)", type: "number" },
+    { name: "width", summary: "Cell width in px (default 320)", type: "number" },
+    { name: "out", summary: "Output image path (default .overcast/media/)", type: "string" },
+    { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },
+    { name: "json", summary: "Shorthand for --format json", type: "boolean" },
+  ],
+  outputKind: "media.grid",
+  providerKey: "grid",
+  run: async (ctx) => {
+    if (!ctx.input) return [err("grid requires a video input (path or record id)")];
+    const numErr =
+      badNumber(ctx.opts, "count", (n) => n >= 1 && n <= MAX_CELLS, `1–${MAX_CELLS}`) ??
+      badNumber(ctx.opts, "cols", (n) => n >= 1 && n <= 12, "1–12") ??
+      badNumber(ctx.opts, "width", (n) => n >= 120 && n <= 960, "120–960");
+    if (numErr) return [err(numErr)];
+
+    // accept a path / URL / case record id, and validate it's real AV media.
+    const resolved = resolveVideoArg(ctx.case, ctx.input, "grid input", { requireReady: false });
+    if (resolved.error) return [err(resolved.error)];
+    const input = resolved.ref ?? ctx.input;
+
+    // decide the timestamps: explicit --at wins; otherwise sample the window.
+    let seconds: number[];
+    let window: { start: number; end: number } | undefined;
+    if (ctx.opts.at) {
+      const parts = String(ctx.opts.at).split(",").map((s) => parseTimecode(s));
+      if (parts.some((p) => p === undefined)) {
+        return [err(`invalid --at: ${ctx.opts.at} (use comma-separated SS or MM:SS)`)];
+      }
+      seconds = [...new Set(parts as number[])].sort((a, b) => a - b).slice(0, MAX_CELLS);
+      if (!seconds.length) return [err("--at listed no valid timestamps")];
+    } else {
+      const start = ctx.opts.start != null ? parseTimecode(String(ctx.opts.start)) : 0;
+      if (start === undefined) return [err(`invalid --start: ${ctx.opts.start}`)];
+      let end = ctx.opts.end != null ? parseTimecode(String(ctx.opts.end)) : undefined;
+      if (ctx.opts.end != null && end === undefined) return [err(`invalid --end: ${ctx.opts.end}`)];
+      if (end === undefined) {
+        const p = await probe(input).catch(() => undefined);
+        end = p?.durationSeconds;
+        if (end === undefined) {
+          return [err("could not read video duration — pass --end or an explicit --at list")];
+        }
+      }
+      if (!(end > start)) return [err(`empty window: --start ${start} is not before --end ${end}`)];
+      const count = ctx.opts.count != null ? Number(ctx.opts.count) : 16;
+      const step = (end - start) / count;
+      // sample the MIDPOINT of each segment so we never hit an all-black first/last frame.
+      seconds = Array.from({ length: count }, (_, i) => Number((start + (i + 0.5) * step).toFixed(3)));
+      window = { start, end };
+    }
+
+    try {
+      const sheet = await contactSheet(input, seconds, ctx.case.mediaDir, {
+        cols: ctx.opts.cols != null ? Number(ctx.opts.cols) : undefined,
+        cellWidth: ctx.opts.width != null ? Number(ctx.opts.width) : undefined,
+        outPath: ctx.opts.out ? String(ctx.opts.out) : undefined,
+      });
+      const grid = `${sheet.cols}x${sheet.rows}`;
+      return [
+        makeRecord({
+          verb: "grid",
+          format: "json",
+          payload: {
+            summary:
+              `contact sheet: ${sheet.cells.length} frames from ${basename(input)} ` +
+              `(${grid}${sheet.labeled ? ", labeled" : ", unlabeled — cells numbered left-to-right, top-to-bottom"})`,
+            source: input,
+            source_record: resolved.recordId,
+            montage: sheet.output,
+            grid,
+            cols: sheet.cols,
+            rows: sheet.rows,
+            count: sheet.cells.length,
+            labeled: sheet.labeled,
+            window,
+            cells: sheet.cells,
+          },
+          media: { ref: sheet.output },
+          meta: { provider: "ffmpeg", case: ctx.case.dir },
+          state: "ready",
+        }),
+      ];
+    } catch (e) {
+      return [err(`grid failed: ${(e as Error).message}`)];
+    }
+  },
+};

--- a/src/verbs/grid.ts
+++ b/src/verbs/grid.ts
@@ -7,8 +7,11 @@
 // straight back to a source time. Pure internal ffmpeg (invariant #7), like crop.
 
 import { basename, join } from "node:path";
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { makeRecord, type OvercastRecord } from "../record.js";
-import { contactSheet, probe, parseTimecode } from "../media/ffmpeg.js";
+import { contactSheet, probe, parseTimecode, type GridCell } from "../media/ffmpeg.js";
+import { openHtmlPlayer } from "../media/view.js";
 import { resolveVideoArg } from "./media-ref.js";
 import { badNumber } from "./validate.js";
 import type { VerbSpec } from "../registry/types.js";
@@ -31,7 +34,9 @@ export const gridVerb: VerbSpec = {
     "media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact " +
     "timestamp. Chain it: `overcast see <montage-path> --prompt \"which numbered cell best shows X? give the " +
     "cell number\"` then read payload.cells to recover the source time — one VLM call triages a long clip " +
-    "before a frame-precise zoom-in (see frame://<record>@<sec>).",
+    "before a frame-precise zoom-in (see frame://<record>@<sec>). Add --view for a clickable HTML contact " +
+    "sheet (cells labeled with their timestamp even when ffmpeg can't burn labels, each seeking the source " +
+    "video on click); --no-open writes it without launching.",
   args: [{ name: "input", summary: "Video file path or case record id", required: true }],
   flags: [
     { name: "count", summary: "Number of frames to sample across the window (default 16)", type: "number" },
@@ -41,6 +46,8 @@ export const gridVerb: VerbSpec = {
     { name: "cols", summary: "Grid columns (default ceil(sqrt(count)), max 12)", type: "number" },
     { name: "width", summary: "Cell width in px (default 320)", type: "number" },
     { name: "out", summary: "Output image path (default .overcast/media/)", type: "string" },
+    { name: "view", summary: "Also render a clickable HTML contact sheet (numbered cells seek the source video)", type: "boolean" },
+    { name: "no-open", summary: "With --view, write the HTML board but don't launch it", type: "boolean" },
     { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],
@@ -133,6 +140,33 @@ export const gridVerb: VerbSpec = {
       });
       const grid = `${sheet.cols}x${sheet.rows}`;
       const blanks = sheet.cells.length - seconds.length; // trailing padding tiles
+
+      // --view: render the human-facing counterpart to the VLM-facing PNG — a
+      // clickable HTML board that labels every cell with its number + timestamp
+      // (in CSS, so labels show even when this ffmpeg lacks drawtext) and seeks
+      // the source video on click. Opens unless --no-open (like `view`).
+      let viewPath: string | undefined;
+      let opened = false;
+      if (ctx.opts.view) {
+        viewPath = sheet.output.replace(/\.png$/i, "") + "_board.html";
+        const html = buildGridHtml({
+          montage: sheet.output,
+          video: input,
+          videoIsRemote: /^https?:\/\//i.test(input),
+          cells: sheet.cells,
+          cols: sheet.cols,
+          rows: sheet.rows,
+          cellWidth: sheet.cellWidth,
+          cellHeight: sheet.cellHeight,
+          title: basename(input),
+        });
+        writeFileSync(viewPath, html, "utf8");
+        if (ctx.opts["no-open"] !== true) {
+          openHtmlPlayer(viewPath);
+          opened = true;
+        }
+      }
+
       return [
         makeRecord({
           verb: "grid",
@@ -153,6 +187,7 @@ export const gridVerb: VerbSpec = {
             window,
             // full tile map (cols×rows); entries with at:null are blank padding.
             cells: sheet.cells,
+            ...(viewPath ? { view: viewPath, opened } : {}),
           },
           media: { ref: sheet.output },
           meta: { provider: "ffmpeg", case: ctx.case.dir },
@@ -164,3 +199,100 @@ export const gridVerb: VerbSpec = {
     }
   },
 };
+
+// --- HTML contact-sheet board (the --view render) ---------------------------
+
+interface GridHtmlOpts {
+  montage: string;
+  video: string;
+  videoIsRemote: boolean;
+  cells: GridCell[];
+  cols: number;
+  rows: number;
+  cellWidth: number;
+  cellHeight: number;
+  title: string;
+}
+
+/** Escape for HTML text content. */
+function htmlText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+/** Escape for a double-quoted HTML attribute. */
+function htmlAttr(s: string): string {
+  return htmlText(s).replace(/"/g, "&quot;");
+}
+/** Whole seconds → M:SS (labels); the exact seconds ride the seek + the record. */
+function mmss(sec: number): string {
+  const s = Math.max(0, Math.round(sec));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+/**
+ * A self-contained board: the montage PNG with a percentage-positioned overlay of
+ * numbered, seekable cells (percentages so the overlay scales exactly with the
+ * image), above the source video. Clicking a cell seeks the video to that cell's
+ * timestamp. Blank padding tiles render dimmed and inert.
+ */
+function buildGridHtml(o: GridHtmlOpts): string {
+  const margin = 6, gap = 6; // must match contactSheet's tile margin/padding
+  const totalW = 2 * margin + o.cols * o.cellWidth + (o.cols - 1) * gap;
+  const totalH = 2 * margin + o.rows * o.cellHeight + (o.rows - 1) * gap;
+  const pct = (n: number, d: number) => `${((n / d) * 100).toFixed(4)}%`;
+
+  const overlay = o.cells
+    .map((cell) => {
+      const idx = cell.n - 1;
+      const c = idx % o.cols;
+      const r = Math.floor(idx / o.cols);
+      const style =
+        `left:${pct(margin + c * (o.cellWidth + gap), totalW)};` +
+        `top:${pct(margin + r * (o.cellHeight + gap), totalH)};` +
+        `width:${pct(o.cellWidth, totalW)};height:${pct(o.cellHeight, totalH)}`;
+      if (cell.at == null) {
+        return `<div class="cell blank" style="${style}"><span class="badge">${cell.n}</span></div>`;
+      }
+      return (
+        `<button class="cell" style="${style}" onclick="seek(${cell.at})" ` +
+        `title="cell ${cell.n} · ${cell.at}s">` +
+        `<span class="badge">${cell.n}</span><span class="tc">${htmlText(mmss(cell.at))}</span></button>`
+      );
+    })
+    .join("");
+
+  const videoUrl = htmlAttr(o.videoIsRemote ? o.video : pathToFileURL(o.video).href);
+  const montageUrl = htmlAttr(pathToFileURL(o.montage).href);
+  const nameEsc = htmlText(o.title);
+
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>overcast grid — ${nameEsc}</title>
+<style>
+  :root{--bg:#08120c;--panel:#0d1c12;--rule:#1f9d57;--ink:#c6f7d5;--amber:#ffc400;--dim:#5f9e79}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:ui-monospace,Menlo,Consolas,monospace;padding:20px}
+  h1{color:var(--amber);font-size:14px;letter-spacing:2px;margin:0 0 4px}
+  .sub{color:var(--dim);font-size:12px;margin:0 0 16px}
+  .board{position:relative;max-width:1100px;margin:0 auto;border:1px solid var(--rule);border-radius:8px;overflow:hidden;line-height:0}
+  .board img{display:block;width:100%;height:auto}
+  .overlay{position:absolute;inset:0}
+  .cell{position:absolute;margin:0;padding:0;border:1px solid transparent;background:transparent;cursor:pointer;border-radius:4px;transition:border-color .12s,background .12s}
+  .cell:hover,.cell:focus-visible{border-color:var(--amber);background:rgba(255,196,0,.12);outline:none}
+  .cell .badge{position:absolute;top:5px;left:5px;font-size:12px;font-weight:700;color:#08120c;background:var(--amber);border-radius:4px;padding:1px 6px;line-height:1.4}
+  .cell .tc{position:absolute;bottom:5px;right:5px;font-size:11px;color:var(--ink);background:rgba(8,18,12,.72);border:1px solid var(--rule);border-radius:4px;padding:1px 5px}
+  .cell.blank{cursor:default;background:repeating-linear-gradient(45deg,rgba(255,255,255,.03),rgba(255,255,255,.03) 6px,transparent 6px,transparent 12px)}
+  .cell.blank .badge{background:var(--dim);opacity:.6}
+  video{display:block;width:100%;max-width:1100px;margin:16px auto 0;background:#000;border:1px solid var(--rule);border-radius:8px}
+  .hint{color:var(--dim);font-size:12px;text-align:center;margin:12px 0 0}
+</style></head><body>
+<h1>▦ OVERCAST GRID — ${nameEsc}</h1>
+<p class="sub">${o.cols}×${o.rows} contact sheet · click a numbered cell to seek the clip to that moment</p>
+<div class="board"><img src="${montageUrl}" alt="contact sheet"><div class="overlay">${overlay}</div></div>
+<video id="v" src="${videoUrl}" controls preload="metadata"></video>
+<p class="hint">cells labeled #n · M:SS — the exact seconds live in the grid record's payload.cells</p>
+<script>
+  var v=document.getElementById('v');
+  function seek(t){ if(!v)return; v.currentTime=t; v.play&&v.play().catch(function(){}); v.scrollIntoView({behavior:'smooth',block:'nearest'}); }
+</script>
+</body></html>`;
+}

--- a/src/verbs/grid.ts
+++ b/src/verbs/grid.ts
@@ -62,9 +62,13 @@ export const gridVerb: VerbSpec = {
   run: async (ctx) => {
     if (!ctx.input) return [err("grid requires a video input (path or record id)")];
     const numErr =
-      badNumber(ctx.opts, "count", (n) => n >= 1 && n <= MAX_CELLS, `1–${MAX_CELLS}`) ??
       badNumber(ctx.opts, "cols", (n) => n >= 1 && n <= 12, "1–12") ??
-      badNumber(ctx.opts, "width", (n) => n >= 120 && n <= 960, "120–960");
+      badNumber(ctx.opts, "width", (n) => n >= 120 && n <= 960, "120–960") ??
+      // --count only drives window sampling; an explicit --at overrides it, so
+      // don't reject a count the user isn't actually using.
+      (ctx.opts.at == null
+        ? badNumber(ctx.opts, "count", (n) => n >= 1 && n <= MAX_CELLS, `1–${MAX_CELLS}`)
+        : undefined);
     if (numErr) return [err(numErr)];
 
     // accept a path / URL / case record id, and validate it's real AV media.
@@ -80,8 +84,13 @@ export const gridVerb: VerbSpec = {
       if (parts.some((p) => p === undefined)) {
         return [err(`invalid --at: ${ctx.opts.at} (use comma-separated SS or MM:SS)`)];
       }
-      seconds = [...new Set(parts as number[])].sort((a, b) => a - b).slice(0, MAX_CELLS);
+      seconds = [...new Set(parts as number[])].sort((a, b) => a - b);
       if (!seconds.length) return [err("--at listed no valid timestamps")];
+      // reject rather than silently drop: a truncated triage that still reports
+      // success would quietly miss the moments the caller explicitly asked for.
+      if (seconds.length > MAX_CELLS) {
+        return [err(`too many --at timestamps (${seconds.length}); max ${MAX_CELLS}`)];
+      }
     } else {
       const start = ctx.opts.start != null ? parseTimecode(String(ctx.opts.start)) : 0;
       if (start === undefined) return [err(`invalid --start: ${ctx.opts.start}`)];

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -558,6 +558,7 @@ async function captureRef(
   // sharing a basename don't clobber each other / share a capture_id.
   if (existsSync(ref)) {
     const dest = opts.out ? opts.out : join(outDir, uniqueName(ref));
+    mkdirSync(dirname(dest), { recursive: true }); // a nested --out needs its parent first
     try {
       copyFileSync(ref, dest);
     } catch (e) {
@@ -586,6 +587,7 @@ async function captureRef(
     return err("capture", `no source provider can fetch ${ref} (source type '${type}')`);
   }
   const dest = opts.out ? opts.out : join(outDir, uniqueName(ref));
+  mkdirSync(dirname(dest), { recursive: true }); // a nested --out needs its parent first
   return fetchSource(desc, { url: ref, out: dest, signal: ctx.signal });
 }
 

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -20,6 +20,7 @@ import {
   defaultOps,
   extractFrame,
   parseFrameRef,
+  parseTimecode,
   modalityFromExt,
   spectrogram as ffSpectrogram,
   type EnhanceOp,
@@ -550,7 +551,7 @@ function buildPlayerHtml(
   spectrogramPath: string | undefined,
   isRemote = false,
 ): string {
-  const startAt = at ? parseTimecode(String(at).split("-")[0]) : 0;
+  const startAt = at ? parseTimecode(String(at).split("-")[0]) ?? 0 : 0;
   const tag = modality === "video" ? "video" : "audio";
   const markerPins = markers
     .map((m) => `<button class="pin" onclick="seek(${Number(m)})">⏱ ${Number(m)}s</button>`)
@@ -587,20 +588,6 @@ ${spectrogramPath ? `<img src="${htmlAttr(pathToFileURL(spectrogramPath).href)}"
 
 function basenameOf(p: string): string {
   return p.split("/").pop() ?? p;
-}
-
-/** Parse a seek value: plain seconds ("134", "134.5") or a timecode ("02:14",
- *  "1:02:14"). Returns 0 for anything unparseable. */
-function parseTimecode(s: string): number {
-  const str = s.trim();
-  if (str === "") return 0;
-  if (str.includes(":")) {
-    const parts = str.split(":").map((p) => Number(p));
-    if (parts.some((n) => !Number.isFinite(n))) return 0;
-    return parts.reduce((acc, p) => acc * 60 + p, 0);
-  }
-  const n = Number(str);
-  return Number.isFinite(n) ? n : 0;
 }
 
 /** Escape for HTML text content. */

--- a/src/verbs/skills.ts
+++ b/src/verbs/skills.ts
@@ -16,6 +16,11 @@ import {
   generateReconBriefSkill,
   generateVisualTargetSearchSkill,
   generateCopycatSweepSkill,
+  generatePinpointSkill,
+  generateFrameGridSkill,
+  generateEventBisectSkill,
+  generateWhereSkill,
+  generatePresenceWindowSkill,
 } from "../skill-gen.js";
 import type { VerbSpec } from "../registry/types.js";
 
@@ -75,6 +80,11 @@ const SHIPPED_SKILLS = [
   "overcast-recon-brief",
   "overcast-visual-target-search",
   "overcast-copycat-sweep",
+  "overcast-pinpoint",
+  "overcast-frame-grid",
+  "overcast-event-bisect",
+  "overcast-where",
+  "overcast-presence-window",
 ] as const;
 
 /** Harnesses `skills install` knows how to target. */
@@ -115,6 +125,11 @@ function generateSkills(skillsDir: string): string[] {
     ["overcast-recon-brief", generateReconBriefSkill],
     ["overcast-visual-target-search", generateVisualTargetSearchSkill],
     ["overcast-copycat-sweep", generateCopycatSweepSkill],
+    ["overcast-pinpoint", generatePinpointSkill],
+    ["overcast-frame-grid", generateFrameGridSkill],
+    ["overcast-event-bisect", generateEventBisectSkill],
+    ["overcast-where", generateWhereSkill],
+    ["overcast-presence-window", generatePresenceWindowSkill],
   ];
   for (const [name, generate] of focusedSkills) {
     const dir = join(skillsDir, name);

--- a/test/e2e/cases/phase2_senses.sh
+++ b/test/e2e/cases/phase2_senses.sh
@@ -71,6 +71,13 @@ assert_eq "grid.cells" "4" "$(jq -r '.payload.cells | length' <<<"$gout")" "grid
 grid_path="$(jq -r '.media.ref' <<<"$gout")"
 if [ -f "$grid_path" ]; then ok "grid.output_exists" "contact sheet written"; else fail "grid.output_exists" "no montage at $grid_path"; fi
 
+# grid --view: render the clickable HTML board (numbered, seekable cells)
+gvout="$($OVERCAST grid "$clip" --count 4 --cols 2 --view --no-open --json --case "$casedir" 2>/dev/null)"
+save_json "phase2_grid_view" "$gvout" >/dev/null
+assert_eq "grid.view_not_opened" "false" "$(jq -r '.payload.opened' <<<"$gvout")" "--no-open respected"
+grid_html="$(jq -r '.payload.view' <<<"$gvout")"
+if [ -f "$grid_html" ] && grep -q 'onclick="seek(' "$grid_html"; then ok "grid.view_html" "board HTML has seekable cells"; else fail "grid.view_html" "no clickable board at $grid_html"; fi
+
 # see: with NO brain, NO HF token, and no binding, it's the placeholder.
 # (A brain / HF_TOKEN / a binding routes see to that backend instead.) Both the
 # brain default (OVERCAST_SEE_BRAIN=off) and .env auto-load (OVERCAST_NO_DOTENV=1)

--- a/test/e2e/cases/phase2_senses.sh
+++ b/test/e2e/cases/phase2_senses.sh
@@ -27,10 +27,10 @@ casedir="$SMOKE_DIR/case_senses"; mkdir -p "$casedir"
 # phases append more verbs, so assert presence, not the exact set).
 verbs="$($OVERCAST commands --json | jq -r '.verbs[].name')"
 missing=""
-for v in watch listen see enhance view crop; do
+for v in watch listen see enhance view crop grid; do
   echo "$verbs" | grep -qx "$v" || missing="$missing $v"
 done
-if [ -z "$missing" ]; then ok "senses.verb_surface" "commands --json lists watch/listen/see/enhance/view/crop"; else fail "senses.verb_surface" "missing verbs:$missing"; fi
+if [ -z "$missing" ]; then ok "senses.verb_surface" "commands --json lists watch/listen/see/enhance/view/crop/grid"; else fail "senses.verb_surface" "missing verbs:$missing"; fi
 
 # enhance: ffmpeg op -> media.enhanced with output media.ref
 eout="$($OVERCAST enhance "$clip" --ops grayscale --json --case "$casedir" 2>/dev/null)"
@@ -60,6 +60,16 @@ assert_eq "crop.verb" "crop" "$(jq -r '.verb' <<<"$cout")" "crop emits crop reco
 assert_eq "crop.state" "ready" "$(jq -r '.state' <<<"$cout")" "crop ready"
 crop_path="$(jq -r '.media.ref' <<<"$cout")"
 if [ -f "$crop_path" ]; then ok "crop.output_exists" "crop image written"; else fail "crop.output_exists" "no crop at $crop_path"; fi
+
+# grid: tile timestamped frames into ONE contact sheet via the internal ffmpeg
+# toolkit — emits media.grid with a cell-number->timestamp map and a montage on disk.
+gout="$($OVERCAST grid "$clip" --count 4 --cols 2 --json --case "$casedir" 2>/dev/null)"
+save_json "phase2_grid" "$gout" >/dev/null
+assert_eq "grid.verb" "grid" "$(jq -r '.verb' <<<"$gout")" "grid emits grid record"
+assert_eq "grid.state" "ready" "$(jq -r '.state' <<<"$gout")" "grid ready"
+assert_eq "grid.cells" "4" "$(jq -r '.payload.cells | length' <<<"$gout")" "grid maps 4 cells"
+grid_path="$(jq -r '.media.ref' <<<"$gout")"
+if [ -f "$grid_path" ]; then ok "grid.output_exists" "contact sheet written"; else fail "grid.output_exists" "no montage at $grid_path"; fi
 
 # see: with NO brain, NO HF token, and no binding, it's the placeholder.
 # (A brain / HF_TOKEN / a binding routes see to that backend instead.) Both the

--- a/test/e2e/live/cases/18_grid.sh
+++ b/test/e2e/live/cases/18_grid.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Real grid: tile a real video into labeled contact sheets (pure ffmpeg — the core
+# grid path needs NO creds), covering the variations Bugbot hardened (no filename
+# collision, blank-padding cell map, explicit --at, past-duration reject, audio
+# reject). Then, Cloudglue-gated, the frame-grid CoT loop: see the montage → map a
+# cell to a timestamp → see frame:// to verify that exact frame.
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; source "$LIVE/lib.sh"
+C=grid
+
+# a real video with people/objects (objects preferred), any of the standard clips
+VID=""
+for v in "$VIDEO_OBJECTS" "$VIDEO_VISUAL" "$VIDEO_SMALL"; do
+  if have_media "$v"; then VID="$v"; break; fi
+done
+[ -n "$VID" ] || { skip "$C" "no video (set OC_VIDEO_OBJECTS/VISUAL/SMALL)"; exit 0; }
+
+CASE=$(case_dir grid)
+
+# --- 1) full-clip triage grid (pure ffmpeg; no creds) ---
+cond "grid tiles a real video into a contact sheet -> ready media.grid with a cell->timestamp map"
+out="$(oc "$CASE" grid "$VID" --count 12 --cols 4 --json)"
+save_json "18_grid_full" "$out" >/dev/null
+assert_eq "$C.verb" "grid" "$(echo "$out"|jq -r '.verb')" "record.verb is grid"
+assert_eq "$C.state" "ready" "$(echo "$out"|jq -r '.state')" "state ready"
+assert_eq "$C.count" "12" "$(echo "$out"|jq -r '.payload.count')" "12 frames sampled"
+MON="$(echo "$out"|jq -r '.payload.montage')"
+if have_media "$MON"; then ok "$C.montage" "contact sheet written ($(echo "$out"|jq -r '.payload.grid'))"; else fail "$C.montage" "no montage at $MON"; fi
+assert_nonempty "$C.cells" "$(echo "$out"|jq -r '.payload.cells[0].at')" "cell 1 has a timestamp"
+
+# --- 2) no filename collision: same count, different samples -> distinct montage ---
+cond "two grids of the same clip with the same count but different samples get distinct montage files"
+a="$(oc "$CASE" grid "$VID" --at "1,2,3" --json)"
+b="$(oc "$CASE" grid "$VID" --at "1,2,4" --json)"
+ma="$(echo "$a"|jq -r '.payload.montage')"; mb="$(echo "$b"|jq -r '.payload.montage')"
+if [ "$ma" != "$mb" ] && have_media "$ma" && have_media "$mb"; then
+  ok "$C.no_collision" "distinct montages, neither overwritten"
+else
+  fail "$C.no_collision" "collision or missing: '$ma' vs '$mb'"
+fi
+
+# --- 3) odd count -> trailing blank padding tile mapped as null ---
+cond "an odd frame count pads the last row with a blank tile mapped at:null (count stays real)"
+o="$(oc "$CASE" grid "$VID" --count 5 --json)"
+save_json "18_grid_pad" "$o" >/dev/null
+assert_eq "$C.pad.real" "5" "$(echo "$o"|jq -r '.payload.count')" "count reports 5 real frames"
+nnull="$(echo "$o"|jq -r '[.payload.cells[]|select(.at==null)]|length')"
+if [ "${nnull:-0}" -ge 1 ]; then ok "$C.pad.null" "$nnull blank padding cell(s) mapped null"; else fail "$C.pad.null" "no null padding cell in a 5-frame grid"; fi
+
+# --- 4) explicit --at maps exactly the requested (sorted, deduped) timestamps ---
+cond "explicit --at samples exactly the requested timestamps"
+at="$(oc "$CASE" grid "$VID" --at "1,5,9" --cols 3 --json)"
+assert_eq "$C.at" "[1,5,9]" "$(echo "$at"|jq -rc '[.payload.cells[]|select(.at!=null)|.at]')" "cells map to [1,5,9]"
+
+# --- 5) --at past the clip duration is rejected (never claim an unsampled second) ---
+cond "a --at timestamp past the clip duration is rejected instead of claiming a never-sampled frame"
+pd="$(oc "$CASE" grid "$VID" --at "1,99999" --json)"
+assert_eq "$C.past.state" "error" "$(echo "$pd"|jq -r '.state')" "past-duration --at errors"
+case "$(echo "$pd"|jq -r '.error // empty')" in
+  *"past the video duration"*) ok "$C.past.msg" "clear past-duration error" ;;
+  *) fail "$C.past.msg" "unexpected: $(echo "$pd"|jq -r '.error // empty' | head -c 80)" ;;
+esac
+
+# --- 6) audio-only input is rejected (grid needs a video stream) ---
+if have_media "$AUDIO_FILE"; then
+  cond "grid rejects an audio-only input (no video stream) with a clear error"
+  au="$(oc "$CASE" grid "$AUDIO_FILE" --count 4 --json)"
+  assert_eq "$C.audio.state" "error" "$(echo "$au"|jq -r '.state')" "audio-only errors"
+  case "$(echo "$au"|jq -r '.error // empty')" in
+    *"no video stream"*) ok "$C.audio.msg" "clear video-required error" ;;
+    *) fail "$C.audio.msg" "unexpected: $(echo "$au"|jq -r '.error // empty' | head -c 80)" ;;
+  esac
+else
+  skip "$C.audio" "no OC_AUDIO for the audio-reject check"
+fi
+
+# --- 7) records persist to the case store ---
+cond "grid records persist to the case store"
+n="$(oc "$CASE" case records --verb grid --json | jq '.payload.count')"
+if [ "${n:-0}" -ge 1 ]; then ok "$C.persisted" "$n grid record(s) persisted"; else fail "$C.persisted" "no persisted grid records"; fi
+
+# --- 8) Cloudglue-gated frame-grid CoT loop: see montage -> map cell -> verify frame ---
+if require_cred "$C.cot" CLOUDGLUE_API_KEY "skipping the VLM loop"; then
+  BRAIN=$(case_dir grid_cot)   # fresh case -> default profile (no see binding) -> turnkey Cloudglue brain
+  cond "see the montage with a grid prompt (turnkey brain) -> ready description"
+  s="$(OC_TIMEOUT=180 oc "$BRAIN" see "$MON" --prompt "This is a contact sheet of 12 frames numbered 1-12 left-to-right, top-to-bottom. In one sentence, which numbered cell best shows a person, and why? Give the cell number." --json)"
+  save_json "18_grid_see_montage" "$s" >/dev/null
+  assert_eq "$C.cot.see_state" "ready" "$(echo "$s"|jq -r '.state')" "montage see ready"
+  case "$(echo "$s"|jq -r '.meta.provider // empty')" in
+    brain:*) ok "$C.cot.provider" "routed to brain ($(echo "$s"|jq -r '.meta.provider'))" ;;
+    *) fail "$C.cot.provider" "expected brain:*, got '$(echo "$s"|jq -r '.meta.provider // empty')'" ;;
+  esac
+  assert_nonempty "$C.cot.desc" "$(echo "$s"|jq -r '.payload.description // .payload.caption')" "montage description non-empty"
+
+  # map a real cell timestamp from the full grid and verify that exact frame
+  T="$(echo "$out"|jq -r '.payload.cells[3].at')"   # cell 4's timestamp
+  w="$(OC_TIMEOUT=300 oc "$BRAIN" watch "$VID" --json)"
+  REC="$(echo "$w"|jq -r '.id')"
+  if [ "$(echo "$w"|jq -r '.state')" = "ready" ] && [ -n "$REC" ] && [ "$REC" != "null" ]; then
+    cond "see frame://REC@t (turnkey brain) verifies the exact frame a montage cell points to"
+    fv="$(OC_TIMEOUT=180 oc "$BRAIN" see "frame://$REC@$T" --prompt "Describe this single frame in one sentence." --json)"
+    save_json "18_grid_frame_verify" "$fv" >/dev/null
+    assert_eq "$C.cot.verify_state" "ready" "$(echo "$fv"|jq -r '.state')" "frame verify ready at t=$T"
+    assert_nonempty "$C.cot.verify_desc" "$(echo "$fv"|jq -r '.payload.description // .payload.caption')" "frame description non-empty"
+  else
+    skip "$C.cot.verify" "watch did not produce a record to frame://-verify"
+  fi
+fi

--- a/test/e2e/live/cases/18_grid.sh
+++ b/test/e2e/live/cases/18_grid.sh
@@ -27,6 +27,13 @@ MON="$(echo "$out"|jq -r '.payload.montage')"
 if have_media "$MON"; then ok "$C.montage" "contact sheet written ($(echo "$out"|jq -r '.payload.grid'))"; else fail "$C.montage" "no montage at $MON"; fi
 assert_nonempty "$C.cells" "$(echo "$out"|jq -r '.payload.cells[0].at')" "cell 1 has a timestamp"
 
+# --view renders the clickable HTML board (numbered, seekable cells)
+cond "grid --view renders an HTML board whose numbered cells seek the source clip"
+vout="$(oc "$CASE" grid "$VID" --count 9 --view --no-open --json)"
+assert_eq "$C.view.opened" "false" "$(echo "$vout"|jq -r '.payload.opened')" "--no-open respected"
+VH="$(echo "$vout"|jq -r '.payload.view')"
+if have_media "$VH" && grep -q 'onclick="seek(' "$VH"; then ok "$C.view.html" "board HTML has seekable cells"; else fail "$C.view.html" "no clickable board at $VH"; fi
+
 # --- 2) no filename collision: same count, different samples -> distinct montage ---
 cond "two grids of the same clip with the same count but different samples get distinct montage files"
 a="$(oc "$CASE" grid "$VID" --at "1,2,3" --json)"

--- a/test/unit/ffmpeg.test.ts
+++ b/test/unit/ffmpeg.test.ts
@@ -64,6 +64,13 @@ test("enhance runs deterministic ffmpeg ops and writes output", async () => {
   assert.equal(r.modality, "video");
 });
 
+test("enhance creates the parent dir of a nested explicit --out path", async () => {
+  const out = join(dir, "enh-nested", "deep", "gray.mp4");
+  const r = await enhance(clip, ["grayscale"], join(dir, "enh"), out);
+  assert.equal(r.output, out);
+  assert.ok(existsSync(out), "output written into freshly-created nested dir");
+});
+
 test("defaultOps differ per modality", () => {
   assert.deepEqual(defaultOps("audio"), ["denoise", "normalize"]);
   assert.deepEqual(defaultOps("image"), ["denoise"]);

--- a/test/unit/ffmpeg.test.ts
+++ b/test/unit/ffmpeg.test.ts
@@ -71,6 +71,15 @@ test("enhance creates the parent dir of a nested explicit --out path", async () 
   assert.ok(existsSync(out), "output written into freshly-created nested dir");
 });
 
+test("enhance default output name distinguishes op sets but is idempotent per op set", async () => {
+  const g = await enhance(clip, ["grayscale"], join(dir, "enh-ops"));
+  const d = await enhance(clip, ["denoise"], join(dir, "enh-ops"));
+  assert.notEqual(g.output, d.output); // different ops -> different file, no overwrite
+  assert.ok(existsSync(g.output) && existsSync(d.output));
+  const g2 = await enhance(clip, ["grayscale"], join(dir, "enh-ops"));
+  assert.equal(g2.output, g.output); // same ops -> same (cached) name
+});
+
 test("defaultOps differ per modality", () => {
   assert.deepEqual(defaultOps("audio"), ["denoise", "normalize"]);
   assert.deepEqual(defaultOps("image"), ["denoise"]);

--- a/test/unit/grid.test.ts
+++ b/test/unit/grid.test.ts
@@ -1,11 +1,12 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gridVerb } from "../../src/verbs/grid.ts";
 import { contactSheet, probe, FFMPEG_PATH } from "../../src/media/ffmpeg.ts";
+import { isMemoryRecord } from "../../src/record.ts";
 import { openCase } from "../../src/case.ts";
 import { defaultProfile } from "../../src/profile.ts";
 import type { VerbContext } from "../../src/registry/types.ts";
@@ -122,6 +123,28 @@ test("grid verb: missing input errors cleanly", async () => {
   const [rec] = await gridVerb.run(ctx("", { json: true }));
   assert.equal(rec.state, "error");
   assert.match(rec.error ?? "", /requires a video/);
+});
+
+test("grid verb: --view --no-open renders a clickable HTML board (labels + per-cell seeks)", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { count: 6, cols: 3, view: true, "no-open": true, json: true }));
+  assert.equal(rec.state, "ready");
+  const p = rec.payload as Record<string, any>;
+  assert.equal(p.opened, false); // --no-open respected
+  assert.ok(existsSync(p.view), "board HTML written");
+  const html = readFileSync(p.view, "utf8");
+  // one seekable cell per sampled frame, each seeking to its exact timestamp
+  for (const cell of p.cells.filter((c: any) => c.at != null)) {
+    assert.ok(html.includes(`onclick="seek(${cell.at})"`), `board seeks cell ${cell.n} to ${cell.at}s`);
+  }
+  assert.match(html, /<video/); // the source video to seek
+  assert.ok(html.includes("_grid_"), "board references the montage");
+});
+
+test("grid records are operational — excluded from case memory (a triage artifact, not evidence)", () => {
+  assert.equal(
+    isMemoryRecord({ verb: "grid", state: "ready", payload: { summary: "contact sheet: 16 frames" } }),
+    false,
+  );
 });
 
 test("grid verb: >64 --at timestamps error instead of silently truncating", async () => {

--- a/test/unit/grid.test.ts
+++ b/test/unit/grid.test.ts
@@ -101,6 +101,24 @@ test("grid verb: an out-of-range --count is ignored when --at overrides it", asy
   assert.deepEqual(p.cells.map((c: any) => c.at), [2, 5, 8]);
 });
 
+test("grid verb: a fractional --count is rejected (skews window sampling)", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { count: 16.9, json: true }));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /whole number/);
+});
+
+test("grid verb: an audio-only input is rejected with a clear video-required error", async () => {
+  const audio = join(dir, "tone.m4a");
+  execFileSync(
+    FFMPEG_PATH,
+    ["-y", "-f", "lavfi", "-i", "sine=frequency=440:duration=1", "-c:a", "aac", audio],
+    { stdio: "ignore" },
+  );
+  const [rec] = await gridVerb.run(ctx(audio, { count: 4, json: true }));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /no video stream/);
+});
+
 test("grid verb: a nested --out path has its parent dir created", async () => {
   const out = join(dir, "nested", "deep", "sheet.png");
   const [rec] = await gridVerb.run(ctx(clip, { count: 4, out, json: true }));

--- a/test/unit/grid.test.ts
+++ b/test/unit/grid.test.ts
@@ -106,6 +106,18 @@ test("grid verb: validation rejects out-of-range flags and bad --at", async () =
   assert.match(emptyWin.error ?? "", /window/);
 });
 
+test("grid verb: same count, different windows produce distinct montage paths (no overwrite)", async () => {
+  const [a] = await gridVerb.run(ctx(clip, { count: 4, start: "0", end: "4", json: true }));
+  const [b] = await gridVerb.run(ctx(clip, { count: 4, start: "6", end: "10", json: true }));
+  const [c] = await gridVerb.run(ctx(clip, { count: 4, start: "0", end: "4", json: true }));
+  const pa = a.payload as Record<string, any>;
+  const pb = b.payload as Record<string, any>;
+  const pc = c.payload as Record<string, any>;
+  assert.notEqual(pa.montage, pb.montage); // different windows -> different file
+  assert.equal(pc.montage, pa.montage); // identical inputs -> same (idempotent) file
+  assert.ok(existsSync(pa.montage) && existsSync(pb.montage), "both montages persist, neither overwritten");
+});
+
 test("grid verb: missing input errors cleanly", async () => {
   const [rec] = await gridVerb.run(ctx("", { json: true }));
   assert.equal(rec.state, "error");

--- a/test/unit/grid.test.ts
+++ b/test/unit/grid.test.ts
@@ -59,12 +59,37 @@ test("grid verb: window sampling emits a media.grid record with midpoint cells",
   assert.equal(rec.media?.ref, p.montage);
 });
 
-test("grid verb: explicit --at overrides window and is sorted + deduped", async () => {
+test("grid verb: explicit --at overrides window, sorted + deduped, padding mapped as null", async () => {
   const [rec] = await gridVerb.run(ctx(clip, { at: "8,2,2,5", json: true }));
   assert.equal(rec.state, "ready");
   const p = rec.payload as Record<string, any>;
-  assert.deepEqual(p.cells.map((c: any) => c.at), [2, 5, 8]);
+  assert.deepEqual(p.cells.filter((c: any) => c.at != null).map((c: any) => c.at), [2, 5, 8]);
+  assert.equal(p.count, 3); // count is real frames, not tiles
+  // default layout for 3 frames is 2x2 → one trailing blank padding tile, mapped as null
+  assert.equal(p.cells.length, p.cols * p.rows);
+  assert.equal(p.cells.filter((c: any) => c.at === null).length, p.cols * p.rows - 3);
   assert.equal(p.window, undefined); // --at path carries no window
+});
+
+test("grid verb: an empty --at= does not skip --count validation (window sampling still runs)", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { at: "", count: 999, json: true }));
+  assert.equal(rec.state, "error"); // hasAt is false for "", so count IS validated
+  assert.match(rec.error ?? "", /whole number 1–64/);
+});
+
+test("grid verb: --at past the clip duration is rejected", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { at: "5,9999", json: true }));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /past the video duration/);
+});
+
+test("grid verb: an over-long --end is clamped to the clip so cells stay truthful", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { start: "0", end: "9999", count: 4, json: true }));
+  assert.equal(rec.state, "ready");
+  const p = rec.payload as Record<string, any>;
+  assert.ok(p.window.end <= 12.5, `window end clamped to clip duration, got ${p.window.end}`);
+  const maxAt = Math.max(...p.cells.filter((c: any) => c.at != null).map((c: any) => c.at));
+  assert.ok(maxAt <= 12, `no sampled cell past EOF, got ${maxAt}`);
 });
 
 test("grid verb: validation rejects out-of-range flags and bad --at", async () => {
@@ -98,7 +123,7 @@ test("grid verb: an out-of-range --count is ignored when --at overrides it", asy
   const [rec] = await gridVerb.run(ctx(clip, { count: 999, at: "2,5,8", json: true }));
   assert.equal(rec.state, "ready"); // count is irrelevant with --at, so no validation error
   const p = rec.payload as Record<string, any>;
-  assert.deepEqual(p.cells.map((c: any) => c.at), [2, 5, 8]);
+  assert.deepEqual(p.cells.filter((c: any) => c.at != null).map((c: any) => c.at), [2, 5, 8]);
 });
 
 test("grid verb: a fractional --count is rejected (skews window sampling)", async () => {

--- a/test/unit/grid.test.ts
+++ b/test/unit/grid.test.ts
@@ -1,0 +1,88 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gridVerb } from "../../src/verbs/grid.ts";
+import { contactSheet, probe, FFMPEG_PATH } from "../../src/media/ffmpeg.ts";
+import { openCase } from "../../src/case.ts";
+import { defaultProfile } from "../../src/profile.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+let dir: string;
+let clip: string;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "oc-grid-"));
+  clip = join(dir, "clip.mp4");
+  // a 12s 320x180 clip so cell aspect + windowing are exercised on real media
+  execFileSync(
+    FFMPEG_PATH,
+    ["-y", "-f", "lavfi", "-i", "testsrc=size=320x180:rate=10:duration=12", "-pix_fmt", "yuv420p", clip],
+    { stdio: "ignore" },
+  );
+});
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+function ctx(input: string, opts: VerbContext["opts"] = {}): VerbContext {
+  const c = openCase(dir);
+  c.ensure();
+  return { input, rest: [], opts, case: c, profile: defaultProfile() };
+}
+
+test("contactSheet tiles a real clip into one montage with an exact cell map", async () => {
+  const secs = [1, 4, 7, 10];
+  const r = await contactSheet(clip, secs, join(dir, "sheets"), { cols: 2 });
+  assert.ok(existsSync(r.output), "montage written");
+  assert.equal(r.cols, 2);
+  assert.equal(r.rows, 2); // 4 cells / 2 cols
+  assert.deepEqual(r.cells, secs.map((at, i) => ({ n: i + 1, at })));
+  // it's a real, non-empty image the tile filter actually produced
+  const p = await probe(r.output);
+  assert.ok((p.width ?? 0) > 0 && (p.height ?? 0) > 0, "montage has dimensions");
+  assert.equal(typeof r.labeled, "boolean"); // labeled iff drawtext + font present
+});
+
+test("grid verb: window sampling emits a media.grid record with midpoint cells", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { count: 6, cols: 3, json: true }));
+  assert.equal(rec.verb, "grid");
+  assert.equal(rec.state, "ready");
+  const p = rec.payload as Record<string, any>;
+  assert.equal(p.count, 6);
+  assert.equal(p.grid, "3x2");
+  assert.equal(p.cells.length, 6);
+  // midpoint sampling never lands on the exact clip start (0) or a black tail
+  assert.ok(p.cells[0].at > 0, "first sample is a midpoint, not 0");
+  assert.ok(p.cells.every((c: any, i: number) => c.n === i + 1), "cells numbered 1..N");
+  assert.ok(existsSync(p.montage), "montage on disk");
+  assert.equal(rec.media?.ref, p.montage);
+});
+
+test("grid verb: explicit --at overrides window and is sorted + deduped", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { at: "8,2,2,5", json: true }));
+  assert.equal(rec.state, "ready");
+  const p = rec.payload as Record<string, any>;
+  assert.deepEqual(p.cells.map((c: any) => c.at), [2, 5, 8]);
+  assert.equal(p.window, undefined); // --at path carries no window
+});
+
+test("grid verb: validation rejects out-of-range flags and bad --at", async () => {
+  const [tooMany] = await gridVerb.run(ctx(clip, { count: 999, json: true }));
+  assert.equal(tooMany.state, "error");
+  assert.match(tooMany.error ?? "", /count/);
+
+  const [badAt] = await gridVerb.run(ctx(clip, { at: "nope", json: true }));
+  assert.equal(badAt.state, "error");
+  assert.match(badAt.error ?? "", /--at/);
+
+  const [emptyWin] = await gridVerb.run(ctx(clip, { start: "10", end: "5", json: true }));
+  assert.equal(emptyWin.state, "error");
+  assert.match(emptyWin.error ?? "", /window/);
+});
+
+test("grid verb: missing input errors cleanly", async () => {
+  const [rec] = await gridVerb.run(ctx("", { json: true }));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /requires a video/);
+});

--- a/test/unit/grid.test.ts
+++ b/test/unit/grid.test.ts
@@ -86,3 +86,25 @@ test("grid verb: missing input errors cleanly", async () => {
   assert.equal(rec.state, "error");
   assert.match(rec.error ?? "", /requires a video/);
 });
+
+test("grid verb: >64 --at timestamps error instead of silently truncating", async () => {
+  const many = Array.from({ length: 65 }, (_, i) => i + 1).join(",");
+  const [rec] = await gridVerb.run(ctx(clip, { at: many, json: true }));
+  assert.equal(rec.state, "error");
+  assert.match(rec.error ?? "", /too many --at timestamps \(65\)/);
+});
+
+test("grid verb: an out-of-range --count is ignored when --at overrides it", async () => {
+  const [rec] = await gridVerb.run(ctx(clip, { count: 999, at: "2,5,8", json: true }));
+  assert.equal(rec.state, "ready"); // count is irrelevant with --at, so no validation error
+  const p = rec.payload as Record<string, any>;
+  assert.deepEqual(p.cells.map((c: any) => c.at), [2, 5, 8]);
+});
+
+test("grid verb: a nested --out path has its parent dir created", async () => {
+  const out = join(dir, "nested", "deep", "sheet.png");
+  const [rec] = await gridVerb.run(ctx(clip, { count: 4, out, json: true }));
+  assert.equal(rec.state, "ready");
+  assert.equal((rec.payload as Record<string, any>).montage, out);
+  assert.ok(existsSync(out), "montage written into freshly-created nested dir");
+});

--- a/test/unit/skill-gen.test.ts
+++ b/test/unit/skill-gen.test.ts
@@ -9,6 +9,11 @@ import {
   generateReconBriefSkill,
   generateVisualTargetSearchSkill,
   generateCopycatSweepSkill,
+  generatePinpointSkill,
+  generateFrameGridSkill,
+  generateEventBisectSkill,
+  generateWhereSkill,
+  generatePresenceWindowSkill,
 } from "../../src/skill-gen.ts";
 import { VERBS } from "../../src/registry/verbs.ts";
 
@@ -66,6 +71,31 @@ const generatedSkills = [
     name: "overcast-copycat-sweep",
     body: generateCopycatSweepSkill,
     verbs: ["doctor", "case init", "case setup", "watch", "index", "image", "scan", "capture", "face", "listen", "finding", "note", "ask", "brief", "monitor"],
+  },
+  {
+    name: "overcast-pinpoint",
+    body: generatePinpointSkill,
+    verbs: ["doctor", "case init", "watch", "grid", "see", "similar", "ask", "note", "view", "brief"],
+  },
+  {
+    name: "overcast-frame-grid",
+    body: generateFrameGridSkill,
+    verbs: ["doctor", "case init", "grid", "see", "note", "brief"],
+  },
+  {
+    name: "overcast-event-bisect",
+    body: generateEventBisectSkill,
+    verbs: ["doctor", "case init", "watch", "see", "note", "view", "brief"],
+  },
+  {
+    name: "overcast-where",
+    body: generateWhereSkill,
+    verbs: ["see", "crop", "enhance", "finding", "face", "brief"],
+  },
+  {
+    name: "overcast-presence-window",
+    body: generatePresenceWindowSkill,
+    verbs: ["doctor", "case init", "watch", "face", "grid", "see", "note", "view", "brief"],
   },
 ];
 


### PR DESCRIPTION
Adds precise **"when / where did X happen"** tooling to overcast, designed from a deep-research survey of the VLM video temporal- and spatial-localization literature (T\*/LV-Haystack, VideoAgent, VideoTree, LLoVi, Socratic Models, Moment-DETR→CG-DETR→Mr.BLIP, OWLv2 / Grounding-DINO / Set-of-Mark / Molmo).

Two calibration lessons from that literature are baked into every skill:
- **Report a window, not a frame** — exact-frame localization is single-digit temporal F1; frontier VLMs asked directly for a timestamp get ~24% R1@0.5.
- **Every emitted timestamp must trace to a frame the VLM actually verified** — models answer correctly while grounding on the wrong moment (NExT-GQA answer/evidence decoupling). Proven live: a montage-level guess of "hard hat" was corrected to "soft bucket hat, no PPE" once the exact frame was checked.

## New verb: `grid`

Tiles N timestamped frames into ONE contact sheet for a single-call VLM triage pass (the "grid trick"). Emits a `media.grid` record whose `payload.cells` maps cell number → exact timestamp, plus `montage`, `cols`, `labeled`.

```
overcast grid ./clip.mp4 --count 16 --json
overcast see <montage-path> --prompt "which numbered cells show X?"
# translate the answer cell → time via payload.cells[n].at, then verify:
overcast see frame://<watch-record>@<sec> --prompt "is X happening here?"
```

- `contactSheet()` **detects `drawtext` + a usable font and degrades** to positional numbering when absent; the exact cell→timestamp map is in the record regardless. `OVERCAST_GRID_FONT` overrides the font.
- **`grid --view`** renders the human-facing counterpart to the VLM-facing PNG: a self-contained HTML board that **CSS-labels every numbered cell with its timestamp** (labels show even when ffmpeg can't burn them) and **seeks the source clip on click**; blank padding tiles render dimmed. `--no-open` for headless. Same family as `view`/`wall`.
- `grid` is a triage artifact, not evidence — added to `OPERATIONAL_VERBS` so `ask`/`brief`/case-memory never cite a contact sheet.
- Registered in the one verb registry → CLI + agent tool + `reference/verbs.md` all generate from the spec (invariant #5).

## Five skills (generated from `src/skill-gen.ts`)

| skill | pattern |
|---|---|
| `overcast-pinpoint` | coarse candidates (shots / CLIP / grid / probe) → `see frame://` verify → zoom to a window |
| `overcast-frame-grid` | one-VLM-call `grid` triage → map the winning cell back to a timestamp (`--view` to eyeball) |
| `overcast-event-bisect` | binary-search a **monotone** state change over `see frame://` (~log₂N calls) |
| `overcast-where` | detector-propose (`see --detect`) → `crop` → `see` re-verify (kills hallucinated boxes) |
| `overcast-presence-window` | anchor one appearance, sweep outward with `face --match --start/--end/--fps` |

## Docs

README verb table + quickstart, `docs/flows.md` (new temporal-localization flow + operational-record classification), CLAUDE.md, and the frame-grid skill are all updated; `reference/verbs.md` is regenerated from the registry.

## Rebased on `main`

Merged the latest `main` (audio senses #49 + analyst briefs #47); CLAUDE.md / docs/flows.md conflicts resolved (grid/wall operational classification alongside main's suggested-findings wording), skills reference regenerated from the merged **29-verb** registry.

The merge pushed the registry JSON past the 64KB pipe buffer, exposing a **latent stdout-truncation bug**: `process.exit()` raced the async pipe flush, truncating `commands --json` (and any >64KB record dump) when piped — identically under Node and a bun-compiled binary. Fixed by writing CLI output synchronously to the fd (`writeAllSync`), which flushes in full before exit in both runtimes.

## Verification

- **648/648** unit tests, **170/170** offline e2e (fixture providers), shellcheck clean.
- **21/21 live e2e** (`test/e2e/live/cases/18_grid.sh`) against real videos + the real Cloudglue brain — the full CoT loop (montage → `brain:cloudglue` → frame-verify) and `--view`.
- `npm run typecheck` + `npm run build` clean; bun binary compiles with 29 verbs.
- Reviewed clean: 12 Bugbot findings across 4 rounds all fixed and re-verified; round 5 returned SUCCESS with 0 findings. Adjacent classes root-fixed in `enhance` / `capture` too.

Real-video demo (montages + verbatim model outputs + the rendered board): shared in review.