### PR TITLE
New audio senses: `audio` (Shazam fingerprint match) + `similar`/basic-clap (CLAP embeddings)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,10 +61,18 @@ OC_LOCAL_IMAGE_VIDEO_B=/path/to/candidate-b.mp4
 # OC_CLIP_VIDEO=/path/to/scene-video.mp4          # video A override (embedded, frame-sampled)
 # OC_CLIP_IMAGE_REF=/path/to/reference.jpg        # image-member override
 # OC_CLIP_TEXT=a red car at night                 # fallback text query when `see` is unavailable
-# Python for local image/face/CLIP DB providers. Recommended setup:
+# Local audio-fp (Shazam fingerprint) + basic-clap (CLAP) DB e2e
+# (test/e2e/live/cases/28_audio_match_local.sh + 29_clap_db.sh). Case 28 is
+# self-contained (synthesizes its own chirp fixtures — no media needed). Case 29
+# (CLAP) is HARD-GATED on OC_CLAP_E2E because the first run downloads ~776MB of
+# model weights; leave it unset in CI.
+# OC_CLAP_E2E=1                                    # opt in to the CLAP db e2e
+# Python for local image/face/CLIP/audio DB providers. Recommended setup:
 #   scripts/visual-db-uv.sh          # image DB deps
 #   scripts/visual-db-uv.sh --face   # image + face DB deps
 #   scripts/visual-db-uv.sh --clip   # CLIP (open_clip + torch) DB deps
+#   scripts/visual-db-uv.sh --audio  # audio fingerprint (scipy) DB deps
+#   scripts/visual-db-uv.sh --clap   # CLAP (transformers + torch) audio DB deps
 #   scripts/visual-db-uv.sh --all    # all of the above
 # Then set this to the printed venv Python if you do not use the default path.
 OC_VISUAL_DB_PY=
@@ -72,6 +80,9 @@ OC_VISUAL_DB_PY=
 # OC_CLIP_MODEL=ViT-B-32
 # OC_CLIP_PRETRAINED=openai
 # OC_CLIP_DEVICE=cpu
+# Optional CLAP model overrides (defaults: laion/larger_clap_general / cpu):
+# OC_CLAP_MODEL=laion/larger_clap_general
+# OC_CLAP_DEVICE=cpu
 # Optional LIVE e2e assertion thresholds. Normal CLI use can omit these and pass
 # flags per command instead. Provider defaults when flags are omitted are:
 # image min-inliers=15 min-ratio=0.4 max-frames=8; face min-similarity=68 max-frames=8.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,9 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `image-ransac` indexes), `audio` (local Shazam-style Wang-2003 fingerprint
   matching — `add`/`match` exact-recording clips against `audio-fp` indexes with
   time-offset alignment, or clip-to-clip `audio match <query> <reference>`;
-  numpy/scipy, robust to transcode/noise, NOT to pitch/speed change), `cluster`
+  numpy/scipy, `--min-margin` rejects sped-up re-uploads, `--draw` renders an SVG
+  alignment plot (hash-pair scatter + offset histogram) that embeds in briefs like
+  `image --draw`; robust to transcode/noise, NOT to pitch/speed change), `cluster`
   (persistent LOCAL face DB: ingest faces out
   of media → assign-or-create people, `identify`, `recluster`, `list/show/label`,
   and an HTML gallery `view`; deepface-only, over a `face-cluster` local index),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,12 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
   opt-in `see:tinycloud` provider — need ≥ 0.3.7).
 - `ffmpeg` + `ffprobe` — a **system prerequisite** (on `PATH`, or via
   `OVERCAST_FFMPEG` / `OVERCAST_FFPROBE`); the internal media toolkit, NOT bundled.
-- uv-managed visual DB Python — optional for visual DBs and
+- uv-managed visual/audio DB Python — optional for visual/audio DBs and
   `face:deepface-local`: `scripts/visual-db-uv.sh --face` installs OpenCV/Numpy and
   DeepFace/TensorFlow; `--clip` adds OpenAI CLIP (open_clip + torch + pillow) for
-  the `basic-clip` semantic DB; `--all` installs both. Override with
+  the `basic-clip` semantic DB; `--audio` adds scipy for the `audio-fp` Shazam-style
+  fingerprint DB; `--clap` adds LAION CLAP (transformers + torch) for the
+  `basic-clap` audio-embedding DB; `--all` installs everything. Override with
   `OC_VISUAL_DB_PY` / `OVERCAST_VISUAL_DB_PY`.
 - TypeScript / ESM / Node ≥22; `tsup` (dev build) + `bun build --compile` (binary).
 
@@ -59,14 +61,17 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
    `src/registry/verbs.ts`; the CLI subcommand, the pi AgentTool, and the skill doc
    are generated from it. `overcast commands --json` is the source of truth.
 6. **Providers are pluggable.** Three classes share one machinery — **sense**
-   (`watch/listen/see/face/similar/enhance`), **source** (`scan/capture/monitor`; youtube,
+   (`watch/listen/see/face/image/audio/similar/enhance`), **source** (`scan/capture/monitor`; youtube,
    tiktok, x, web, lens), and **memory** (`ask/brief`; local-grep, optional qmd). Bindings live in the profile;
    transports are `exec` (default), `http`, `in-proc`. Default sense binding =
    tinycloud (exec) — except `see`, whose default is the in-proc brain-vision
    backend (invariant #2), falling back to the HF exec captioner;
    `face:deepface-local` is the local DeepFace profile provider for face
-   detection/matching, and `basic-clip` is the local OpenAI CLIP DB for
-   `similar` (cross-modal semantic search).
+   detection/matching, `basic-clip` is the local OpenAI CLIP DB for
+   `similar` (cross-modal semantic search), `audio-fp` is the local numpy/scipy
+   Shazam-style fingerprint DB for `audio` (exact audio matching), and
+   `basic-clap` is the local LAION CLAP DB for `similar` audio↔audio + text→audio
+   search.
 7. **ffmpeg is internal**, not a pluggable provider — `enhance`, `crop`, `view`,
    and frame extraction shell out to the **system** `ffmpeg`/`ffprobe` (PATH or
    `OVERCAST_FFMPEG`/`OVERCAST_FFPROBE`); `overcast doctor` checks it's installed.
@@ -100,12 +105,17 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `face:deepface-local` locally: detect faces, `--match <jpeg|png>` to find/rank a
   person in a clip, or `--index` to search a face-analysis / deepface-local index),
   `image` (local OpenCV RANSAC image/video-frame matching against
-  `image-ransac` indexes), `cluster` (persistent LOCAL face DB: ingest faces out
+  `image-ransac` indexes), `audio` (local Shazam-style Wang-2003 fingerprint
+  matching — `add`/`match` exact-recording clips against `audio-fp` indexes with
+  time-offset alignment, or clip-to-clip `audio match <query> <reference>`;
+  numpy/scipy, robust to transcode/noise, NOT to pitch/speed change), `cluster`
+  (persistent LOCAL face DB: ingest faces out
   of media → assign-or-create people, `identify`, `recluster`, `list/show/label`,
   and an HTML gallery `view`; deepface-only, over a `face-cluster` local index),
-  `similar` (local OpenAI CLIP cross-modal semantic
-  search — `add`/`match` image→image, `search` text→image — against `basic-clip`
-  indexes; videos frame-sampled + pooled, or per-frame moments), `enhance` (system
+  `similar` (local OpenAI CLIP + LAION CLAP cross-modal semantic
+  search — `add`/`match`/`search` image→image, text→image against `basic-clip`
+  indexes, or audio→audio, text→audio against `basic-clap` indexes; videos
+  frame-sampled + pooled, audio windowed into 10s moments), `enhance` (system
   ffmpeg ops or a bound model).
 - **Inspect** — `view` (self-contained HTML media player; `--at`, `--spectrogram`,
   `--no-open`), `crop` (materialize `face`/`see` detection boxes into cropped
@@ -124,7 +134,8 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   `index entities`, face-analysis → `face --index`; local DBs:
   `image-ransac` for `image match`, `deepface-local` for local face search,
   `face-cluster` for the `cluster` face DB, `basic-clip` for `similar` CLIP
-  semantic search).
+  semantic search, `audio-fp` for `audio match` fingerprinting, `basic-clap` for
+  `similar` CLAP audio search).
   Built-in source refs: `youtube:@handle`, `youtube:search:<q>`,
   `youtube:playlist:<id>` or a URL; `tiktok:@user`, `tiktok:#tag`; `x:@handle`,
   `x:<advanced query>`, `x:video:<q>` / `x:image:<q>` (media targeting); `web:<q>`;
@@ -165,16 +176,16 @@ index mirrors). `case setup` saves a *mutable* setup model to
 (`payload.op = startup_setup` / `startup_setup_update`).
 
 Case memory is **evidence-only**. `ask` / `brief` read primary evidence
-(`watch listen see face image similar crop note scan capture enhance` + root
+(`watch listen see face image audio similar crop note scan capture enhance` + root
 `finding`s + `cluster` ingest/identify) through
 bound memory providers — `local-grep` (always on) and optional `qmd` (semantic;
 `setup memory qmd`, then rebuild before querying). Read/meta and operational
 records (`ask brief case setup doctor provider skills index target source
 prebrief wall`, finding review-rows, dismissed findings, cluster DB
 reads/maintenance `list/show/view/label/recluster`) are excluded even when they
-match the query. `face`/`see`/`image`/`similar`/`cluster` detections index only
-compact summaries / counts / moments / matched refs — raw boxes, thumbnails,
-homographies, and vectors stay in the record for exact reads and `crop`.
+match the query. `face`/`see`/`image`/`audio`/`similar`/`cluster` detections index only
+compact summaries / counts / moments / matched refs / offsets — raw boxes, thumbnails,
+homographies, fingerprint hashes, and vectors stay in the record for exact reads and `crop`.
 Local visual DB artifacts stay in typed local indexes: local-grep/qmd ingest the
 records and summaries, not binary media, embeddings, sampled frames, match
 visualizations, or raw face boxes.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ scripts/visual-db-uv.sh --audio           # numpy/scipy fingerprint deps (add --
 overcast index create jingles --type audio-fp --local --json
 overcast audio add ./original.mp4 --to jingles --json                 # fingerprint (video → audio track)
 overcast audio match ./suspect.mp4 --index jingles --json             # which recording + WHERE (offset)
+overcast audio match ./suspect.mp4 --index jingles --min-margin 2 --json # reject sped-up re-uploads
+overcast audio match ./suspect.mp4 --index jingles --draw --json      # + SVG alignment plot (embeds in briefs)
 overcast audio match ./a.mp3 ./b.mp3 --json                           # clip-to-clip, no index
 overcast index create sounds --type basic-clap --local --json         # CLAP audio-embedding DB
 overcast similar add ./clip.wav --index sounds --json                 # embed + cache (10s audio windows)
@@ -233,7 +235,7 @@ surface + env vars.)
 | `see` | caption / OCR / detect on an image, image URL, or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM / the opt-in tinycloud `see`+`extract` provider, ≥ 0.3.7) |
 | `face` | detect faces in a video, `--match <img>` to find a person, or search a face-analysis index |
 | `image` | match images/video frames against a local OpenCV RANSAC image index |
-| `audio` | Shazam-style exact audio matching against a local `audio-fp` index (with time-offset alignment), or clip-to-clip `audio match <query> <reference>` |
+| `audio` | Shazam-style exact audio matching against a local `audio-fp` index (time-offset alignment), or clip-to-clip `audio match <query> <reference>`; `--min-margin` rejects sped re-uploads, `--draw` renders an SVG alignment plot for briefs |
 | `cluster` | local face DB: ingest faces → group into people (assign-or-create), `identify`, `recluster`, `label`, HTML `view` |
 | `similar` | cross-modal semantic search over a local CLIP (`basic-clip`) or CLAP (`basic-clap`) index — `search` by text, `match` by image/audio, video/audio moments included |
 | `enhance` | denoise / normalize / upscale via bundled ffmpeg, or a bound model provider |

--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ overcast similar add ./clip.mp4 --index scenes --json          # embed + cache (
 overcast similar search "a red car at night" --index scenes --json   # text → image/video moments
 overcast similar match ./reference.jpg --index scenes --json         # image → image/video moments
 
+# 9b) audio DBs: Shazam-style exact matching (audio-fp) + CLAP audio similarity (basic-clap)
+scripts/visual-db-uv.sh --audio           # numpy/scipy fingerprint deps (add --clap for CLAP embeddings)
+overcast index create jingles --type audio-fp --local --json
+overcast audio add ./original.mp4 --to jingles --json                 # fingerprint (video → audio track)
+overcast audio match ./suspect.mp4 --index jingles --json             # which recording + WHERE (offset)
+overcast audio match ./a.mp3 ./b.mp3 --json                           # clip-to-clip, no index
+overcast index create sounds --type basic-clap --local --json         # CLAP audio-embedding DB
+overcast similar add ./clip.wav --index sounds --json                 # embed + cache (10s audio windows)
+overcast similar search "crowd chanting" --index sounds --json        # text → audio moments
+
 # 10) launch the interactive agent (pi TUI) in the current case
 overcast
 ```
@@ -223,8 +233,9 @@ surface + env vars.)
 | `see` | caption / OCR / detect on an image, image URL, or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM / the opt-in tinycloud `see`+`extract` provider, ≥ 0.3.7) |
 | `face` | detect faces in a video, `--match <img>` to find a person, or search a face-analysis index |
 | `image` | match images/video frames against a local OpenCV RANSAC image index |
+| `audio` | Shazam-style exact audio matching against a local `audio-fp` index (with time-offset alignment), or clip-to-clip `audio match <query> <reference>` |
 | `cluster` | local face DB: ingest faces → group into people (assign-or-create), `identify`, `recluster`, `label`, HTML `view` |
-| `similar` | cross-modal semantic search over a local CLIP (`basic-clip`) index — `search` by text, `match` by image, video moments included |
+| `similar` | cross-modal semantic search over a local CLIP (`basic-clip`) or CLAP (`basic-clap`) index — `search` by text, `match` by image/audio, video/audio moments included |
 | `enhance` | denoise / normalize / upscale via bundled ffmpeg, or a bound model provider |
 
 **Inspect** — look at the evidence
@@ -240,7 +251,7 @@ surface + env vars.)
 | `scan` | sweep registered sources for the target; if no sources are enabled, scan local case media/indexes; `--pull` to capture + sense external hits |
 | `capture` | fetch a URL / scan-hit / local path into the case |
 | `monitor` | scan on a loop, diff the seen-set, pipe new items into a sense (`--once` / `--every`) |
-| `index` | index media into searchable corpora: remote media/entities/face indexes, plus local `image-ransac`, `deepface-local`, and `basic-clip` DBs |
+| `index` | index media into searchable corpora: remote media/entities/face indexes, plus local `image-ransac`, `deepface-local`, `basic-clip`, `audio-fp`, and `basic-clap` DBs |
 | `target` / `source` / `note` | manage the standing scope, where to look, and human-authored observations |
 | `finding` | create and review findings (`create` / `list` / `accept` / `dismiss`) — manual + setup-automated |
 | `prebrief` | stand up a case (name + target + source) in one shot |

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -365,7 +365,11 @@ overcast similar search "crowd chanting" --index sounds --json # text -> audio m
 where the query lines up inside the recording, a `match_ratio`, and a `margin` over
 the next-best alignment; `--min-votes` (default 6) is the confidence floor. It is
 robust to transcode, noise, and clipping but **not** to pitch/speed change (classic
-Wang) — a sped-up copy will not match (planned for a future `--speed-sweep`).
+Wang). A slightly sped-up re-upload can still clear the raw vote floor as a weak
+partial alignment (margin ~1.2–1.7× vs a true match's 250–1600×) — pass
+`--min-margin 2` for exact-copy detection to reject those (a matching-oriented
+`--speed-sweep` is planned separately). A silent/tonal clip fingerprints to 0 hashes
+and `audio add` flags it with a `payload.warning`.
 `basic-clap` reuses the `similar` grammar and the `basic-clip` cache layout; audio is
 chunked into `--window`-second slices (default 10s), pooled to a track vector, or
 stored per-window as moments with `--granularity frame`. The first CLAP call

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -351,6 +351,7 @@ overcast doctor --json            # the `audio-db` check reports fingerprint + c
 overcast index create jingles --type audio-fp --local --json
 overcast audio add ./original.mp4 --to jingles --json          # fingerprint (videos → audio track)
 overcast audio match ./suspect.mp4 --index jingles --json      # offset-aligned: "appears at 01:23"
+overcast audio match ./suspect.mp4 --index jingles --min-margin 2 --draw --json  # reject sped re-uploads + plot the alignment
 overcast audio match ./clipA.mp3 ./clipB.mp3 --json            # clip-to-clip, no index needed
 
 # semantic similarity: audio->audio and text->audio (CLAP)
@@ -369,7 +370,11 @@ Wang). A slightly sped-up re-upload can still clear the raw vote floor as a weak
 partial alignment (margin ~1.2–1.7× vs a true match's 250–1600×) — pass
 `--min-margin 2` for exact-copy detection to reject those (a matching-oriented
 `--speed-sweep` is planned separately). A silent/tonal clip fingerprints to 0 hashes
-and `audio add` flags it with a `payload.warning`.
+and `audio add` flags it with a `payload.warning`. `--draw` renders an SVG alignment
+plot per match (hash-pair scatter + offset histogram, the Shazam analog of `image
+--draw`) into the case media store; the `brief`/`case status` HTML embeds it — a true
+match shows a tight aligned band + one sharp spike, a rejected copy a short scattered
+cluster.
 `basic-clap` reuses the `similar` grammar and the `basic-clip` cache layout; audio is
 chunked into `--window`-second slices (default 10s), pooled to a track vector, or
 stored per-window as moments with `--granularity frame`. The first CLAP call

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -337,6 +337,43 @@ frame-level and a video-level index side by side in the wizard (one comma-separa
 `--index`; per-index config pairs use `;`):
 `case setup --index "moments:basic-clip@granularity=frame,clips:basic-clip@granularity=video" --yes`.
 
+### 4b. Local audio DB: fingerprint matching + CLAP similarity
+
+The audio twins of `image` and `similar`: `audio` does Shazam-style **exact**
+recording matching (Wang 2003 constellation hashes), and a `basic-clap` index gives
+`similar` audio↔audio + text→audio **semantic** search.
+
+```bash
+scripts/visual-db-uv.sh --audio   # numpy/scipy fingerprint deps (add --clap for CLAP)
+overcast doctor --json            # the `audio-db` check reports fingerprint + clap deps
+
+# exact matching: which recording contains this clip, and WHERE
+overcast index create jingles --type audio-fp --local --json
+overcast audio add ./original.mp4 --to jingles --json          # fingerprint (videos → audio track)
+overcast audio match ./suspect.mp4 --index jingles --json      # offset-aligned: "appears at 01:23"
+overcast audio match ./clipA.mp3 ./clipB.mp3 --json            # clip-to-clip, no index needed
+
+# semantic similarity: audio->audio and text->audio (CLAP)
+scripts/visual-db-uv.sh --clap    # ~776MB model, downloaded once on first use
+overcast index create sounds --type basic-clap --local --json
+overcast similar add ./scene.wav --index sounds --json         # embed + cache (10s audio windows)
+overcast similar match ./query.wav --index sounds --json       # audio -> audio
+overcast similar search "crowd chanting" --index sounds --json # text -> audio moments
+```
+
+`audio match` reports, per member, the aligned-vote count, the time `offset_seconds`
+where the query lines up inside the recording, a `match_ratio`, and a `margin` over
+the next-best alignment; `--min-votes` (default 6) is the confidence floor. It is
+robust to transcode, noise, and clipping but **not** to pitch/speed change (classic
+Wang) — a sped-up copy will not match (planned for a future `--speed-sweep`).
+`basic-clap` reuses the `similar` grammar and the `basic-clip` cache layout; audio is
+chunked into `--window`-second slices (default 10s), pooled to a track vector, or
+stored per-window as moments with `--granularity frame`. The first CLAP call
+downloads the model to the HF cache; pre-warm it, then set `HF_HUB_OFFLINE=1` for
+fully offline runs. `--clip` and `--clap` share one torch in the venv — install both
+together via `scripts/visual-db-uv.sh --all` when you want the whole visual+audio
+stack (see [providers.md](providers.md)).
+
 ### 5. Local-media-only person search
 
 Candidate videos on disk + a reference image, no external sources.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -374,13 +374,28 @@ clip with no index). A match reports the aligned-vote count, the `offset_seconds
 where the query lines up inside the recording, the `match_ratio`, and a `margin`
 over the next-best alignment; `--min-votes` (default 6) is the confidence floor and
 `--min-ratio` an optional aligned/total ratio floor. Robust to transcode, noise,
-and clipping; **not** to pitch/speed change (a sped-up copy won't match — a
-`--speed-sweep` variant is planned).
+and clipping; **not** to pitch/speed change (classic Wang).
+
+`--min-margin` is the exact-copy vs evasive-reupload discriminator. A true exact
+match aligns nearly all of its hashes into one offset bin, so its `margin` (best
+bin ÷ next-best bin) is enormous — real self-location and transcoded-reupload
+matches score **250–1600×**. A *slightly sped-up* copy (a common content-ID evasion)
+drifts out of alignment into a small scattered cluster: it can still clear the raw
+`--min-votes` floor but its margin collapses to **~1.2–1.7×** (ratio to a few percent,
+span to a fraction of the query). `--min-margin 2` (default 1 = off) rejects those
+partial alignments while passing every true match. (A `--speed-sweep` that instead
+re-fingerprints the query at ±2/±4 % to *match* sped copies is still planned;
+`--min-margin` is the complementary knob that *rejects* them.)
+
+A member whose audio is silent or purely tonal produces **0 constellation hashes**
+and can never match; `audio add` still succeeds but the record carries a
+`payload.warning` so a silent screen-recording isn't mistaken for a searchable member.
 
 ```bash
 overcast index create jingles --type audio-fp --local --json
 overcast audio add ./original.mp4 --to jingles --json        # fingerprint (video → audio track)
 overcast audio match ./suspect.mp4 --index jingles --json    # offset-aligned exact match
+overcast audio match ./suspect.mp4 --index jingles --min-margin 2 --json  # reject sped-up re-uploads
 overcast audio match ./a.mp3 ./b.mp3 --json                  # clip-to-clip, no index
 ```
 
@@ -394,9 +409,19 @@ to a track vector, or stored per-window as moments with `--granularity frame`.
 ```bash
 overcast index create sounds --type basic-clap --local --json
 overcast similar add ./scene.wav --index sounds --json        # embed + cache (10s windows)
-overcast similar match ./query.wav --index sounds --json      # audio → audio
+overcast similar match ./query.wav --index sounds --json      # audio → audio (strong: 20–90)
 overcast similar search "crowd chanting" --index sounds --json # text → audio
+overcast similar search "a person speaking" --index sounds --min-similarity -100 --json  # see full ranking
 ```
+
+Audio→audio scores are strong and well-separated (same-source clips rank 80–90,
+unrelated 20–30). **Text→audio is weaker and low-magnitude** — CLAP text queries
+often score near or *below* zero even for the right clip, and short generic phrases
+can be unreliable. Because `--min-similarity` defaults to `0`, a text search can
+come back empty even when a best candidate exists; the floor now accepts negatives
+(`-100…100`, cosine×100's true range), so pass e.g. `--min-similarity -100` to
+retrieve the full ranking. For finding a specific sound, audio→audio `match` is far
+more reliable than text `search`.
 
 The default model is `laion/larger_clap_general` (Apache-2.0, ~776 MB), overridable
 via `OC_CLAP_MODEL`; `OC_CLAP_DEVICE` defaults to `cpu`. **The first CLAP call

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -75,6 +75,8 @@ Catalog presets:
 | `owl-local` | `see:owl-local` |
 | `deepface-local` | `face:deepface-local` |
 | `basic-clip` | `similar:basic-clip` |
+| `audio-fp` | `audio:audio-fp` |
+| `basic-clap` | `similar:basic-clap` |
 
 Common environment:
 
@@ -86,6 +88,8 @@ Common environment:
 | `elevenlabs` | `ELEVENLABS_API_KEY` |
 | `owl-local` | optional `DETECT_MODEL` |
 | `deepface-local` | optional `OC_VISUAL_DB_PY` / `OVERCAST_VISUAL_DB_PY` |
+| `audio-fp` | optional `OC_VISUAL_DB_PY` / `OVERCAST_VISUAL_DB_PY` |
+| `basic-clap` | optional `OC_VISUAL_DB_PY` / `OVERCAST_VISUAL_DB_PY`, `OC_CLAP_MODEL` |
 
 After provider/profile setup, use `case setup` for per-investigation policy:
 
@@ -258,7 +262,10 @@ below). They use shipped Python providers under
 scripts/visual-db-uv.sh          # image matching: opencv-python + numpy
 scripts/visual-db-uv.sh --face   # face matching too: deepface + tf-keras
 scripts/visual-db-uv.sh --clip   # CLIP semantic search: open_clip + torch + pillow
-overcast doctor --json              # reports uv + visual-db readiness
+scripts/visual-db-uv.sh --audio  # audio fingerprinting: scipy (see Audio DBs below)
+scripts/visual-db-uv.sh --clap   # CLAP audio embeddings: transformers + torch
+scripts/visual-db-uv.sh --all    # everything (one shared torch for CLIP + CLAP)
+overcast doctor --json              # reports uv + visual-db + audio-db readiness
 
 overcast provider setup apply --verb face --choice deepface-local --profile local --yes --json
 overcast face ./clip.mp4 --profile local --fps 0.5 --max-frames 32 --json
@@ -347,8 +354,63 @@ The record (`similar.match`) emits ranked `payload.matches[]` (`ref`, `similarit
 `OC_CLIP_MODEL` (default `ViT-B-32`) and `OC_CLIP_PRETRAINED` (default `openai`);
 `OC_CLIP_DEVICE` defaults to `cpu`.
 
-These emit ordinary Overcast records (`image.match`, `face.analysis`, or
-`similar.match`) and write
+## Audio DBs (`audio-fp`, `basic-clap`)
+
+The audio counterparts of `image-ransac` and `basic-clip`, under
+`examples/providers/audio-db/` and the same uv-managed Python (install with
+`scripts/visual-db-uv.sh --audio` and/or `--clap`; the `audio-db` doctor check
+reports both halves). Both decode a file's first audio stream via the system
+ffmpeg (so a **video** member's audio track is used automatically) and follow the
+loose-record + `indexes.json` wire contract of the visual-DB scripts.
+
+`audio-fp` is a local **Shazam-style** exact-recording matcher (Wang 2003
+constellation hashing: STFT → spectral peak picking → anchor/target-zone pair
+hashing → offset-histogram voting; pure numpy/scipy, reimplemented from the paper
+and MIT references). `audio add` fingerprints + caches a recording (`fp/<sha1>.npz`
+under the index dir, keyed on `config_hash` + `mtime`, mirroring `basic-clip`'s
+cache discipline — reads never write). `audio match` fingerprints the query and
+votes it against each member (or, in `audio match <query> <reference>`, a single
+clip with no index). A match reports the aligned-vote count, the `offset_seconds`
+where the query lines up inside the recording, the `match_ratio`, and a `margin`
+over the next-best alignment; `--min-votes` (default 6) is the confidence floor and
+`--min-ratio` an optional aligned/total ratio floor. Robust to transcode, noise,
+and clipping; **not** to pitch/speed change (a sped-up copy won't match — a
+`--speed-sweep` variant is planned).
+
+```bash
+overcast index create jingles --type audio-fp --local --json
+overcast audio add ./original.mp4 --to jingles --json        # fingerprint (video → audio track)
+overcast audio match ./suspect.mp4 --index jingles --json    # offset-aligned exact match
+overcast audio match ./a.mp3 ./b.mp3 --json                  # clip-to-clip, no index
+```
+
+`basic-clap` is a local **LAION CLAP** (transformers `ClapModel`) DB for **audio
+semantic similarity** — audio→audio (`match`) and text→audio (`search`), the audio
+analog of `basic-clip`. It reuses the `similar` verb grammar and the
+`basic-clip` cache layout (`emb/<sha1>.npy` + sidecar, 512-d L2-normed vectors,
+cosine×100). Audio is chunked into `--window`-second slices (default 10s), pooled
+to a track vector, or stored per-window as moments with `--granularity frame`.
+
+```bash
+overcast index create sounds --type basic-clap --local --json
+overcast similar add ./scene.wav --index sounds --json        # embed + cache (10s windows)
+overcast similar match ./query.wav --index sounds --json      # audio → audio
+overcast similar search "crowd chanting" --index sounds --json # text → audio
+```
+
+The default model is `laion/larger_clap_general` (Apache-2.0, ~776 MB), overridable
+via `OC_CLAP_MODEL`; `OC_CLAP_DEVICE` defaults to `cpu`. **The first CLAP call
+downloads the weights** to the Hugging Face cache — pre-warm it (e.g.
+`python -c "from transformers import ClapModel; ClapModel.from_pretrained('laion/larger_clap_general')"`),
+then set `HF_HUB_OFFLINE=1` for fully offline runs; `overcast doctor` only probes
+imports and never triggers a download. **Shared-venv note:** `--clip` (open-clip-torch)
+and `--clap` (transformers) both ride torch. Installing both at once with
+`scripts/visual-db-uv.sh --all` lets uv resolve a single shared torch; upgrading one
+package independently later can bump torch under the other, so prefer `--all` when
+you want the full visual+audio stack.
+
+These emit ordinary Overcast records (`image.match`, `face.analysis`, `audio.match`,
+or `similar.match`) and write
 local artifacts under the case `.overcast/` store. Local-grep/qmd memory indexes
 should index the records and summaries only; do not ingest raw media, embeddings,
 sampled frames, face boxes, or match visualization images as text. Add `note`,
@@ -368,6 +430,7 @@ sample 8 frames.
 - [`examples/providers/detect/detect.py`](../examples/providers/detect/detect.py) — OWLv2 open-vocabulary `see` object detector (OWLv2 / Grounding DINO), image + video.
 - [`examples/providers/tinycloud/see.sh`](../examples/providers/tinycloud/see.sh) — Cloudglue tinycloud image `see`/`extract` provider (describe + on-screen text; boxless `--prompt`/`--detect` facts; tinycloud ≥ 0.3.7).
 - [`examples/providers/visual-db/{image_match,face_match,clip_match,face_cluster}.py`](../examples/providers/visual-db/) — local image RANSAC, DeepFace, CLIP (basic-clip), and face-cluster DB matching for visual DB indexes.
+- [`examples/providers/audio-db/{audio_match,clap_match}.py`](../examples/providers/audio-db/) — local Shazam-style fingerprint matching (audio-fp) and LAION CLAP audio embeddings (basic-clap) for audio DB indexes.
 - [`examples/providers/sources/{youtube,tiktok,x,web,lens}.sh`](../examples/providers/sources/) — yt-dlp + Apify (tiktok/x/lens) + web-search (Tavily/Brave) + Google Lens reverse-image source providers.
 
 ## Source providers (built-in types)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -391,11 +391,20 @@ A member whose audio is silent or purely tonal produces **0 constellation hashes
 and can never match; `audio add` still succeeds but the record carries a
 `payload.warning` so a silent screen-recording isn't mistaken for a searchable member.
 
+`--draw` renders a dependency-free **SVG alignment visualization** per match (the
+Shazam analog of `image --draw`'s `cv2.drawMatches`): a scatter of every matching
+`(query-time, member-time)` hash pair — a true match is a tight bright band, a
+speed-drift/false match is a short scattered cluster — plus the offset-vote
+histogram (one sharp spike for a real match). The `.svg` lands in the case media
+store under `audio-matches/`, its path in `matches[].match_draw_path`, and the
+`brief`/`case status` HTML embeds it exactly like the image-match overlays.
+
 ```bash
 overcast index create jingles --type audio-fp --local --json
 overcast audio add ./original.mp4 --to jingles --json        # fingerprint (video → audio track)
 overcast audio match ./suspect.mp4 --index jingles --json    # offset-aligned exact match
 overcast audio match ./suspect.mp4 --index jingles --min-margin 2 --json  # reject sped-up re-uploads
+overcast audio match ./suspect.mp4 --index jingles --draw --json          # + SVG alignment plot
 overcast audio match ./a.mp3 ./b.mp3 --json                  # clip-to-clip, no index
 ```
 

--- a/examples/providers/audio-db/audio_match.py
+++ b/examples/providers/audio-db/audio_match.py
@@ -62,6 +62,7 @@ def parse():
     p.add_argument("--against")  # pairwise: a second clip (no index)
     p.add_argument("--min-votes", dest="min_votes", type=int, default=6)
     p.add_argument("--min-ratio", dest="min_ratio", type=float, default=0.0)
+    p.add_argument("--min-margin", dest="min_margin", type=float, default=1.0)
     p.add_argument("input")
     return p.parse_args()
 
@@ -251,10 +252,17 @@ def build_member(ref, cfg, index_dir, op, persist=True):
 
 # ---- offset-histogram scoring ----------------------------------------------
 
-def score_member(q_hashes, q_times, m_hashes, m_times, cfg, min_votes, min_ratio):
+def score_member(q_hashes, q_times, m_hashes, m_times, cfg, min_votes, min_ratio, min_margin=1.0):
     """Vote query hashes against a member; return a match dict (offset, votes,
     ratio, margin, span) or None. Merges +/-1 delta bins so frame quantization
-    doesn't split a true alignment across the confirm threshold."""
+    doesn't split a true alignment across the confirm threshold.
+
+    A true exact match aligns almost all of its hashes into ONE offset bin, so it
+    has an overwhelming margin over the second-best bin (real matches score
+    500-1600x). A pitch/speed-changed copy drifts out of alignment and leaves only
+    a small scattered cluster (margin ~1.2-1.7, low ratio, short span) — `min_margin`
+    lets exact-copy detection reject those partial alignments the raw vote floor
+    would otherwise confirm."""
     if q_hashes.size == 0 or m_hashes.size == 0:
         return None
     mdict = defaultdict(list)
@@ -293,14 +301,15 @@ def score_member(q_hashes, q_times, m_hashes, m_times, cfg, min_votes, min_ratio
     span_frames = (max(aligned_tqs) - min(aligned_tqs)) if aligned_tqs else 0
     total_query_hashes = int(q_hashes.size)
     match_ratio = aligned_votes / max(1, total_query_hashes)
+    margin = aligned_votes / max(1, second)
     return {
         "offset_seconds": round(best_c * hop / float(sr), 2),
         "aligned_votes": int(aligned_votes),
         "total_query_hashes": total_query_hashes,
         "match_ratio": round(match_ratio, 4),
-        "margin": round(aligned_votes / max(1, second), 2),
+        "margin": round(margin, 2),
         "span_seconds": round(span_frames * hop / float(sr), 2),
-        "_confirmed": aligned_votes >= min_votes and match_ratio >= min_ratio,
+        "_confirmed": aligned_votes >= min_votes and match_ratio >= min_ratio and margin >= min_margin,
     }
 
 
@@ -314,14 +323,21 @@ def op_add(args):
         fail("audio add requires --index/--index-dir", ref, "add")
     cfg = read_config(args.index_dir)
     hashes, times, duration = _member_or_fail(ref, cfg, args.index_dir)
+    payload = {
+        "op": "add", "index": args.index, "file": ref,
+        "hashes": int(hashes.size), "duration_seconds": duration,
+        "summary": "fingerprinted %s into %s (%d hashes, %.1fs)" % (Path(ref).name, args.index, int(hashes.size), duration),
+    }
+    # a member with no (or barely any) constellation hashes is effectively
+    # silent/tonal and will never match — surface it rather than registering a
+    # dead member the user thinks is searchable.
+    if hashes.size == 0:
+        payload["warning"] = "no fingerprint hashes — the audio is silent or too quiet/tonal to fingerprint; this member cannot be matched"
+        payload["summary"] = "fingerprinted %s into %s but produced 0 hashes (silent/unmatchable audio)" % (Path(ref).name, args.index)
     emit({
         "verb": "audio",
         "format": "json",
-        "payload": {
-            "op": "add", "index": args.index, "file": ref,
-            "hashes": int(hashes.size), "duration_seconds": duration,
-            "summary": "fingerprinted %s into %s (%d hashes, %.1fs)" % (Path(ref).name, args.index, int(hashes.size), duration),
-        },
+        "payload": payload,
         "media": {"ref": ref},
         "meta": {"provider": "local:audio-fp", "model": MODEL},
         "state": "ready",
@@ -341,6 +357,8 @@ def op_match(args):
         fail("--min-votes must be at least 1", args.input, op)
     if args.min_ratio < 0 or args.min_ratio > 1:
         fail("--min-ratio must be between 0 and 1", args.input, op)
+    if args.min_margin < 1:
+        fail("--min-margin must be at least 1", args.input, op)
 
     if args.against:
         # ---- pairwise: fingerprint both, no index ----
@@ -353,7 +371,7 @@ def op_match(args):
         m_hashes, m_times, _, m_dur = fingerprint_file(args.against, cfg, op)
         matches = []
         best_rejected = None
-        s = score_member(q_hashes, q_times, m_hashes, m_times, cfg, args.min_votes, args.min_ratio)
+        s = score_member(q_hashes, q_times, m_hashes, m_times, cfg, args.min_votes, args.min_ratio, args.min_margin)
         if s:
             item = {"ref": args.against, "duration_seconds": m_dur, **_public(s)}
             if s["_confirmed"]:
@@ -379,7 +397,7 @@ def op_match(args):
         if not built:
             continue
         m_hashes, m_times, m_dur = built
-        s = score_member(q_hashes, q_times, m_hashes, m_times, cfg, args.min_votes, args.min_ratio)
+        s = score_member(q_hashes, q_times, m_hashes, m_times, cfg, args.min_votes, args.min_ratio, args.min_margin)
         if not s:
             continue
         item = {"ref": mem["ref"], "duration_seconds": m_dur, **_public(s)}

--- a/examples/providers/audio-db/audio_match.py
+++ b/examples/providers/audio-db/audio_match.py
@@ -63,6 +63,7 @@ def parse():
     p.add_argument("--min-votes", dest="min_votes", type=int, default=6)
     p.add_argument("--min-ratio", dest="min_ratio", type=float, default=0.0)
     p.add_argument("--min-margin", dest="min_margin", type=float, default=1.0)
+    p.add_argument("--draw", action="store_true", help="render an SVG alignment visualization per match")
     p.add_argument("input")
     return p.parse_args()
 
@@ -310,7 +311,103 @@ def score_member(q_hashes, q_times, m_hashes, m_times, cfg, min_votes, min_ratio
         "margin": round(margin, 2),
         "span_seconds": round(span_frames * hop / float(sr), 2),
         "_confirmed": aligned_votes >= min_votes and match_ratio >= min_ratio and margin >= min_margin,
+        # plotting data for --draw (stripped from the public payload by _public):
+        # every matching (query-time, member-time) hash pair + the winning offset.
+        "_tqs": tqs, "_deltas": deltas, "_best_c": best_c,
     }
+
+
+# ---- match visualization (dependency-free SVG) -----------------------------
+# The Shazam analog of image_match.py's cv2.drawMatches: a scatter of every
+# matching (query-time, member-time) hash pair — a true match is a tight bright
+# diagonal at the offset, a spurious/speed-drift match is scattered — plus the
+# offset-vote histogram (one sharp spike for a real match). Hand-rolled SVG so it
+# needs no matplotlib; the .svg file drops into the case media store and the brief
+# HTML embeds it exactly like the image-match overlays.
+
+def _esc(s):
+    return str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def render_match_svg(query_name, member_name, s, cfg, out_dir):
+    tqs = s.get("_tqs") or []
+    deltas = s.get("_deltas") or []
+    best_c = s.get("_best_c", 0)
+    if not tqs:
+        return None
+    hop = cfg["hop"]
+    sr = cfg["sampleRate"]
+    to_s = hop / float(sr)
+    # (query_time, member_time) pairs in seconds; flag the aligned ones (the votes)
+    pts = [(tq * to_s, (tq + d) * to_s, abs(d - best_c) <= 1) for tq, d in zip(tqs, deltas)]
+    # cap plotted dots so the SVG stays small on dense audio (keep all aligned)
+    aligned = [p for p in pts if p[2]]
+    noise = [p for p in pts if not p[2]]
+    if len(noise) > 3000:
+        step = len(noise) / 3000.0
+        noise = [noise[int(i * step)] for i in range(3000)]
+    if len(aligned) > 3000:
+        step = len(aligned) / 3000.0
+        aligned = [aligned[int(i * step)] for i in range(3000)]
+
+    W, H = 720, 460
+    pad = 44
+    sc_h = 300  # scatter panel height
+    qmax = max((p[0] for p in pts), default=1.0) or 1.0
+    mmax = max((p[1] for p in pts), default=1.0) or 1.0
+
+    def sx(q):
+        return pad + (q / qmax) * (W - 2 * pad)
+
+    def sy(m):
+        return pad + (1 - m / mmax) * (sc_h - pad)
+
+    parts = ['<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d" font-family="monospace">' % (W, H, W, H)]
+    parts.append('<rect width="%d" height="%d" fill="#0a0f0d"/>' % (W, H))
+    off = best_c * to_s
+    conf = "CONFIRMED" if s.get("_confirmed") else "rejected"
+    color = "#39ff14" if s.get("_confirmed") else "#ff5f56"
+    parts.append('<text x="%d" y="20" fill="%s" font-size="13">%s  %s -> %s</text>' % (pad, color, conf, _esc(query_name), _esc(member_name)))
+    parts.append('<text x="%d" y="36" fill="#8fa" font-size="11">offset=%.2fs  votes=%d  ratio=%.3f  margin=%.1fx  span=%.1fs</text>'
+                 % (pad, off, s["aligned_votes"], s["match_ratio"], s["margin"], s["span_seconds"]))
+    # scatter axes
+    parts.append('<rect x="%d" y="%d" width="%d" height="%d" fill="none" stroke="#1e3b30"/>' % (pad, pad, W - 2 * pad, sc_h - pad))
+    parts.append('<text x="%d" y="%d" fill="#5a7" font-size="10">member time (s) ^   |   query time (s) ></text>' % (pad + 4, sc_h + 2))
+    # the offset diagonal member_t = query_t + offset (the true-match line)
+    x0, x1 = 0.0, qmax
+    parts.append('<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="#2f6" stroke-dasharray="4 4" opacity="0.5"/>'
+                 % (sx(x0), sy(x0 + off), sx(x1), sy(min(mmax, x1 + off))))
+    for q, m, _a in noise:
+        parts.append('<circle cx="%.1f" cy="%.1f" r="1" fill="#3a5" opacity="0.35"/>' % (sx(q), sy(m)))
+    for q, m, _a in aligned:
+        parts.append('<circle cx="%.1f" cy="%.1f" r="1.6" fill="%s" opacity="0.9"/>' % (sx(q), sy(m), color))
+
+    # offset histogram (bottom strip)
+    hist = Counter(int(round(d * to_s)) for d in deltas)  # 1-second offset bins
+    hy0, hy1 = sc_h + 24, H - 16
+    hmax = max(hist.values()) if hist else 1
+    keys = sorted(hist.keys())
+    kmin, kmax = (keys[0], keys[-1]) if keys else (0, 1)
+    span = max(1, kmax - kmin)
+    bw = max(1.0, (W - 2 * pad) / (span + 1))
+    parts.append('<text x="%d" y="%d" fill="#5a7" font-size="10">offset-vote histogram (spike = the match)</text>' % (pad, hy0 - 4))
+    for k, v in hist.items():
+        bx = pad + ((k - kmin) / span) * (W - 2 * pad - bw)
+        bh = (v / hmax) * (hy1 - hy0)
+        bc = color if abs(k - int(round(off))) <= 1 else "#2a6"
+        parts.append('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" fill="%s"/>' % (bx, hy1 - bh, bw, bh, bc))
+    parts.append('</svg>')
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    key = hashlib.sha1(("%s|%s" % (query_name, member_name)).encode()).hexdigest()[:16]
+    path = out_dir / ("match_%s.svg" % key)
+    path.write_text("\n".join(parts))
+    return str(path.resolve())
+
+
+def draw_dir(args):
+    base = os.environ.get("OVERCAST_MEDIA_DIR") or args.index_dir or "."
+    return Path(base) / "audio-matches"
 
 
 # ---- ops -------------------------------------------------------------------
@@ -374,6 +471,10 @@ def op_match(args):
         s = score_member(q_hashes, q_times, m_hashes, m_times, cfg, args.min_votes, args.min_ratio, args.min_margin)
         if s:
             item = {"ref": args.against, "duration_seconds": m_dur, **_public(s)}
+            if args.draw:
+                p = render_match_svg(Path(args.input).name, Path(args.against).name, s, cfg, draw_dir(args))
+                if p:
+                    item["match_draw_path"] = p
             if s["_confirmed"]:
                 matches.append(item)
             else:
@@ -390,8 +491,8 @@ def op_match(args):
         fail("local audio-fp index has no members — add some with `audio add ... --index %s`" % args.index, args.input, op)
     q_hashes, q_times, _, q_dur = fingerprint_file(args.input, cfg, op)
 
-    matches = []
-    best_rejected = None
+    scored = []          # (item, s) for confirmed matches
+    best = None          # (item, s) for the single best rejected candidate
     for mem in members:
         built = build_member(mem["ref"], cfg, args.index_dir, op, persist=False)
         if not built:
@@ -404,10 +505,19 @@ def op_match(args):
         if mem.get("recordId"):
             item["recordId"] = mem["recordId"]
         if s["_confirmed"]:
-            matches.append(item)
-        elif best_rejected is None or item["aligned_votes"] > best_rejected["aligned_votes"]:
-            best_rejected = item
-    matches.sort(key=lambda x: x["aligned_votes"], reverse=True)
+            scored.append((item, s))
+        elif best is None or item["aligned_votes"] > best[0]["aligned_votes"]:
+            best = (item, s)
+    scored.sort(key=lambda pair: pair[0]["aligned_votes"], reverse=True)
+    # render only the confirmed matches + the single best rejected (bounds the
+    # SVG count regardless of how many members share a few coincidental hashes)
+    if args.draw:
+        for it, sc in scored + ([best] if best else []):
+            p = render_match_svg(Path(args.input).name, Path(it["ref"]).name, sc, cfg, draw_dir(args))
+            if p:
+                it["match_draw_path"] = p
+    matches = [it for it, _ in scored]
+    best_rejected = best[0] if best else None
     _emit_match(args, op, matches, q_hashes.size, q_dur, cfg, index=args.index, best_rejected=best_rejected)
 
 

--- a/examples/providers/audio-db/audio_match.py
+++ b/examples/providers/audio-db/audio_match.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+# Local Shazam-style audio fingerprint DB (`audio-fp`) provider for overcast's
+# `audio` verb. Exact-recording matching via the Wang 2003 constellation
+# algorithm: STFT -> spectral peak picking -> anchor/target-zone pair hashing ->
+# offset-histogram voting. Fingerprints are precomputed + cached on `add` under
+# <index-dir>/fp/<sha1(ref)>.npz (+ .json sidecar); `match` fingerprints the query
+# and votes it against each member (indexed) or a single reference (pairwise).
+#
+# Reimplemented from the Wang 2003 paper and MIT references (dejavu / abracadabra
+# / audfprint) — no code copied from unlicensed sources. Robust to
+# transcode/noise/clipping; NOT robust to pitch/speed change (classic Wang).
+#
+# Same wire contract as the visual-db scripts: read members from
+# .overcast/indexes.json, emit exactly ONE JSON record on stdout, try-import deps
+# and emit a state:"error" record on failure, ffmpeg/ffprobe via env overrides.
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+MODEL = "wang2003"
+
+# Fingerprint params — defaults MUST match src/providers/local/audio.ts
+# defaultAudioFpConfig(); the index's config.json overrides them per-index.
+DEFAULT_CONFIG = {
+    "sampleRate": 11025,
+    "nFft": 2048,
+    "hop": 512,
+    "peakNeighborhood": 15,
+    "peakFloorDb": 20,
+    "fanOut": 15,
+    "minDt": 1,
+    "maxDt": 64,
+}
+
+
+def emit(rec):
+    sys.stdout.write(json.dumps(rec) + "\n")
+
+
+def fail(msg, inp="", op="match", state="error"):
+    emit({
+        "verb": "audio",
+        "format": "json",
+        "payload": {"op": op, "matches": [], "count": 0},
+        "media": {"ref": inp} if inp else None,
+        "error": msg,
+        "state": state,
+    })
+    sys.exit(0)
+
+
+def parse():
+    p = argparse.ArgumentParser()
+    p.add_argument("--op", choices=["add", "match"], required=True)
+    p.add_argument("--index")
+    p.add_argument("--index-dir", dest="index_dir")
+    p.add_argument("--against")  # pairwise: a second clip (no index)
+    p.add_argument("--min-votes", dest="min_votes", type=int, default=6)
+    p.add_argument("--min-ratio", dest="min_ratio", type=float, default=0.0)
+    p.add_argument("input")
+    return p.parse_args()
+
+
+def read_config(index_dir):
+    cfg = dict(DEFAULT_CONFIG)
+    if index_dir:
+        try:
+            parsed = json.loads((Path(index_dir) / "config.json").read_text())
+            for k in DEFAULT_CONFIG:
+                if parsed.get(k) is not None:
+                    cfg[k] = parsed[k]
+        except Exception:
+            pass
+    return cfg
+
+
+def config_hash(cfg):
+    payload = json.dumps({**cfg, "model": MODEL}, sort_keys=True)
+    return hashlib.sha1(payload.encode()).hexdigest()
+
+
+def members_full(index_dir, index_id):
+    idx_file = Path(index_dir).parent.parent / "indexes.json"
+    try:
+        store = json.loads(idx_file.read_text())
+    except Exception:
+        return []
+    for idx in store.get("indexes", []):
+        if idx.get("id") == index_id:
+            return [{"ref": m.get("ref"), "recordId": m.get("recordId")} for m in idx.get("members", []) if m.get("ref")]
+    return []
+
+
+# ---- ffmpeg decode ---------------------------------------------------------
+
+def has_audio(path):
+    probe = os.environ.get("OVERCAST_FFPROBE") or "ffprobe"
+    try:
+        out = subprocess.run(
+            [probe, "-v", "error", "-select_streams", "a", "-show_entries", "stream=codec_type", "-of", "csv=p=0", path],
+            capture_output=True, text=True, timeout=30,
+        )
+        return "audio" in out.stdout
+    except Exception:
+        # can't probe → let the decode attempt surface the real error
+        return True
+
+
+def decode_mono(path, sr):
+    """Decode a file's first audio stream to a mono float32 numpy array at `sr`.
+    Streams f32le over a pipe (no temp files). Returns None on failure."""
+    import numpy as np
+    ffmpeg = os.environ.get("OVERCAST_FFMPEG") or "ffmpeg"
+    cmd = [ffmpeg, "-v", "error", "-i", path, "-map", "0:a:0", "-ac", "1", "-ar", str(int(sr)), "-f", "f32le", "-"]
+    try:
+        r = subprocess.run(cmd, capture_output=True, timeout=600)
+    except Exception:
+        return None
+    if r.returncode != 0 or not r.stdout:
+        return None
+    return np.frombuffer(r.stdout, dtype=np.float32)
+
+
+# ---- fingerprint (Wang 2003) -----------------------------------------------
+
+def fingerprint(samples, cfg):
+    """Return (hashes uint32[N], times uint32[N], n_frames). Constellation-map
+    peak pairs hashed into 32-bit ints, each tagged with its anchor time frame."""
+    import numpy as np
+    from scipy.signal import stft
+    from scipy.ndimage import maximum_filter
+
+    sr = cfg["sampleRate"]
+    nfft = cfg["nFft"]
+    hop = cfg["hop"]
+    if samples.size < nfft:
+        return np.zeros(0, dtype=np.uint32), np.zeros(0, dtype=np.uint32), 0
+
+    _, _, Z = stft(samples, fs=sr, nperseg=nfft, noverlap=nfft - hop, boundary=None, padded=False)
+    S = 20.0 * np.log10(np.abs(Z) + 1e-10)  # (freq, time) dB magnitude
+    n_frames = S.shape[1]
+
+    neigh = cfg["peakNeighborhood"]
+    local_max = maximum_filter(S, size=(neigh, neigh), mode="constant") == S
+    thresh = np.median(S) + cfg["peakFloorDb"]
+    peak_mask = local_max & (S > thresh)
+    freqs, frames = np.where(peak_mask)
+    if freqs.size == 0:
+        return np.zeros(0, dtype=np.uint32), np.zeros(0, dtype=np.uint32), n_frames
+
+    # sort peaks by time frame for target-zone scanning
+    order = np.argsort(frames, kind="stable")
+    tf = frames[order]
+    ff = freqs[order]
+
+    fan_out = cfg["fanOut"]
+    min_dt = cfg["minDt"]
+    max_dt = cfg["maxDt"]
+    hashes = []
+    times = []
+    n = tf.size
+    for i in range(n):
+        t1 = int(tf[i])
+        f1 = int(ff[i]) & 0x3FF  # 10 bits
+        paired = 0
+        j = i + 1
+        while j < n and paired < fan_out:
+            dt = int(tf[j]) - t1
+            if dt > max_dt:
+                break
+            if dt >= min_dt:
+                f2 = int(ff[j]) & 0x3FF  # 10 bits
+                h = ((f1 & 0x3FF) << 22) | ((f2 & 0x3FF) << 12) | (dt & 0xFFF)
+                hashes.append(h)
+                times.append(t1)
+                paired += 1
+            j += 1
+    return (
+        np.asarray(hashes, dtype=np.uint32),
+        np.asarray(times, dtype=np.uint32),
+        n_frames,
+    )
+
+
+def fingerprint_file(path, cfg, op):
+    """Decode + fingerprint a file. fail()s with a clear message on any problem."""
+    import numpy as np  # noqa: F401
+    if not has_audio(path):
+        fail("input has no audio stream: %s" % path, path, op)
+    samples = decode_mono(path, cfg["sampleRate"])
+    if samples is None or samples.size == 0:
+        fail("could not decode audio from: %s" % path, path, op)
+    hashes, times, n_frames = fingerprint(samples, cfg)
+    duration = round(len(samples) / float(cfg["sampleRate"]), 2)
+    return hashes, times, n_frames, duration
+
+
+# ---- fingerprint cache -----------------------------------------------------
+
+def cache_paths(index_dir, ref):
+    key = hashlib.sha1(ref.encode()).hexdigest()
+    fp_dir = Path(index_dir) / "fp"
+    return fp_dir / ("%s.npz" % key), fp_dir / ("%s.json" % key)
+
+
+def build_member(ref, cfg, index_dir, op, persist=True):
+    """Load a member's cached fingerprint (fresh) or compute + cache it. Returns
+    (hashes, times, duration) or None when the ref is unreadable. persist=False
+    (query-time) keeps a recomputed fingerprint in memory only — reads never
+    write. Freshness keys on config_hash + file mtime (mirrors clip_match.py)."""
+    import numpy as np
+    path = Path(ref)
+    if not path.exists():
+        return None
+    npz, sidecar = cache_paths(index_dir, ref)
+    chash = config_hash(cfg)
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    if npz.exists() and sidecar.exists():
+        try:
+            meta = json.loads(sidecar.read_text())
+            fresh = meta.get("config_hash") == chash and abs(float(meta.get("mtime", -1)) - mtime) < 1e-6
+            if fresh:
+                data = np.load(str(npz))
+                return data["hashes"], data["times"], float(meta.get("duration_seconds", 0.0))
+        except Exception:
+            pass
+    if not has_audio(ref):
+        return None
+    samples = decode_mono(ref, cfg["sampleRate"])
+    if samples is None or samples.size == 0:
+        return None
+    hashes, times, _ = fingerprint(samples, cfg)
+    duration = round(len(samples) / float(cfg["sampleRate"]), 2)
+    if persist:
+        npz.parent.mkdir(parents=True, exist_ok=True)
+        np.savez(str(npz), hashes=hashes, times=times)
+        sidecar.write_text(json.dumps({
+            "ref": ref, "config_hash": chash, "mtime": mtime,
+            "n_hashes": int(hashes.size), "duration_seconds": duration, "model": MODEL,
+        }))
+    return hashes, times, duration
+
+
+# ---- offset-histogram scoring ----------------------------------------------
+
+def score_member(q_hashes, q_times, m_hashes, m_times, cfg, min_votes, min_ratio):
+    """Vote query hashes against a member; return a match dict (offset, votes,
+    ratio, margin, span) or None. Merges +/-1 delta bins so frame quantization
+    doesn't split a true alignment across the confirm threshold."""
+    if q_hashes.size == 0 or m_hashes.size == 0:
+        return None
+    mdict = defaultdict(list)
+    for h, t in zip(m_hashes.tolist(), m_times.tolist()):
+        mdict[h].append(t)
+    deltas = []
+    tqs = []
+    for h, t in zip(q_hashes.tolist(), q_times.tolist()):
+        hits = mdict.get(h)
+        if not hits:
+            continue
+        for tdb in hits:
+            deltas.append(tdb - t)
+            tqs.append(t)
+    if not deltas:
+        return None
+
+    counts = Counter(deltas)
+    centers = sorted(counts.keys())
+
+    def window(c):
+        return counts.get(c - 1, 0) + counts.get(c, 0) + counts.get(c + 1, 0)
+
+    best_c = max(centers, key=window)
+    aligned_votes = window(best_c)
+    second = 0
+    for c in centers:
+        if abs(c - best_c) >= 3:
+            w = window(c)
+            if w > second:
+                second = w
+
+    hop = cfg["hop"]
+    sr = cfg["sampleRate"]
+    aligned_tqs = [tq for d, tq in zip(deltas, tqs) if abs(d - best_c) <= 1]
+    span_frames = (max(aligned_tqs) - min(aligned_tqs)) if aligned_tqs else 0
+    total_query_hashes = int(q_hashes.size)
+    match_ratio = aligned_votes / max(1, total_query_hashes)
+    return {
+        "offset_seconds": round(best_c * hop / float(sr), 2),
+        "aligned_votes": int(aligned_votes),
+        "total_query_hashes": total_query_hashes,
+        "match_ratio": round(match_ratio, 4),
+        "margin": round(aligned_votes / max(1, second), 2),
+        "span_seconds": round(span_frames * hop / float(sr), 2),
+        "_confirmed": aligned_votes >= min_votes and match_ratio >= min_ratio,
+    }
+
+
+# ---- ops -------------------------------------------------------------------
+
+def op_add(args):
+    ref = args.input
+    if not Path(ref).exists():
+        fail("input not found: %s" % ref, ref, "add")
+    if not args.index or not args.index_dir:
+        fail("audio add requires --index/--index-dir", ref, "add")
+    cfg = read_config(args.index_dir)
+    hashes, times, duration = _member_or_fail(ref, cfg, args.index_dir)
+    emit({
+        "verb": "audio",
+        "format": "json",
+        "payload": {
+            "op": "add", "index": args.index, "file": ref,
+            "hashes": int(hashes.size), "duration_seconds": duration,
+            "summary": "fingerprinted %s into %s (%d hashes, %.1fs)" % (Path(ref).name, args.index, int(hashes.size), duration),
+        },
+        "media": {"ref": ref},
+        "meta": {"provider": "local:audio-fp", "model": MODEL},
+        "state": "ready",
+    })
+
+
+def _member_or_fail(ref, cfg, index_dir):
+    built = build_member(ref, cfg, index_dir, "add")
+    if not built:
+        fail("could not fingerprint audio (no readable audio): %s" % ref, ref, "add")
+    return built
+
+
+def op_match(args):
+    op = "match"
+    if args.min_votes < 1:
+        fail("--min-votes must be at least 1", args.input, op)
+    if args.min_ratio < 0 or args.min_ratio > 1:
+        fail("--min-ratio must be between 0 and 1", args.input, op)
+
+    if args.against:
+        # ---- pairwise: fingerprint both, no index ----
+        cfg = read_config(None)
+        if not Path(args.input).exists():
+            fail("input not found: %s" % args.input, args.input, op)
+        if not Path(args.against).exists():
+            fail("reference not found: %s" % args.against, args.input, op)
+        q_hashes, q_times, _, q_dur = fingerprint_file(args.input, cfg, op)
+        m_hashes, m_times, _, m_dur = fingerprint_file(args.against, cfg, op)
+        matches = []
+        best_rejected = None
+        s = score_member(q_hashes, q_times, m_hashes, m_times, cfg, args.min_votes, args.min_ratio)
+        if s:
+            item = {"ref": args.against, "duration_seconds": m_dur, **_public(s)}
+            if s["_confirmed"]:
+                matches.append(item)
+            else:
+                best_rejected = item
+        _emit_match(args, op, matches, q_hashes.size, q_dur, cfg, reference=args.against, best_rejected=best_rejected)
+        return
+
+    # ---- indexed ----
+    if not args.index or not args.index_dir:
+        fail("audio match requires --index/--index-dir or --against <clip>", args.input, op)
+    cfg = read_config(args.index_dir)
+    members = members_full(args.index_dir, args.index)
+    if not members:
+        fail("local audio-fp index has no members — add some with `audio add ... --index %s`" % args.index, args.input, op)
+    q_hashes, q_times, _, q_dur = fingerprint_file(args.input, cfg, op)
+
+    matches = []
+    best_rejected = None
+    for mem in members:
+        built = build_member(mem["ref"], cfg, args.index_dir, op, persist=False)
+        if not built:
+            continue
+        m_hashes, m_times, m_dur = built
+        s = score_member(q_hashes, q_times, m_hashes, m_times, cfg, args.min_votes, args.min_ratio)
+        if not s:
+            continue
+        item = {"ref": mem["ref"], "duration_seconds": m_dur, **_public(s)}
+        if mem.get("recordId"):
+            item["recordId"] = mem["recordId"]
+        if s["_confirmed"]:
+            matches.append(item)
+        elif best_rejected is None or item["aligned_votes"] > best_rejected["aligned_votes"]:
+            best_rejected = item
+    matches.sort(key=lambda x: x["aligned_votes"], reverse=True)
+    _emit_match(args, op, matches, q_hashes.size, q_dur, cfg, index=args.index, best_rejected=best_rejected)
+
+
+def _public(s):
+    return {k: v for k, v in s.items() if not k.startswith("_")}
+
+
+def _emit_match(args, op, matches, n_hashes, q_dur, cfg, index=None, reference=None, best_rejected=None):
+    if matches:
+        top = matches[0]
+        summary = "query matches %s at %s (%d aligned votes)" % (
+            Path(top["ref"]).name, _fmt_offset(top["offset_seconds"]), top["aligned_votes"],
+        )
+    else:
+        summary = "no confident audio match"
+    payload = {
+        "op": op,
+        "summary": summary,
+        "matches": matches,
+        "count": len(matches),
+        "query": {"duration_seconds": q_dur, "n_hashes": int(n_hashes)},
+        "fingerprint": {"sample_rate": cfg["sampleRate"], "n_fft": cfg["nFft"], "hop": cfg["hop"], "fan_out": cfg["fanOut"]},
+    }
+    if index is not None:
+        payload["index"] = index
+    if reference is not None:
+        payload["reference"] = reference
+    if not matches and best_rejected is not None:
+        payload["best_rejected"] = best_rejected
+    emit({
+        "verb": "audio",
+        "format": "json",
+        "payload": payload,
+        # media anchors the QUERY — a matched member's offset lives in matches[].
+        "media": {"ref": args.input},
+        "meta": {"provider": "local:audio-fp", "model": MODEL},
+        "state": "ready",
+    })
+
+
+def _fmt_offset(sec):
+    sec = max(0.0, float(sec))
+    m = int(sec // 60)
+    s = sec - m * 60
+    return "%d:%05.2f" % (m, s) if m else "%.2fs" % s
+
+
+def main():
+    args = parse()
+    inp = args.input
+    if inp.startswith("http://") or inp.startswith("https://"):
+        fail("local audio matcher only supports local files; capture remote media first", inp, args.op)
+    try:
+        import numpy  # noqa: F401
+        import scipy.signal  # noqa: F401
+        import scipy.ndimage  # noqa: F401
+    except Exception as e:
+        fail("audio-fp deps missing: %s (run scripts/visual-db-uv.sh --audio)" % e, inp, args.op)
+    if args.op == "add":
+        op_add(args)
+    else:
+        op_match(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/providers/audio-db/clap_match.py
+++ b/examples/providers/audio-db/clap_match.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# Local CLAP audio-embedding DB (`basic-clap`) provider for overcast's `similar`
+# verb. Cross-modal similarity via LAION CLAP (transformers ClapModel):
+# audio->audio (`match`) and text->audio (`search`). Embeddings are precomputed +
+# cached on `add` under <index-dir>/emb/<sha1(ref)>.npy (+ .json sidecar) — the
+# SAME layout basic-clip uses, so removeClipEmbedding in index.ts cleans it too.
+# Structural clone of clip_match.py with frame sampling replaced by 10s audio
+# windowing. Same wire contract: read members from indexes.json, emit ONE record.
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SR = 48000            # CLAP native sampling rate
+MIN_CHUNK_S = 1.0     # drop a trailing chunk shorter than this (unless it's the only one)
+MAX_WINDOWS = 720     # safety cap (~2h at 10s windows)
+
+
+def emit(rec):
+    sys.stdout.write(json.dumps(rec) + "\n")
+
+
+def fail(msg, inp="", op="match", state="error"):
+    emit({
+        "verb": "similar",
+        "format": "json",
+        "payload": {"op": op, "matches": [], "count": 0},
+        "media": {"ref": inp} if inp else None,
+        "error": msg,
+        "state": state,
+    })
+    sys.exit(0)
+
+
+def parse():
+    p = argparse.ArgumentParser()
+    p.add_argument("--op", choices=["add", "match", "search"], required=True)
+    p.add_argument("--index", required=True)
+    p.add_argument("--index-dir", dest="index_dir", required=True)
+    p.add_argument("--min-similarity", dest="min_similarity", type=float, default=0.0)
+    p.add_argument("--limit", type=int, default=20)
+    p.add_argument("--offset", type=int, default=0)
+    p.add_argument("--pooling", choices=["max", "mean"], default="mean")
+    p.add_argument("--granularity", choices=["video", "frame"], default="video")
+    p.add_argument("--window", type=float, default=10.0)
+    p.add_argument("input")
+    return p.parse_args()
+
+
+def members_full(index_dir, index_id):
+    idx_file = Path(index_dir).parent.parent / "indexes.json"
+    try:
+        store = json.loads(idx_file.read_text())
+    except Exception:
+        return []
+    for idx in store.get("indexes", []):
+        if idx.get("id") == index_id:
+            return [{"ref": m.get("ref"), "recordId": m.get("recordId")} for m in idx.get("members", []) if m.get("ref")]
+    return []
+
+
+# ---- ffmpeg decode ---------------------------------------------------------
+
+def has_audio(path):
+    probe = os.environ.get("OVERCAST_FFPROBE") or "ffprobe"
+    try:
+        out = subprocess.run(
+            [probe, "-v", "error", "-select_streams", "a", "-show_entries", "stream=codec_type", "-of", "csv=p=0", path],
+            capture_output=True, text=True, timeout=30,
+        )
+        return "audio" in out.stdout
+    except Exception:
+        return True
+
+
+def decode_mono(path):
+    import numpy as np
+    ffmpeg = os.environ.get("OVERCAST_FFMPEG") or "ffmpeg"
+    cmd = [ffmpeg, "-v", "error", "-i", path, "-map", "0:a:0", "-ac", "1", "-ar", str(SR), "-f", "f32le", "-"]
+    try:
+        r = subprocess.run(cmd, capture_output=True, timeout=600)
+    except Exception:
+        return None
+    if r.returncode != 0 or not r.stdout:
+        return None
+    return np.frombuffer(r.stdout, dtype=np.float32)
+
+
+def window_audio(samples, window):
+    """Split into consecutive `window`-second chunks (hop == window). Returns
+    (chunks [np arrays], ats [start seconds], truncated bool)."""
+    win = max(1, int(window * SR))
+    min_len = int(MIN_CHUNK_S * SR)
+    chunks = []
+    ats = []
+    i = 0
+    n = samples.size
+    while i < n:
+        chunk = samples[i:i + win]
+        if chunk.size < min_len and chunks:
+            break  # drop a short trailing chunk unless it's the only one
+        chunks.append(chunk)
+        ats.append(round(i / float(SR), 2))
+        i += win
+    if not chunks:
+        chunks = [samples]
+        ats = [0.0]
+    truncated = len(chunks) > MAX_WINDOWS
+    if truncated:
+        chunks = chunks[:MAX_WINDOWS]
+        ats = ats[:MAX_WINDOWS]
+    return chunks, ats, truncated
+
+
+# ---- CLAP model (lazy) -----------------------------------------------------
+
+_MODEL = None
+
+
+def load_model():
+    global _MODEL
+    if _MODEL is None:
+        import torch
+        from transformers import ClapModel, ClapProcessor
+        name = os.environ.get("OC_CLAP_MODEL", "laion/larger_clap_general")
+        device = os.environ.get("OC_CLAP_DEVICE", "cpu")
+        model = ClapModel.from_pretrained(name).to(device)
+        model.eval()
+        processor = ClapProcessor.from_pretrained(name)
+        _MODEL = {"model": model, "processor": processor, "device": device, "name": name, "torch": torch}
+    return _MODEL
+
+
+def l2norm(v):
+    import numpy as np
+    n = np.linalg.norm(v, axis=-1, keepdims=True)
+    n[n == 0] = 1.0
+    return (v / n).astype("float32")
+
+
+def pool(vectors, method):
+    v = vectors.mean(axis=0, keepdims=True) if method == "mean" else vectors.max(axis=0, keepdims=True)
+    return l2norm(v)
+
+
+def _process_audio(processor, batch):
+    # transformers renamed the ClapProcessor kwarg `audios` -> `audio` in v5;
+    # prefer the new name and fall back to the old one for pinned <5 installs.
+    try:
+        return processor(audio=batch, sampling_rate=SR, return_tensors="pt")
+    except (TypeError, ValueError):
+        return processor(audios=batch, sampling_rate=SR, return_tensors="pt")
+
+
+def _features(out):
+    # transformers <5 returns the projected (B, 512) embedding tensor directly;
+    # v5's get_audio_features/get_text_features return an output object whose
+    # pooler_output (== audio_embeds/text_embeds) is that projected embedding.
+    if hasattr(out, "shape"):
+        return out
+    for attr in ("audio_embeds", "text_embeds", "pooler_output"):
+        v = getattr(out, attr, None)
+        if v is not None:
+            return v
+    return out
+
+
+def embed_audio_chunks(chunks):
+    import numpy as np
+    m = load_model()
+    torch = m["torch"]
+    processor = m["processor"]
+    model = m["model"]
+    out = []
+    for i in range(0, len(chunks), 8):
+        batch = [c.astype("float32") for c in chunks[i:i + 8]]
+        inputs = _process_audio(processor, batch)
+        inputs = {k: v.to(m["device"]) for k, v in inputs.items()}
+        with torch.no_grad():
+            feats = _features(model.get_audio_features(**inputs))
+        out.append(feats.cpu().numpy().astype("float32"))
+    return l2norm(np.concatenate(out, axis=0))
+
+
+def embed_text(text):
+    m = load_model()
+    torch = m["torch"]
+    processor = m["processor"]
+    model = m["model"]
+    inputs = processor(text=[text], return_tensors="pt", padding=True)
+    inputs = {k: v.to(m["device"]) for k, v in inputs.items()}
+    with torch.no_grad():
+        feats = _features(model.get_text_features(**inputs))
+    return l2norm(feats.cpu().numpy().astype("float32"))
+
+
+def config_hash(args):
+    m = load_model()
+    payload = json.dumps({
+        "pooling": args.pooling, "granularity": args.granularity,
+        "window": args.window, "model": m["name"],
+    }, sort_keys=True)
+    return hashlib.sha1(payload.encode()).hexdigest()
+
+
+# ---- embedding cache (basic-clip layout) -----------------------------------
+
+def cache_paths(index_dir, ref):
+    key = hashlib.sha1(ref.encode()).hexdigest()
+    emb_dir = Path(index_dir) / "emb"
+    return emb_dir / ("%s.npy" % key), emb_dir / ("%s.json" % key)
+
+
+def embed_media(ref, args):
+    """Return (vectors (N,D) float32, ats [N] with None for pooled, truncated)."""
+    import numpy as np
+    samples = decode_mono(ref)
+    if samples is None or samples.size == 0:
+        return np.zeros((0, 1), dtype="float32"), [], False
+    chunks, ats, truncated = window_audio(samples, args.window)
+    vecs = embed_audio_chunks(chunks)
+    if args.granularity == "frame":
+        return vecs, ats, truncated
+    return pool(vecs, args.pooling), [None], truncated
+
+
+def index_config_args(args):
+    """Member-side config = the PERSISTED index config (config.json), not the
+    per-query flags (mirrors clip_match.py). Falls back to clap defaults."""
+    cfg = {}
+    try:
+        cfg = json.loads((Path(args.index_dir) / "config.json").read_text())
+    except Exception:
+        pass
+    return argparse.Namespace(**{
+        **vars(args),
+        "pooling": cfg.get("pooling") or "mean",
+        "granularity": cfg.get("granularity") or "video",
+        "window": float(cfg.get("window") or 10.0),
+    })
+
+
+def build_member(ref, args, index_dir, persist=True):
+    """Load a member's cached vectors (fresh) or embed + cache them. Returns
+    (vectors, ats, granularity) or None when unreadable. persist=False keeps a
+    rebuilt embedding in memory only — reads never write."""
+    import numpy as np
+    path = Path(ref)
+    if not path.exists():
+        return None
+    npy, sidecar = cache_paths(index_dir, ref)
+    chash = config_hash(args)
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    if npy.exists() and sidecar.exists():
+        try:
+            meta = json.loads(sidecar.read_text())
+            fresh = meta.get("config_hash") == chash and abs(float(meta.get("mtime", -1)) - mtime) < 1e-6
+            if fresh:
+                vecs = np.load(str(npy))
+                return vecs, meta.get("ats", [None] * len(vecs)), meta.get("granularity", args.granularity)
+        except Exception:
+            pass
+    if not has_audio(ref):
+        return None
+    vecs, ats, _ = embed_media(ref, args)
+    if vecs.shape[0] == 0:
+        return None
+    if persist:
+        npy.parent.mkdir(parents=True, exist_ok=True)
+        np.save(str(npy), vecs)
+        sidecar.write_text(json.dumps({
+            "ref": ref, "kind": "audio",
+            "granularity": args.granularity, "ats": ats,
+            "config_hash": chash, "mtime": mtime,
+            "model": load_model()["name"],
+        }))
+    return vecs, ats, args.granularity
+
+
+# ---- ops -------------------------------------------------------------------
+
+def op_add(args):
+    ref = args.input
+    if not Path(ref).exists():
+        fail("input not found: %s" % ref, ref, "add")
+    if not has_audio(ref):
+        fail("input has no audio stream: %s" % ref, ref, "add")
+    member_args = index_config_args(args)
+    built = build_member(ref, member_args, args.index_dir)
+    if not built:
+        fail("could not embed audio (no readable audio): %s" % ref, ref, "add")
+    vecs, ats, granularity = built
+    emit({
+        "verb": "similar",
+        "format": "json",
+        "payload": {
+            "op": "add", "index": args.index, "file": ref,
+            "granularity": granularity, "vectors": int(vecs.shape[0]),
+            "window": member_args.window,
+            "summary": "embedded %s into %s (%d vector%s)" % (Path(ref).name, args.index, vecs.shape[0], "" if vecs.shape[0] == 1 else "s"),
+        },
+        "media": {"ref": ref},
+        "meta": {"provider": "local:basic-clap", "model": load_model()["name"]},
+        "state": "ready",
+    })
+
+
+def query_vector(args, op):
+    if op == "search":
+        return embed_text(args.input)
+    ref = args.input
+    if not Path(ref).exists():
+        fail("input not found: %s" % ref, ref, "match")
+    if not has_audio(ref):
+        fail("query has no audio stream: %s" % ref, ref, "match")
+    # match: window the query and pool to one vector
+    vecs, _, _ = embed_media(ref, argparse.Namespace(**{**vars(args), "granularity": "frame"}))
+    if vecs.shape[0] == 0:
+        fail("could not decode audio from query", ref, "match")
+    return pool(vecs, args.pooling)
+
+
+def op_query(args):
+    import numpy as np
+    op = args.op
+    members = members_full(args.index_dir, args.index)
+    if not members:
+        fail("local basic-clap index has no members — add some with `similar add ... --index %s`" % args.index, args.input, op)
+    if args.min_similarity < 0 or args.min_similarity > 100:
+        fail("--min-similarity must be between 0 and 100", args.input, op)
+    if args.limit <= 0:
+        fail("--limit must be positive", args.input, op)
+    if args.offset < 0:
+        fail("--offset must be non-negative", args.input, op)
+    qv = query_vector(args, op)[0]
+    results = []
+    member_args = index_config_args(args)
+    for mem in members:
+        built = build_member(mem["ref"], member_args, args.index_dir, persist=False)
+        if not built:
+            continue
+        vecs, ats, granularity = built
+        for j in range(vecs.shape[0]):
+            score = float(np.dot(qv, vecs[j]) * 100.0)
+            if score < args.min_similarity:
+                continue
+            item = {"ref": mem["ref"], "similarity": round(score, 2), "granularity": granularity}
+            if mem.get("recordId"):
+                item["recordId"] = mem["recordId"]
+            at = ats[j] if j < len(ats) else None
+            if at is not None:
+                item["at"] = at
+            results.append(item)
+    results.sort(key=lambda x: x.get("similarity", 0), reverse=True)
+    results = results[args.offset:args.offset + args.limit]
+    if op == "search":
+        summary = "no semantic matches for that text" if not results else "%d semantic match%s" % (len(results), "" if len(results) == 1 else "es")
+    else:
+        summary = "no acoustically-similar audio" if not results else "%d audio match%s" % (len(results), "" if len(results) == 1 else "es")
+    payload = {
+        "op": op, "index": args.index, "summary": summary,
+        "matches": results, "count": len(results),
+    }
+    if op == "search":
+        payload["query"] = args.input
+    emit({
+        "verb": "similar",
+        "format": "json",
+        "payload": payload,
+        "media": {"ref": args.input},
+        "meta": {"provider": "local:basic-clap", "model": load_model()["name"]},
+        "state": "ready",
+    })
+
+
+def main():
+    args = parse()
+    inp = args.input
+    if args.op != "search":
+        if inp.startswith("http://") or inp.startswith("https://"):
+            fail("local basic-clap only supports local files; capture remote media first", inp, args.op)
+    try:
+        import numpy  # noqa: F401
+        import torch  # noqa: F401
+        import transformers  # noqa: F401
+    except Exception as e:
+        fail("basic-clap deps missing: %s (run scripts/visual-db-uv.sh --clap)" % e, inp, args.op)
+    if args.op == "add":
+        op_add(args)
+    else:
+        op_query(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/providers/audio-db/clap_match.py
+++ b/examples/providers/audio-db/clap_match.py
@@ -332,8 +332,8 @@ def op_query(args):
     members = members_full(args.index_dir, args.index)
     if not members:
         fail("local basic-clap index has no members — add some with `similar add ... --index %s`" % args.index, args.input, op)
-    if args.min_similarity < 0 or args.min_similarity > 100:
-        fail("--min-similarity must be between 0 and 100", args.input, op)
+    if args.min_similarity < -100 or args.min_similarity > 100:
+        fail("--min-similarity must be between -100 and 100", args.input, op)
     if args.limit <= 0:
         fail("--limit must be positive", args.input, op)
     if args.offset < 0:

--- a/examples/providers/visual-db/clip_match.py
+++ b/examples/providers/visual-db/clip_match.py
@@ -352,8 +352,8 @@ def op_query(args):
     if not members:
         fail("local basic-clip index has no members — add some with `similar add ... --index %s`" % args.index, args.input, op)
     qv = query_vector(args, op)[0]
-    if args.min_similarity < 0 or args.min_similarity > 100:
-        fail("--min-similarity must be between 0 and 100", args.input, op)
+    if args.min_similarity < -100 or args.min_similarity > 100:
+        fail("--min-similarity must be between -100 and 100", args.input, op)
     if args.limit <= 0:
         fail("--limit must be positive", args.input, op)
     if args.offset < 0:

--- a/scripts/visual-db-uv.sh
+++ b/scripts/visual-db-uv.sh
@@ -5,7 +5,9 @@
 #   scripts/visual-db-uv.sh          # image matching deps: opencv + numpy
 #   scripts/visual-db-uv.sh --face   # also install DeepFace stack
 #   scripts/visual-db-uv.sh --clip   # also install OpenAI CLIP (open_clip + torch)
-#   scripts/visual-db-uv.sh --all    # install both the DeepFace and CLIP stacks
+#   scripts/visual-db-uv.sh --audio  # also install audio fingerprint deps (scipy)
+#   scripts/visual-db-uv.sh --clap   # also install LAION CLAP audio embeddings (transformers + torch)
+#   scripts/visual-db-uv.sh --all    # install the DeepFace, CLIP, audio-fp, and CLAP stacks
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -35,14 +37,23 @@ case "$MODE" in
   --clip|clip)
     uv pip install --python "$VENV/bin/python" open-clip-torch torch pillow
     ;;
+  --audio|audio)
+    uv pip install --python "$VENV/bin/python" scipy
+    ;;
+  --clap|clap)
+    uv pip install --python "$VENV/bin/python" torch transformers
+    ;;
   --all|all)
+    # torch-owning packages first so uv resolves a single shared torch for the
+    # CLIP + CLAP stacks (see docs/providers.md on the shared-venv trade).
+    uv pip install --python "$VENV/bin/python" open-clip-torch torch transformers pillow
     uv pip install --python "$VENV/bin/python" deepface tf-keras
-    uv pip install --python "$VENV/bin/python" open-clip-torch torch pillow
+    uv pip install --python "$VENV/bin/python" scipy
     ;;
   --image|image|"")
     ;;
   *)
-    echo "unknown mode: $MODE (expected --image | --face | --clip | --all)" >&2
+    echo "unknown mode: $MODE (expected --image | --face | --clip | --audio | --clap | --all)" >&2
     exit 2
     ;;
 esac

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -23,8 +23,9 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `see` — Understand an image or a single video frame (caption, OCR, detections).
 - `face` — Detect, match, or search faces in video (and across face-analysis indexes).
 - `image` — Match images or video frames against a local RANSAC image index.
+- `audio` — Shazam-style exact audio matching: fingerprint clips into a local audio-fp index, or match clip-to-clip with time-offset alignment.
 - `cluster` — Build and browse a local face-cluster DB: group faces into people, identify, label, and view.
-- `similar` — Find images/video moments by visual or text similarity in a local CLIP (basic-clip) index.
+- `similar` — Find images/video moments or audio by visual, audio, or text similarity in a local CLIP (basic-clip) or CLAP (basic-clap) index.
 - `enhance` — Produce better media (denoise/normalize/upscale/...) via ffmpeg or a bound model provider.
 - `view` — Open media in a lightweight local viewer (scrubbable player) or hand off to the OS.
 - `crop` — Materialize face/object detections as cropped image records with provenance.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -160,6 +160,7 @@ Options:
   --to <string>          alias for --index when adding
   --min-votes <number>   minimum time-aligned hash votes to confirm a match (default: 6)
   --min-ratio <number>   minimum aligned-votes / query-hashes ratio (0–1)
+  --min-margin <number>  minimum ratio of best-offset votes over the next-best offset (≥1); a true exact match scores 100s–1000s×, a pitch/speed-shifted copy ~1.2–1.7× — raise this (e.g. 2) to reject sped-up re-uploads
   --format <string>      json | md | txt
   --json                 Shorthand for --format json
 ```

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -161,6 +161,7 @@ Options:
   --min-votes <number>   minimum time-aligned hash votes to confirm a match (default: 6)
   --min-ratio <number>   minimum aligned-votes / query-hashes ratio (0–1)
   --min-margin <number>  minimum ratio of best-offset votes over the next-best offset (≥1); a true exact match scores 100s–1000s×, a pitch/speed-shifted copy ~1.2–1.7× — raise this (e.g. 2) to reject sped-up re-uploads
+  --draw                 match: render an SVG alignment visualization per match (hash-pair scatter + offset histogram) — embeds in briefs like image --draw
   --format <string>      json | md | txt
   --json                 Shorthand for --format json
 ```

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -139,6 +139,33 @@ Options:
 
 Emits `image.match` records.
 
+### `overcast audio`
+
+`audio add <audio|video|record-id> --index <local-audio-fp-index>` fingerprints a recording (Wang 2003 constellation hashes) and caches it in a local audio-fp index. `audio match <query> --index <id>` finds which indexed recording contains the query and WHERE (offset-histogram alignment: 'query audio appears at 01:23 in recording Y'). `audio match <query> <reference>` compares two clips directly, no index needed. Videos are accepted — their audio track is extracted. Robust to transcode/noise/clipping; NOT robust to pitch/speed change.
+
+```
+overcast audio <action> [input] [reference] [options]
+
+  Shazam-style exact audio matching: fingerprint clips into a local audio-fp index, or match clip-to-clip with time-offset alignment.
+
+  `audio add <audio|video|record-id> --index <local-audio-fp-index>` fingerprints a recording (Wang 2003 constellation hashes) and caches it in a local audio-fp index. `audio match <query> --index <id>` finds which indexed recording contains the query and WHERE (offset-histogram alignment: 'query audio appears at 01:23 in recording Y'). `audio match <query> <reference>` compares two clips directly, no index needed. Videos are accepted — their audio track is extracted. Robust to transcode/noise/clipping; NOT robust to pitch/speed change.
+
+Arguments:
+  action           add | match
+  input            audio/video path, URL, or record id (the query for match)
+  reference        match: a second clip for direct clip-to-clip comparison (instead of --index)
+
+Options:
+  --index <string>       local audio-fp index id/name
+  --to <string>          alias for --index when adding
+  --min-votes <number>   minimum time-aligned hash votes to confirm a match (default: 6)
+  --min-ratio <number>   minimum aligned-votes / query-hashes ratio (0–1)
+  --format <string>      json | md | txt
+  --json                 Shorthand for --format json
+```
+
+Emits `audio.match` records.
+
 ### `overcast cluster`
 
 A persistent LOCAL face database backed by the deepface provider (clustering needs face embeddings, which the tinycloud face path doesn't expose). `cluster add <media>` detects faces, embeds them, and ASSIGN-OR-CREATEs each into a person (nearest existing person above --min-similarity, else a new one); `cluster identify <image|video>` surfaces the most similar person for a probe (or flags it as a likely new person) without writing; `cluster recluster` re-groups every stored face and carries human labels forward; `cluster list`/`show` read the DB and `cluster view` renders a self-contained HTML contact sheet. Needs a face-cluster index (`index create <name> --type face-cluster --local`); resolves the case's sole one when --index is omitted. Emits a `cluster` record.
@@ -176,29 +203,29 @@ Emits `cluster` records.
 
 ### `overcast similar`
 
-`similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB (videos are frame-sampled and pooled). `similar match <image|video> --index <id>` ranks members by image→image similarity; `similar search "<text>" --index <id>` ranks members by text→image similarity. Runs OpenAI CLIP locally (open_clip); scores are cosine×100 (0–100).
+`similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB (videos are frame-sampled and pooled); a `basic-clap` index instead embeds audio (or a video's audio track) with CLAP. `similar match <image|video|audio> --index <id>` ranks members by image→image (CLIP) or audio→audio (CLAP) similarity; `similar search "<text>" --index <id>` ranks members by text→image (CLIP) or text→audio (CLAP) similarity. Runs OpenAI CLIP / LAION CLAP locally; scores are cosine×100 (0–100).
 
 ```
 overcast similar <action> [input]... [options]
 
-  Find images/video moments by visual or text similarity in a local CLIP (basic-clip) index.
+  Find images/video moments or audio by visual, audio, or text similarity in a local CLIP (basic-clip) or CLAP (basic-clap) index.
 
-  `similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB (videos are frame-sampled and pooled). `similar match <image|video> --index <id>` ranks members by image→image similarity; `similar search "<text>" --index <id>` ranks members by text→image similarity. Runs OpenAI CLIP locally (open_clip); scores are cosine×100 (0–100).
+  `similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB (videos are frame-sampled and pooled); a `basic-clap` index instead embeds audio (or a video's audio track) with CLAP. `similar match <image|video|audio> --index <id>` ranks members by image→image (CLIP) or audio→audio (CLAP) similarity; `similar search "<text>" --index <id>` ranks members by text→image (CLIP) or text→audio (CLAP) similarity. Runs OpenAI CLIP / LAION CLAP locally; scores are cosine×100 (0–100).
 
 Arguments:
   action           add | match | search
-  input            image/video path, URL, record id (add/match) — or a text query (search)
+  input            image/video/audio path, URL, record id (add/match) — or a text query (search)
 
 Options:
-  --index <string>       local basic-clip index id/name
+  --index <string>       local basic-clip (CLIP) or basic-clap (CLAP audio) index id/name
   --to <string>          alias for --index when adding
   --min-similarity <number> match/search: similarity floor (0–100)
   --limit <number>       match/search: max results
   --offset <number>      match/search: result offset
-  --pooling <string>     match: pool the query video's frames by max | mean (members follow the index config)
-  --granularity <string> video (one vector/video) | frame (moments) — set at `index create`; members always follow the index config
-  --sampling <string>    match query video: uniform windows | shots (tinycloud watch boundaries); members follow the index config
-  --window <number>      video: seconds per uniform sampling window
+  --pooling <string>     match: pool the query's frames/windows by max | mean (members follow the index config)
+  --granularity <string> video (one vector per file) | frame (moments — video frames, or 10s audio windows for basic-clap) — set at `index create`; members always follow the index config
+  --sampling <string>    basic-clip only — match query video: uniform windows | shots (tinycloud watch boundaries); members follow the index config
+  --window <number>      seconds per uniform sampling window (basic-clip video) or audio chunk (basic-clap)
   --fps <number>         video: frame sampling rate; --max-frames can cap it
   --max-frames <number>  video: frame sample count/cap
   --format <string>      json | md | txt
@@ -407,7 +434,7 @@ Arguments:
   arg2             entities: the video/record-id (index entities <id> <video>)
 
 Options:
-  --type <string>        create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip
+  --type <string>        create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip | audio-fp | basic-clap
   --local                create a local index instead of a tinycloud-backed index
   --description <string> create: human description
   --prompt <string>      create entities: free-text extraction prompt
@@ -420,10 +447,10 @@ Options:
   --no-download          add: don't materialize the source locally
   --limit <number>       entities: max entities
   --offset <number>      entities: entity offset
-  --pooling <string>     create basic-clip: pool video frames by max | mean
-  --granularity <string> create basic-clip: video | frame (moment-level)
+  --pooling <string>     create basic-clip/basic-clap: pool video frames / audio windows by max | mean
+  --granularity <string> create basic-clip/basic-clap: video (one vector/file) | frame (moment-level / audio windows)
   --sampling <string>    create basic-clip: uniform | shots (watch boundaries)
-  --window <number>      create basic-clip: seconds per uniform sampling window
+  --window <number>      create basic-clip/basic-clap: seconds per uniform sampling window / audio chunk
   --format <string>      json | md | txt
   --json                 Shorthand for --format json
 ```
@@ -700,7 +727,7 @@ Options:
   --profile <string>     Profile name to write/read (default: active/default)
   --verb <string>        provider setup: verb to configure
   --choice <string>      provider setup: catalog choice id
-  --preset <string>      provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local|basic-clip)
+  --preset <string>      provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local|basic-clip|audio-fp|basic-clap)
   --yes                  provider setup apply: confirm profile changes
   --json                 JSON output
   --format <string>      json | md | txt

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -95,6 +95,34 @@ export function providerChoices(): ProviderChoice[] {
       indexableDefault: true,
     },
     {
+      id: "audio-fp",
+      verb: "audio",
+      label: "Local audio fingerprint (audio-fp)",
+      summary: "Local Shazam-style fingerprint matcher (numpy/scipy); audio-fp indexes are the local hash store for `audio` (exact clip matching).",
+      descriptor: {
+        type: "inproc",
+        backend: "audio-fp",
+        id: "audio-fp",
+        init: { command: `bash ${localVisionSetup} --audio` },
+      },
+      env: ["OC_VISUAL_DB_PY"],
+      indexableDefault: true,
+    },
+    {
+      id: "basic-clap",
+      verb: "similar",
+      label: "Local CLAP audio (basic-clap)",
+      summary: "Local LAION CLAP audio-embedding DB; basic-clap indexes are the local vector store for `similar` (audio/text→audio search).",
+      descriptor: {
+        type: "inproc",
+        backend: "basic-clap",
+        id: "basic-clap",
+        init: { command: `bash ${localVisionSetup} --clap` },
+      },
+      env: ["OC_VISUAL_DB_PY", "OC_CLAP_MODEL"],
+      indexableDefault: true,
+    },
+    {
       id: "ffmpeg",
       verb: "enhance",
       label: "Local ffmpeg",
@@ -206,6 +234,12 @@ export const PROVIDER_PRESETS: Record<string, Array<{ verb: string; choice: stri
   ],
   "basic-clip": [
     { verb: "similar", choice: "basic-clip" },
+  ],
+  "audio-fp": [
+    { verb: "audio", choice: "audio-fp" },
+  ],
+  "basic-clap": [
+    { verb: "similar", choice: "basic-clap" },
   ],
 };
 

--- a/src/providers/local/audio.ts
+++ b/src/providers/local/audio.ts
@@ -1,0 +1,193 @@
+// Local audio DB shims: `audio-fp` (Wang-2003 constellation fingerprint, exact
+// match) and `basic-clap` (CLAP audio embeddings, semantic similarity). Both are
+// deliberately local-only and shell out to uv-managed Python under
+// examples/providers/audio-db/, reusing the same venv + Python locator as the
+// visual DBs (localVisionPython / localIndexDir live in vision.ts). The wire
+// contract (one loose record on stdout, members read from indexes.json) matches
+// the visual-db scripts exactly.
+
+import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { makeRecord, type OvercastRecord } from "../../record.js";
+import { runExecProvider } from "../run.js";
+import { providerEnv } from "../provider-env.js";
+import { shippedPath } from "../../pkg.js";
+import { localIndexDir, localVisionPython, type ClipConfig } from "./vision.js";
+import type { Case } from "../../case.js";
+
+export type LocalAudioOp = "add" | "match";
+export type LocalClapOp = "add" | "match" | "search";
+
+function script(name: string): string | undefined {
+  return shippedPath("examples", "providers", "audio-db", name);
+}
+
+function missingScript(verb: string, input: string, name: string): OvercastRecord {
+  return makeRecord({
+    verb,
+    format: "json",
+    payload: { input },
+    media: { ref: input },
+    error: `audio DB provider script not found: examples/providers/audio-db/${name}`,
+    state: "error",
+  });
+}
+
+/** Per-index fingerprint params for an `audio-fp` DB, persisted as
+ *  `<index-dir>/config.json` at create time and hashed into each member's cache
+ *  key so a param change invalidates stale fingerprints. */
+export interface AudioFpConfig {
+  /** mono resample rate before STFT */
+  sampleRate: number;
+  nFft: number;
+  hop: number;
+  /** max-filter footprint (freq × time bins) for peak detection */
+  peakNeighborhood: number;
+  /** amplitude floor above the per-file median magnitude, in dB */
+  peakFloorDb: number;
+  /** anchor→target pairs per peak */
+  fanOut: number;
+  /** min/max target-zone offset in STFT frames */
+  minDt: number;
+  maxDt: number;
+}
+
+export function defaultAudioFpConfig(): AudioFpConfig {
+  return { sampleRate: 11025, nFft: 2048, hop: 512, peakNeighborhood: 15, peakFloorDb: 20, fanOut: 15, minDt: 1, maxDt: 64 };
+}
+
+/** Read an audio-fp index's config.json, merged over defaults (missing file =
+ *  all defaults). Tolerates a corrupt/partial file by falling back to defaults. */
+export function readAudioFpConfig(indexDir: string): AudioFpConfig {
+  const file = join(indexDir, "config.json");
+  const base = defaultAudioFpConfig();
+  try {
+    if (!existsSync(file)) return base;
+    const parsed = JSON.parse(readFileSync(file, "utf8")) as Partial<AudioFpConfig>;
+    return { ...base, ...parsed };
+  } catch {
+    return base;
+  }
+}
+
+export function writeAudioFpConfig(indexDir: string, config: AudioFpConfig): void {
+  mkdirSync(indexDir, { recursive: true });
+  writeFileSync(join(indexDir, "config.json"), JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+/** Delete an audio-fp member's cached fingerprint (`fp/<sha1(ref)>.npz` + json).
+ *  Mirrors the Python cache key (sha1 of the resolved ref). */
+export function removeAudioFingerprint(indexDir: string, ref: string): void {
+  const key = createHash("sha1").update(ref).digest("hex");
+  for (const ext of ["npz", "json"]) {
+    const f = join(indexDir, "fp", `${key}.${ext}`);
+    try {
+      if (existsSync(f)) rmSync(f, { force: true });
+    } catch {
+      /* best-effort cache cleanup */
+    }
+  }
+}
+
+/** CLAP config reuses ClipConfig's shape — sampling/fps/maxFrames stay unused
+ *  (audio is chunked in `window`-second slices, not frame-sampled). */
+export function defaultClapConfig(): ClipConfig {
+  return { pooling: "mean", granularity: "video", sampling: "uniform", window: 10, maxFrames: null, fps: null };
+}
+
+export function readClapConfig(indexDir: string): ClipConfig {
+  const file = join(indexDir, "config.json");
+  const base = defaultClapConfig();
+  try {
+    if (!existsSync(file)) return base;
+    const parsed = JSON.parse(readFileSync(file, "utf8")) as Partial<ClipConfig>;
+    return { ...base, ...parsed };
+  } catch {
+    return base;
+  }
+}
+
+export function writeClapConfig(indexDir: string, config: ClipConfig): void {
+  mkdirSync(indexDir, { recursive: true });
+  writeFileSync(join(indexDir, "config.json"), JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+/**
+ * Local audio fingerprint DB (`audio-fp`): `add` fingerprints + caches a
+ * recording; `match` finds which indexed recording contains a query (and where,
+ * via offset-histogram alignment). Pairwise mode (`against`) compares two clips
+ * directly and MUST NOT touch any index — no index id, no OVERCAST_INDEX_DIR.
+ */
+export async function runLocalAudio(
+  c: Case,
+  input: string,
+  opts: {
+    op: LocalAudioOp;
+    indexId?: string;
+    /** a second clip for direct clip-to-clip comparison (no index) */
+    against?: string;
+    minVotes?: number;
+    minRatio?: number;
+    signal?: AbortSignal;
+  },
+): Promise<OvercastRecord> {
+  const path = script("audio_match.py");
+  if (!path) return missingScript("audio", input, "audio_match.py");
+  const args = ["--op", opts.op];
+  if (opts.indexId) {
+    args.push("--index", opts.indexId, "--index-dir", localIndexDir(c, opts.indexId));
+  }
+  if (opts.against) args.push("--against", opts.against);
+  if (opts.minVotes != null) args.push("--min-votes", String(opts.minVotes));
+  if (opts.minRatio != null) args.push("--min-ratio", String(opts.minRatio));
+  const env = { ...providerEnv(c.mediaDir), ...(opts.indexId ? { OVERCAST_INDEX_DIR: localIndexDir(c, opts.indexId) } : {}) };
+  const rec = await runExecProvider("audio", localVisionPython(), input, {
+    env,
+    extraArgs: [path, ...args],
+    timeoutMs: 15 * 60_000,
+    signal: opts.signal,
+  });
+  rec.meta = { ...rec.meta, case: c.dir };
+  return rec;
+}
+
+/**
+ * Local CLAP semantic DB (`basic-clap`): embed + cache audio (or video audio
+ * tracks) and query by audio (`match`) or text (`search`). Mirrors runLocalClip;
+ * shells out to examples/providers/audio-db/clap_match.py. For `search`, `input`
+ * is the text query.
+ */
+export async function runLocalClap(
+  c: Case,
+  input: string,
+  opts: {
+    indexId: string;
+    op: LocalClapOp;
+    minSimilarity?: number;
+    limit?: number;
+    offset?: number;
+    pooling?: "max" | "mean";
+    granularity?: "video" | "frame";
+    window?: number;
+    signal?: AbortSignal;
+  },
+): Promise<OvercastRecord> {
+  const path = script("clap_match.py");
+  if (!path) return missingScript("similar", input, "clap_match.py");
+  const args = ["--op", opts.op, "--index", opts.indexId, "--index-dir", localIndexDir(c, opts.indexId)];
+  if (opts.minSimilarity != null) args.push("--min-similarity", String(opts.minSimilarity));
+  if (opts.limit != null) args.push("--limit", String(opts.limit));
+  if (opts.offset != null) args.push("--offset", String(opts.offset));
+  if (opts.pooling) args.push("--pooling", opts.pooling);
+  if (opts.granularity) args.push("--granularity", opts.granularity);
+  if (opts.window != null) args.push("--window", String(opts.window));
+  const rec = await runExecProvider("similar", localVisionPython(), input, {
+    env: { ...providerEnv(c.mediaDir), OVERCAST_INDEX_DIR: localIndexDir(c, opts.indexId) },
+    extraArgs: [path, ...args],
+    timeoutMs: 15 * 60_000,
+    signal: opts.signal,
+  });
+  rec.meta = { ...rec.meta, case: c.dir };
+  return rec;
+}

--- a/src/providers/local/audio.ts
+++ b/src/providers/local/audio.ts
@@ -130,6 +130,8 @@ export async function runLocalAudio(
     minVotes?: number;
     minRatio?: number;
     minMargin?: number;
+    /** render an SVG alignment visualization per match (embeds in briefs) */
+    draw?: boolean;
     signal?: AbortSignal;
   },
 ): Promise<OvercastRecord> {
@@ -143,6 +145,7 @@ export async function runLocalAudio(
   if (opts.minVotes != null) args.push("--min-votes", String(opts.minVotes));
   if (opts.minRatio != null) args.push("--min-ratio", String(opts.minRatio));
   if (opts.minMargin != null) args.push("--min-margin", String(opts.minMargin));
+  if (opts.draw) args.push("--draw");
   const env = { ...providerEnv(c.mediaDir), ...(opts.indexId ? { OVERCAST_INDEX_DIR: localIndexDir(c, opts.indexId) } : {}) };
   const rec = await runExecProvider("audio", localVisionPython(), input, {
     env,

--- a/src/providers/local/audio.ts
+++ b/src/providers/local/audio.ts
@@ -129,6 +129,7 @@ export async function runLocalAudio(
     against?: string;
     minVotes?: number;
     minRatio?: number;
+    minMargin?: number;
     signal?: AbortSignal;
   },
 ): Promise<OvercastRecord> {
@@ -141,6 +142,7 @@ export async function runLocalAudio(
   if (opts.against) args.push("--against", opts.against);
   if (opts.minVotes != null) args.push("--min-votes", String(opts.minVotes));
   if (opts.minRatio != null) args.push("--min-ratio", String(opts.minRatio));
+  if (opts.minMargin != null) args.push("--min-margin", String(opts.minMargin));
   const env = { ...providerEnv(c.mediaDir), ...(opts.indexId ? { OVERCAST_INDEX_DIR: localIndexDir(c, opts.indexId) } : {}) };
   const rec = await runExecProvider("audio", localVisionPython(), input, {
     env,

--- a/src/providers/memory/fields.ts
+++ b/src/providers/memory/fields.ts
@@ -48,6 +48,7 @@ const FIELD_POLICY: Record<string, string[]> = {
   // (homographies, boxes, embeddings, vectors, artifact paths) stay in the
   // record / typed local index, never in searchable case memory.
   image: ["summary", "op", "index", "count", "matches[].label", "matches[].db_img_path", "matches[].num_inliers", "matches[].inlier_ratio", "matches[].at"],
+  audio: ["summary", "op", "index", "count", "matches[].ref", "matches[].offset_seconds", "matches[].aligned_votes", "matches[].match_ratio", "matches[].span_seconds"],
   cluster: ["summary", "op", "index", "count", "new_clusters", "clusters_total"],
   similar: ["summary", "query", "matches[].ref"],
   crop: ["summary", "kind", "class", "detection_id", "source_record", "source_verb", "source_media", "at", "confidence", "crop"],

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -10,6 +10,7 @@ import { providerEnv } from "../providers/provider-env.js";
 import { listenVerb, seeVerb, enhanceVerb, viewVerb } from "../verbs/senses.js";
 import { faceVerb } from "../verbs/face.js";
 import { imageVerb } from "../verbs/image.js";
+import { audioVerb } from "../verbs/audio.js";
 import { clusterVerb } from "../verbs/cluster.js";
 import { similarVerb } from "../verbs/similar.js";
 import { cropVerb } from "../verbs/crop.js";
@@ -92,6 +93,7 @@ export const VERBS: VerbSpec[] = [
   seeVerb,
   faceVerb,
   imageVerb,
+  audioVerb,
   clusterVerb,
   similarVerb,
   enhanceVerb,

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -28,7 +28,7 @@ export interface TimelineSynthesis {
   findings: Array<{ id: string; status: string; text: string; confidence?: unknown; overlays?: string[] }>;
 }
 
-const VISUAL_EXT_RE = /\.(avif|bmp|gif|jpe?g|png|webp)(?:[?#].*)?$/i;
+const VISUAL_EXT_RE = /\.(avif|bmp|gif|jpe?g|png|svg|webp)(?:[?#].*)?$/i;
 // deliberately NOT a bare `path`/`img` — the image-match payload carries
 // `db_img_path` (the reference frame) and `query_path` (a temp frame that's
 // deleted after the run); only the rendered `match_draw_path` overlay and real
@@ -333,6 +333,7 @@ function imageMime(path: string): string | undefined {
     case ".webp": return "image/webp";
     case ".bmp": return "image/bmp";
     case ".avif": return "image/avif";
+    case ".svg": return "image/svg+xml"; // audio-match alignment overlays
     default: return undefined;
   }
 }

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -22,12 +22,14 @@ export type IndexType =
   | "deepface-local"
   | "image-ransac"
   | "face-cluster"
-  | "basic-clip";
+  | "basic-clip"
+  | "audio-fp"
+  | "basic-clap";
 
 /** Index types that only exist locally (never tinycloud-backed). The canonical
  *  set — every writer that mirrors one of these MUST stamp backend "local", or
  *  the typed verbs (image/face/cluster/similar) will reject the entry as remote. */
-export const LOCAL_INDEX_TYPES: ReadonlySet<string> = new Set(["deepface-local", "image-ransac", "face-cluster", "basic-clip"]);
+export const LOCAL_INDEX_TYPES: ReadonlySet<string> = new Set(["deepface-local", "image-ransac", "face-cluster", "basic-clip", "audio-fp", "basic-clap"]);
 
 export interface IndexMember {
   /** the video ref registered (path / URL) */
@@ -98,6 +100,16 @@ export function normalizeIndexType(input: string): IndexType | undefined {
     case "clips":
     case "semantic":
       return "basic-clip";
+    case "audio-fp":
+    case "audio":
+    case "audio-fingerprint":
+    case "fingerprint":
+      return "audio-fp";
+    case "basic-clap":
+    case "clap":
+    case "audio-clip":
+    case "audio-semantic":
+      return "basic-clap";
     case "rich-transcripts":
     case "rich-transcript":
     case "transcripts":

--- a/src/verbs/audio.ts
+++ b/src/verbs/audio.ts
@@ -59,6 +59,7 @@ export const audioVerb: VerbSpec = {
     { name: "min-votes", summary: "minimum time-aligned hash votes to confirm a match", type: "number", default: 6 },
     { name: "min-ratio", summary: "minimum aligned-votes / query-hashes ratio (0–1)", type: "number" },
     { name: "min-margin", summary: "minimum ratio of best-offset votes over the next-best offset (≥1); a true exact match scores 100s–1000s×, a pitch/speed-shifted copy ~1.2–1.7× — raise this (e.g. 2) to reject sped-up re-uploads", type: "number" },
+    { name: "draw", summary: "match: render an SVG alignment visualization per match (hash-pair scatter + offset histogram) — embeds in briefs like image --draw", type: "boolean" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],
@@ -119,11 +120,11 @@ export const audioVerb: VerbSpec = {
       const ref = resolveVideoArg(ctx.case, reference, "audio match");
       if (ref.error) return [err(ref.error)];
       if (!/^https?:\/\//i.test(ref.ref!) && !existsSync(ref.ref!)) return [err(`audio match: reference not found: ${ref.ref}`)];
-      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", against: ref.ref!, minVotes, minRatio, minMargin, signal: ctx.signal });
+      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", against: ref.ref!, minVotes, minRatio, minMargin, draw: ctx.opts.draw === true, signal: ctx.signal });
     } else {
       const idx = localAudioIndex(ctx.case, indexValue);
       if (idx.error) return [err(`audio match: ${idx.error}`)];
-      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", indexId: idx.id!, minVotes, minRatio, minMargin, signal: ctx.signal });
+      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", indexId: idx.id!, minVotes, minRatio, minMargin, draw: ctx.opts.draw === true, signal: ctx.signal });
     }
     // if the query was captured from a post, trace the match back to it
     stampProvenance(rec, provenanceFromCapture(ctx.case, q.ref));

--- a/src/verbs/audio.ts
+++ b/src/verbs/audio.ts
@@ -58,6 +58,7 @@ export const audioVerb: VerbSpec = {
     { name: "to", summary: "alias for --index when adding", type: "string" },
     { name: "min-votes", summary: "minimum time-aligned hash votes to confirm a match", type: "number", default: 6 },
     { name: "min-ratio", summary: "minimum aligned-votes / query-hashes ratio (0–1)", type: "number" },
+    { name: "min-margin", summary: "minimum ratio of best-offset votes over the next-best offset (≥1); a true exact match scores 100s–1000s×, a pitch/speed-shifted copy ~1.2–1.7× — raise this (e.g. 2) to reject sped-up re-uploads", type: "number" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],
@@ -74,12 +75,14 @@ export const audioVerb: VerbSpec = {
 
     const numErr =
       badNumber(ctx.opts, "min-votes", (n) => n >= 1, "at least 1") ??
-      badNumber(ctx.opts, "min-ratio", (n) => n >= 0 && n <= 1, "0–1");
+      badNumber(ctx.opts, "min-ratio", (n) => n >= 0 && n <= 1, "0–1") ??
+      badNumber(ctx.opts, "min-margin", (n) => n >= 1, "at least 1");
     if (numErr) return [err(`audio ${action}: ${numErr}`)];
 
     const indexValue = ctx.opts.index ?? ctx.opts.to;
     const minVotes = ctx.opts["min-votes"] != null ? Number(ctx.opts["min-votes"]) : undefined;
     const minRatio = ctx.opts["min-ratio"] != null ? Number(ctx.opts["min-ratio"]) : undefined;
+    const minMargin = ctx.opts["min-margin"] != null ? Number(ctx.opts["min-margin"]) : undefined;
 
     // ---- add: fingerprint a member into an index (no pairwise) ----
     if (action === "add") {
@@ -116,11 +119,11 @@ export const audioVerb: VerbSpec = {
       const ref = resolveVideoArg(ctx.case, reference, "audio match");
       if (ref.error) return [err(ref.error)];
       if (!/^https?:\/\//i.test(ref.ref!) && !existsSync(ref.ref!)) return [err(`audio match: reference not found: ${ref.ref}`)];
-      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", against: ref.ref!, minVotes, minRatio, signal: ctx.signal });
+      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", against: ref.ref!, minVotes, minRatio, minMargin, signal: ctx.signal });
     } else {
       const idx = localAudioIndex(ctx.case, indexValue);
       if (idx.error) return [err(`audio match: ${idx.error}`)];
-      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", indexId: idx.id!, minVotes, minRatio, signal: ctx.signal });
+      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", indexId: idx.id!, minVotes, minRatio, minMargin, signal: ctx.signal });
     }
     // if the query was captured from a post, trace the match back to it
     stampProvenance(rec, provenanceFromCapture(ctx.case, q.ref));

--- a/src/verbs/audio.ts
+++ b/src/verbs/audio.ts
@@ -1,0 +1,129 @@
+// `audio` verb: local Shazam-style (Wang 2003) audio fingerprint matching. `audio
+// add` fingerprints a recording into a local audio-fp index (constellation-map
+// hashes, cached on disk like basic-clip embeddings); `audio match` finds which
+// indexed recording contains a query AND where (offset-histogram alignment), or
+// compares two clips directly (`audio match <query> <reference>`). Deliberately
+// local-only — the audio twin of the `image` (RANSAC) verb. Robust to
+// transcode/noise/clipping; NOT robust to pitch/speed change (classic Wang).
+
+import { existsSync, mkdirSync } from "node:fs";
+import { makeRecord, isReady, type OvercastRecord } from "../record.js";
+import { addMember, findIndex, resolveIndexRef } from "../state/index.js";
+import { localIndexDir } from "../providers/local/vision.js";
+import { runLocalAudio } from "../providers/local/audio.js";
+import { resolveVideoArg } from "./media-ref.js";
+import { provenanceFromCapture, stampProvenance } from "./provenance.js";
+import { badNumber } from "./validate.js";
+import type { Case } from "../case.js";
+import type { VerbSpec } from "../registry/types.js";
+
+function err(message: string): OvercastRecord {
+  return makeRecord({ verb: "audio", format: "json", payload: { error: message }, error: message, state: "error" });
+}
+
+/** Resolve + validate a local audio-fp index the query/add targets. */
+function localAudioIndex(ctxCase: Case, value: unknown): { id?: string; error?: string } {
+  const raw = value != null ? String(value).trim() : "";
+  if (!raw) return { error: "--index requires a local audio-fp index id/name" };
+  const r = resolveIndexRef(ctxCase, raw);
+  if (r.error) return { error: r.error };
+  const entry = r.entry ?? findIndex(ctxCase, raw);
+  if (!entry) return { error: `unknown local audio-fp index: ${raw}` };
+  if (entry.type !== "audio-fp") return { error: `index ${entry.id} is type '${entry.type}', not audio-fp` };
+  if (entry.backend !== "local") return { error: `index ${entry.id} is not local; create one with \`index create <name> --type audio-fp --local\`` };
+  return { id: entry.id };
+}
+
+export const audioVerb: VerbSpec = {
+  name: "audio",
+  group: "sense",
+  summary: "Shazam-style exact audio matching: fingerprint clips into a local audio-fp index, or match clip-to-clip with time-offset alignment.",
+  description:
+    "`audio add <audio|video|record-id> --index <local-audio-fp-index>` fingerprints a recording " +
+    "(Wang 2003 constellation hashes) and caches it in a local audio-fp index. " +
+    "`audio match <query> --index <id>` finds which indexed recording contains the query and WHERE " +
+    "(offset-histogram alignment: 'query audio appears at 01:23 in recording Y'). " +
+    "`audio match <query> <reference>` compares two clips directly, no index needed. " +
+    "Videos are accepted — their audio track is extracted. Robust to transcode/noise/clipping; " +
+    "NOT robust to pitch/speed change.",
+  args: [
+    { name: "action", summary: "add | match", required: true },
+    { name: "input", summary: "audio/video path, URL, or record id (the query for match)", required: false },
+    // declared so the pi AgentTool reconstructs it as a positional (see the
+    // `index` verb's arg2 note) — the second clip for direct clip-to-clip match.
+    { name: "reference", summary: "match: a second clip for direct clip-to-clip comparison (instead of --index)", required: false },
+  ],
+  flags: [
+    { name: "index", summary: "local audio-fp index id/name", type: "string" },
+    { name: "to", summary: "alias for --index when adding", type: "string" },
+    { name: "min-votes", summary: "minimum time-aligned hash votes to confirm a match", type: "number", default: 6 },
+    { name: "min-ratio", summary: "minimum aligned-votes / query-hashes ratio (0–1)", type: "number" },
+    { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
+    { name: "json", summary: "Shorthand for --format json", type: "boolean" },
+  ],
+  outputKind: "audio.match",
+  providerKey: "audio",
+  run: async (ctx) => {
+    const action = ctx.input;
+    if (action !== "add" && action !== "match") {
+      return [err("usage: audio <add|match> <query> --index <local-audio-fp-index>  (or: audio match <query> <reference>)")];
+    }
+    const input = ctx.rest[0];
+    const reference = ctx.rest[1];
+    if (!input) return [err(`audio ${action} requires an audio/video input`)];
+
+    const numErr =
+      badNumber(ctx.opts, "min-votes", (n) => n >= 1, "at least 1") ??
+      badNumber(ctx.opts, "min-ratio", (n) => n >= 0 && n <= 1, "0–1");
+    if (numErr) return [err(`audio ${action}: ${numErr}`)];
+
+    const indexValue = ctx.opts.index ?? ctx.opts.to;
+    const minVotes = ctx.opts["min-votes"] != null ? Number(ctx.opts["min-votes"]) : undefined;
+    const minRatio = ctx.opts["min-ratio"] != null ? Number(ctx.opts["min-ratio"]) : undefined;
+
+    // ---- add: fingerprint a member into an index (no pairwise) ----
+    if (action === "add") {
+      if (reference) return [err("audio add takes one input; a second positional is only for `audio match <query> <reference>`")];
+      const idx = localAudioIndex(ctx.case, indexValue);
+      if (idx.error) return [err(`audio add: ${idx.error}`)];
+      const q = resolveVideoArg(ctx.case, input, "audio add");
+      if (q.error) return [err(q.error)];
+      const entry = findIndex(ctx.case, idx.id!);
+      if (entry?.members.some((m) => m.ref === q.ref)) {
+        return [makeRecord({ verb: "audio", format: "json", payload: { op: "add", index: idx.id, file: q.ref, already_member: true }, media: { ref: q.ref! }, meta: { case: ctx.case.dir }, state: "ready" })];
+      }
+      mkdirSync(localIndexDir(ctx.case, idx.id!), { recursive: true });
+      const rec = await runLocalAudio(ctx.case, q.ref!, { op: "add", indexId: idx.id!, signal: ctx.signal });
+      // register the member only after the fingerprint SUCCEEDED (mirrors similar
+      // add) — a failed fingerprint must not leave a cacheless member that match
+      // would silently skip.
+      if (isReady(rec) && !entry?.members.some((m) => m.ref === q.ref)) {
+        addMember(ctx.case, idx.id!, { ref: q.ref!, recordId: q.recordId });
+      }
+      return [rec];
+    }
+
+    // ---- match: exactly one of pairwise reference XOR --index ----
+    if (reference && indexValue) return [err("audio match: pass either a second clip (clip-to-clip) OR --index, not both")];
+    if (!reference && !indexValue) return [err("audio match: pass --index <audio-fp-index> or a second clip to compare against")];
+
+    const q = resolveVideoArg(ctx.case, input, "audio match");
+    if (q.error) return [err(q.error)];
+    if (!/^https?:\/\//i.test(q.ref!) && !existsSync(q.ref!)) return [err(`audio match: input not found: ${q.ref}`)];
+
+    let rec: OvercastRecord;
+    if (reference) {
+      const ref = resolveVideoArg(ctx.case, reference, "audio match");
+      if (ref.error) return [err(ref.error)];
+      if (!/^https?:\/\//i.test(ref.ref!) && !existsSync(ref.ref!)) return [err(`audio match: reference not found: ${ref.ref}`)];
+      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", against: ref.ref!, minVotes, minRatio, signal: ctx.signal });
+    } else {
+      const idx = localAudioIndex(ctx.case, indexValue);
+      if (idx.error) return [err(`audio match: ${idx.error}`)];
+      rec = await runLocalAudio(ctx.case, q.ref!, { op: "match", indexId: idx.id!, minVotes, minRatio, signal: ctx.signal });
+    }
+    // if the query was captured from a post, trace the match back to it
+    stampProvenance(rec, provenanceFromCapture(ctx.case, q.ref));
+    return [rec];
+  },
+};

--- a/src/verbs/index.ts
+++ b/src/verbs/index.ts
@@ -47,6 +47,13 @@ import {
   removeClipEmbedding,
   type ClipConfig,
 } from "../providers/local/vision.js";
+import {
+  writeAudioFpConfig,
+  defaultAudioFpConfig,
+  writeClapConfig,
+  defaultClapConfig,
+  removeAudioFingerprint,
+} from "../providers/local/audio.js";
 import { resolveVideoArg, resolveImageArg, resolveVisualArg, isRegisterableMediaRecord, isImage } from "./media-ref.js";
 import { badNumber, numFlag } from "./validate.js";
 import { tinycloudBaseFromRun } from "../providers/tinycloud/envelope.js";
@@ -66,9 +73,10 @@ function isLocalIndex(entry: { backend?: string; type: string }): boolean {
 }
 
 /** Build a validated basic-clip ClipConfig from create flags, merged over the
- *  defaults. Returns an error string for a bad enum/number value. */
-function clipConfigFromOpts(opts: Record<string, unknown>): { config?: ClipConfig; error?: string } {
-  const cfg = defaultClipConfig();
+ *  given defaults (basic-clap reuses this with its own base). Returns an error
+ *  string for a bad enum/number value. */
+function clipConfigFromOpts(opts: Record<string, unknown>, base: ClipConfig = defaultClipConfig()): { config?: ClipConfig; error?: string } {
+  const cfg = base;
   const enumFlag = <T extends string>(name: string, allowed: readonly T[]): T | undefined | string => {
     const v = opts[name];
     if (v == null) return undefined;
@@ -92,6 +100,15 @@ function clipConfigFromOpts(opts: Record<string, unknown>): { config?: ClipConfi
     cfg[key] = n;
   }
   return { config: cfg };
+}
+
+/** Build a validated basic-clap ClipConfig from create flags. Audio has no
+ *  frame/shot sampling, so reject those flags rather than silently ignoring. */
+function clapConfigFromOpts(opts: Record<string, unknown>): { config?: ClipConfig; error?: string } {
+  for (const f of ["sampling", "fps", "max-frames"] as const) {
+    if (opts[f] != null) return { error: `--${f} doesn't apply to a basic-clap index — audio is embedded in --window second chunks` };
+  }
+  return clipConfigFromOpts(opts, defaultClapConfig());
 }
 
 function indexRecord(rec: OvercastRecord): OvercastRecord {
@@ -314,7 +331,7 @@ export const indexVerb: VerbSpec = {
     { name: "arg2", summary: "entities: the video/record-id (index entities <id> <video>)", required: false },
   ],
   flags: [
-    { name: "type", summary: "create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip", type: "string" },
+    { name: "type", summary: "create/attach: media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip | audio-fp | basic-clap", type: "string" },
     { name: "local", summary: "create a local index instead of a tinycloud-backed index", type: "boolean" },
     { name: "description", summary: "create: human description", type: "string" },
     { name: "prompt", summary: "create entities: free-text extraction prompt", type: "string" },
@@ -327,10 +344,10 @@ export const indexVerb: VerbSpec = {
     { name: "no-download", summary: "add: don't materialize the source locally", type: "boolean" },
     { name: "limit", summary: "entities: max entities", type: "number" },
     { name: "offset", summary: "entities: entity offset", type: "number" },
-    { name: "pooling", summary: "create basic-clip: pool video frames by max | mean", type: "string", choices: ["max", "mean"] },
-    { name: "granularity", summary: "create basic-clip: video | frame (moment-level)", type: "string", choices: ["video", "frame"] },
+    { name: "pooling", summary: "create basic-clip/basic-clap: pool video frames / audio windows by max | mean", type: "string", choices: ["max", "mean"] },
+    { name: "granularity", summary: "create basic-clip/basic-clap: video (one vector/file) | frame (moment-level / audio windows)", type: "string", choices: ["video", "frame"] },
     { name: "sampling", summary: "create basic-clip: uniform | shots (watch boundaries)", type: "string", choices: ["uniform", "shots"] },
-    { name: "window", summary: "create basic-clip: seconds per uniform sampling window", type: "number" },
+    { name: "window", summary: "create basic-clip/basic-clap: seconds per uniform sampling window / audio chunk", type: "number" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
   ],
@@ -359,7 +376,7 @@ export const indexVerb: VerbSpec = {
       const rawType = ctx.opts.type != null ? String(ctx.opts.type) : "media-descriptions";
       const type = normalizeIndexType(rawType);
       if (!type) {
-        return [err(`unknown --type '${rawType}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip)`)];
+        return [err(`unknown --type '${rawType}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip | audio-fp | basic-clap)`)];
       }
       const local = ctx.opts.local === true || LOCAL_INDEX_TYPES.has(type);
       if (ctx.opts.local === true && !LOCAL_INDEX_TYPES.has(type)) {
@@ -384,17 +401,31 @@ export const indexVerb: VerbSpec = {
       }
       if (schema && !existsSync(schema)) return [err(`--schema file not found: ${schema}`)];
       if (local) {
-        // basic-clip carries a per-index CLIP config (pooling/granularity/sampling
-        // /window); persist it to config.json so `similar` + the wizard agree.
+        // basic-clip / basic-clap carry a per-index config (pooling/granularity/
+        // window; +sampling for CLIP); persist it to config.json so `similar` + the
+        // wizard agree. audio-fp persists its fingerprint params (fixed in v1) so
+        // the member cache's config_hash is stable.
         let clipConfig: ClipConfig | undefined;
         if (type === "basic-clip") {
           const built = clipConfigFromOpts(ctx.opts);
           if (built.error) return [err(`index create: ${built.error}`)];
           clipConfig = built.config;
+        } else if (type === "basic-clap") {
+          const built = clapConfigFromOpts(ctx.opts);
+          if (built.error) return [err(`index create: ${built.error}`)];
+          clipConfig = built.config;
         }
         const id = `local_${type.replace(/-/g, "_")}_${randomBytes(4).toString("hex")}`;
         mkdirSync(localIndexDir(c, id), { recursive: true });
-        if (clipConfig) writeClipConfig(localIndexDir(c, id), clipConfig);
+        let audioFpConfig: ReturnType<typeof defaultAudioFpConfig> | undefined;
+        if (type === "basic-clap") {
+          if (clipConfig) writeClapConfig(localIndexDir(c, id), clipConfig);
+        } else if (type === "audio-fp") {
+          audioFpConfig = defaultAudioFpConfig();
+          writeAudioFpConfig(localIndexDir(c, id), audioFpConfig);
+        } else if (clipConfig) {
+          writeClipConfig(localIndexDir(c, id), clipConfig);
+        }
         const entry = addIndex(c, { id, type, name, description, backend: "local" });
         // a face-cluster DB's ingest/identify records are case evidence; if a
         // saved setup already narrows memory search, back-fill the `cluster`
@@ -418,7 +449,7 @@ export const indexVerb: VerbSpec = {
             type: entry.type,
             backend: "local",
             path: localIndexDir(c, id),
-            ...(clipConfig ? { config: clipConfig } : {}),
+            ...(clipConfig ? { config: clipConfig } : audioFpConfig ? { config: audioFpConfig } : {}),
           },
           meta: { provider: "local", case: c.dir },
           state: "ready",
@@ -438,7 +469,7 @@ export const indexVerb: VerbSpec = {
       if (!requested) return [err("usage: index attach <remote-index-id-or-name> [--type <media|entities|face>]")];
       const typeHint = ctx.opts.type != null ? normalizeIndexType(String(ctx.opts.type)) : undefined;
       if (ctx.opts.type != null && !typeHint) {
-        return [err(`unknown --type '${ctx.opts.type}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip)`)];
+        return [err(`unknown --type '${ctx.opts.type}' (expected media-descriptions | entities | face-analysis | rich-transcripts | deepface-local | image-ransac | face-cluster | basic-clip | audio-fp | basic-clap)`)];
       }
       if (typeHint && LOCAL_INDEX_TYPES.has(typeHint)) {
         return [err(`index attach: ${typeHint} is local-only; create it with \`index create <name> --type ${typeHint} --local\``)];
@@ -561,6 +592,14 @@ export const indexVerb: VerbSpec = {
         // that path lives on the `similar` verb, which computes + caches them.
         if (targetEntry.type === "basic-clip") {
           return [err(`index add: '${id}' is a basic-clip index — embed members with \`similar add <image|video> --index ${id}\` (it computes and caches CLIP vectors)`)];
+        }
+        // basic-clap members must be embedded with CLAP; audio-fp members must be
+        // fingerprinted — both compute + cache artifacts on their own verb, not here.
+        if (targetEntry.type === "basic-clap") {
+          return [err(`index add: '${id}' is a basic-clap index — embed members with \`similar add <audio|video> --index ${id}\` (it computes and caches CLAP vectors)`)];
+        }
+        if (targetEntry.type === "audio-fp") {
+          return [err(`index add: '${id}' is an audio-fp index — fingerprint members with \`audio add <clip> --index ${id}\` (it computes and caches constellation hashes)`)];
         }
         if (ctx.opts["no-upload"] === true || ctx.opts["no-download"] === true) {
           return [err("index add: --no-upload/--no-download only apply to tinycloud indexes")];
@@ -747,14 +786,22 @@ export const indexVerb: VerbSpec = {
         return [err(`index remove doesn't apply to a face-cluster index — it stores face assignments in faces.jsonl/clusters.json. Create a new face-cluster index or rebuild with \`cluster recluster --index ${from.id}\`.`)];
       }
       if (local && isLocalIndex(local)) {
-        // basic-clip members can be videos (image-ransac/deepface store stills), so
-        // accept either; also drop the removed member's cached embedding.
-        const resolved = local.type === "basic-clip"
-          ? resolveVisualArg(c, arg, "index remove", { requireExists: false, requireReady: false })
+        // basic-clip/basic-clap/audio-fp members can be videos or audio (image-ransac
+        // /deepface store stills), so accept AV for those; also drop the removed
+        // member's cached embedding/fingerprint.
+        const avTypes = new Set(["basic-clip", "basic-clap", "audio-fp"]);
+        const resolved = avTypes.has(local.type)
+          ? (local.type === "basic-clip"
+              ? resolveVisualArg(c, arg, "index remove", { requireExists: false, requireReady: false })
+              : resolveVideoArg(c, arg, "index remove", { requireExists: false, requireReady: false }))
           : resolveImageArg(c, arg, "index remove", { requireExists: false, requireReady: false });
         if (resolved.error) return [err(resolved.error)];
         const removed = removeMember(c, from.id!, resolved.ref!);
-        if (local.type === "basic-clip" && removed) removeClipEmbedding(localIndexDir(c, from.id!), resolved.ref!);
+        if (removed) {
+          const dir = localIndexDir(c, from.id!);
+          if (local.type === "basic-clip" || local.type === "basic-clap") removeClipEmbedding(dir, resolved.ref!);
+          else if (local.type === "audio-fp") removeAudioFingerprint(dir, resolved.ref!);
+        }
         return [makeRecord({
           verb: "index",
           format: "json",

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -274,10 +274,11 @@ function briefSynthesis(records: OvercastRecord[], statusByFinding: Map<string, 
       const row: BriefSynthesis["findings"][number] = { id: r.id, status: statusByFinding.get(r.id) ?? String(pay.status), text: String(pay.text) };
       if (pay.confidence != null) row.confidence = pay.confidence;
       // attach match-draw overlays: from the finding's own payload, and from the
-      // image/face match record it cites via source_record (the geometric proof).
+      // image/face/audio match record it cites via source_record (the geometric
+      // proof for image/face, the offset-alignment plot for audio).
       const overlays = new Set(collectVisualRefs(pay));
       const src = typeof pay.source_record === "string" ? byId.get(pay.source_record) : undefined;
-      if (src && (src.verb === "image" || src.verb === "face")) {
+      if (src && (src.verb === "image" || src.verb === "face" || src.verb === "audio")) {
         for (const ref of collectVisualRefs(src.payload)) overlays.add(ref);
       }
       if (overlays.size) row.overlays = [...overlays].slice(0, 3);

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -316,7 +316,7 @@ export const providerVerb: VerbSpec = {
     { name: "profile", summary: "Profile name to write/read (default: active/default)", type: "string" },
     { name: "verb", summary: "provider setup: verb to configure", type: "string" },
     { name: "choice", summary: "provider setup: catalog choice id", type: "string" },
-    { name: "preset", summary: "provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local|basic-clip)", type: "string" },
+    { name: "preset", summary: "provider setup: preset id (cloudglue|hf|fal|elevenlabs|owl-local|deepface-local|basic-clip|audio-fp|basic-clap)", type: "string" },
     { name: "yes", summary: "provider setup apply: confirm profile changes", type: "boolean" },
     { name: "json", summary: "JSON output", type: "boolean" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
@@ -503,6 +503,13 @@ export const doctorVerb: VerbSpec = {
       .catch((e) => ({ code: 1, stdout: "", stderr: (e as Error).message }));
     const localFace = await execCapture(localPy, ["-c", "import deepface, numpy; print('face-ok')"], { timeoutMs: 30_000 })
       .catch((e) => ({ code: 1, stdout: "", stderr: (e as Error).message }));
+    // audio deps: scipy is the fingerprint half (audio-fp); transformers+torch is
+    // the heavier CLAP half (basic-clap). Probe imports only — never load a model
+    // (from_pretrained would trigger a ~776MB download).
+    const localAudioFp = await execCapture(localPy, ["-c", "import scipy, numpy; print('audio-ok')"], { timeoutMs: 30_000 })
+      .catch((e) => ({ code: 1, stdout: "", stderr: (e as Error).message }));
+    const localClap = await execCapture(localPy, ["-c", "import transformers, torch; print('clap-ok')"], { timeoutMs: 60_000 })
+      .catch((e) => ({ code: 1, stdout: "", stderr: (e as Error).message }));
     checks.push({
       name: "uv",
       ok: uv.code === 0,
@@ -514,6 +521,14 @@ export const doctorVerb: VerbSpec = {
       detail: localVision.code === 0
         ? `image deps OK via ${localPy}${localFace.code === 0 ? "; face deps OK" : "; face deps missing (run scripts/visual-db-uv.sh --face)"}`
         : `image deps missing via ${localPy} — run \`scripts/visual-db-uv.sh\` and set OC_VISUAL_DB_PY if needed`,
+    });
+    checks.push({
+      name: "audio-db",
+      // gate on the lightweight scipy half; CLAP is optional and reported in detail.
+      ok: localAudioFp.code === 0,
+      detail: localAudioFp.code === 0
+        ? `fingerprint deps OK via ${localPy}${localClap.code === 0 ? "; clap deps OK" : "; clap deps missing (run scripts/visual-db-uv.sh --clap)"}`
+        : `fingerprint deps missing via ${localPy} — run \`scripts/visual-db-uv.sh --audio\` (scipy) and set OC_VISUAL_DB_PY if needed`,
     });
 
     const configuredSources = listSources(ctx.case);

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -156,7 +156,10 @@ export const similarVerb: VerbSpec = {
     const isClap = type === "basic-clap";
 
     const numErr =
-      badNumber(ctx.opts, "min-similarity", (n) => n >= 0 && n <= 100, "0–100") ??
+      // cosine×100 legitimately ranges [-100, 100]; a negative floor lets you
+      // retrieve low/negative-scoring matches (CLAP text→audio in particular
+      // scores near/below zero even for the right clip). Default stays 0.
+      badNumber(ctx.opts, "min-similarity", (n) => n >= -100 && n <= 100, "-100–100") ??
       badNumber(ctx.opts, "limit", (n) => n > 0, "a positive number") ??
       badNumber(ctx.opts, "offset", (n) => n >= 0, "a non-negative number") ??
       badNumber(ctx.opts, "window", (n) => n > 0, "a positive number") ??

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -13,7 +13,9 @@ import {
   readClipConfig,
   type ClipConfig,
 } from "../providers/local/vision.js";
-import { resolveVisualArg } from "./media-ref.js";
+import { runLocalClap, readClapConfig } from "../providers/local/audio.js";
+import { resolveVideoArg, resolveVisualArg } from "./media-ref.js";
+import { provenanceFromCapture, stampProvenance } from "./provenance.js";
 import { badNumber } from "./validate.js";
 import { providerBinding } from "../providers/bindings.js";
 import { isCustomBinding, runBoundProvider } from "../providers/run.js";
@@ -26,22 +28,29 @@ function err(message: string): OvercastRecord {
   return makeRecord({ verb: "similar", format: "json", payload: { error: message }, error: message, state: "error" });
 }
 
-/** Resolve + validate a local basic-clip index the query/add targets. */
-function localClipIndex(ctxCase: Case, value: unknown): { id?: string; error?: string } {
+/** Resolve + validate a local semantic index (basic-clip = CLIP images/video, or
+ *  basic-clap = CLAP audio) the query/add targets. Returns the resolved type so
+ *  the caller dispatches to the right provider + config defaults. */
+function localClipIndex(ctxCase: Case, value: unknown): { id?: string; type?: "basic-clip" | "basic-clap"; error?: string } {
   const raw = value != null ? String(value).trim() : "";
-  if (!raw) return { error: "--index requires a local basic-clip index id/name" };
+  if (!raw) return { error: "--index requires a local semantic index (basic-clip|basic-clap) id/name" };
   const r = resolveIndexRef(ctxCase, raw);
   if (r.error) return { error: r.error };
   const entry = r.entry ?? findIndex(ctxCase, raw);
-  if (!entry) return { error: `unknown local basic-clip index: ${raw}` };
-  if (entry.type !== "basic-clip") return { error: `index ${entry.id} is type '${entry.type}', not basic-clip` };
-  if (entry.backend !== "local") return { error: `index ${entry.id} is not local; create one with \`index create <name> --type basic-clip --local\`` };
-  return { id: entry.id };
+  if (!entry) return { error: `unknown local semantic index: ${raw}` };
+  if (entry.type !== "basic-clip" && entry.type !== "basic-clap") return { error: `index ${entry.id} is type '${entry.type}', not basic-clip or basic-clap` };
+  if (entry.backend !== "local") return { error: `index ${entry.id} is not local; create one with \`index create <name> --type ${entry.type} --local\`` };
+  return { id: entry.id, type: entry.type };
+}
+
+/** Read a semantic index's persisted config with type-correct defaults. */
+function readCfg(indexDir: string, type: "basic-clip" | "basic-clap"): ClipConfig {
+  return type === "basic-clap" ? readClapConfig(indexDir) : readClipConfig(indexDir);
 }
 
 /** Effective config for a query/add: index config.json overridden by CLI flags. */
-function effectiveConfig(indexDir: string, opts: VerbContext["opts"]): ClipConfig {
-  const cfg = readClipConfig(indexDir);
+function effectiveConfig(indexDir: string, opts: VerbContext["opts"], type: "basic-clip" | "basic-clap"): ClipConfig {
+  const cfg = readCfg(indexDir, type);
   const pooling = opts.pooling === "mean" || opts.pooling === "max" ? opts.pooling : cfg.pooling;
   const granularity = opts.granularity === "frame" || opts.granularity === "video" ? opts.granularity : cfg.granularity;
   const sampling = opts.sampling === "shots" || opts.sampling === "uniform" ? opts.sampling : cfg.sampling;
@@ -107,27 +116,27 @@ async function shotMarkers(ctx: VerbContext, ref: string): Promise<{ markers: nu
 export const similarVerb: VerbSpec = {
   name: "similar",
   group: "sense",
-  summary: "Find images/video moments by visual or text similarity in a local CLIP (basic-clip) index.",
+  summary: "Find images/video moments or audio by visual, audio, or text similarity in a local CLIP (basic-clip) or CLAP (basic-clap) index.",
   description:
     "`similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB " +
-    "(videos are frame-sampled and pooled). " +
-    "`similar match <image|video> --index <id>` ranks members by image→image similarity; " +
-    "`similar search \"<text>\" --index <id>` ranks members by text→image similarity. " +
-    "Runs OpenAI CLIP locally (open_clip); scores are cosine×100 (0–100).",
+    "(videos are frame-sampled and pooled); a `basic-clap` index instead embeds audio (or a video's audio track) with CLAP. " +
+    "`similar match <image|video|audio> --index <id>` ranks members by image→image (CLIP) or audio→audio (CLAP) similarity; " +
+    "`similar search \"<text>\" --index <id>` ranks members by text→image (CLIP) or text→audio (CLAP) similarity. " +
+    "Runs OpenAI CLIP / LAION CLAP locally; scores are cosine×100 (0–100).",
   args: [
     { name: "action", summary: "add | match | search", required: true },
-    { name: "input", summary: "image/video path, URL, record id (add/match) — or a text query (search)", required: false, variadic: true },
+    { name: "input", summary: "image/video/audio path, URL, record id (add/match) — or a text query (search)", required: false, variadic: true },
   ],
   flags: [
-    { name: "index", summary: "local basic-clip index id/name", type: "string" },
+    { name: "index", summary: "local basic-clip (CLIP) or basic-clap (CLAP audio) index id/name", type: "string" },
     { name: "to", summary: "alias for --index when adding", type: "string" },
     { name: "min-similarity", summary: "match/search: similarity floor (0–100)", type: "number" },
     { name: "limit", summary: "match/search: max results", type: "number" },
     { name: "offset", summary: "match/search: result offset", type: "number" },
-    { name: "pooling", summary: "match: pool the query video's frames by max | mean (members follow the index config)", type: "string", choices: ["max", "mean"] },
-    { name: "granularity", summary: "video (one vector/video) | frame (moments) — set at `index create`; members always follow the index config", type: "string", choices: ["video", "frame"] },
-    { name: "sampling", summary: "match query video: uniform windows | shots (tinycloud watch boundaries); members follow the index config", type: "string", choices: ["uniform", "shots"] },
-    { name: "window", summary: "video: seconds per uniform sampling window", type: "number" },
+    { name: "pooling", summary: "match: pool the query's frames/windows by max | mean (members follow the index config)", type: "string", choices: ["max", "mean"] },
+    { name: "granularity", summary: "video (one vector per file) | frame (moments — video frames, or 10s audio windows for basic-clap) — set at `index create`; members always follow the index config", type: "string", choices: ["video", "frame"] },
+    { name: "sampling", summary: "basic-clip only — match query video: uniform windows | shots (tinycloud watch boundaries); members follow the index config", type: "string", choices: ["uniform", "shots"] },
+    { name: "window", summary: "seconds per uniform sampling window (basic-clip video) or audio chunk (basic-clap)", type: "number" },
     { name: "fps", summary: "video: frame sampling rate; --max-frames can cap it", type: "number" },
     { name: "max-frames", summary: "video: frame sample count/cap", type: "number" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
@@ -138,11 +147,13 @@ export const similarVerb: VerbSpec = {
   run: async (ctx) => {
     const action = ctx.input;
     if (action !== "add" && action !== "match" && action !== "search") {
-      return [err("usage: similar <add|match|search> <image|video|text> --index <local-basic-clip-index>")];
+      return [err("usage: similar <add|match|search> <image|video|audio|text> --index <local-basic-clip|basic-clap-index>")];
     }
     const indexValue = ctx.opts.index ?? ctx.opts.to;
     const idx = localClipIndex(ctx.case, indexValue);
     if (idx.error) return [err(`similar ${action}: ${idx.error}`)];
+    const type = idx.type!;
+    const isClap = type === "basic-clap";
 
     const numErr =
       badNumber(ctx.opts, "min-similarity", (n) => n >= 0 && n <= 100, "0–100") ??
@@ -153,22 +164,66 @@ export const similarVerb: VerbSpec = {
       badNumber(ctx.opts, "max-frames", (n) => n > 0, "a positive number");
     if (numErr) return [err(`similar ${action}: ${numErr}`)];
 
+    // frame-sampling flags are CLIP-video only; a CLAP (audio) index chunks by
+    // --window seconds and has no shots/fps/max-frames concept, so reject them
+    // outright rather than silently ignoring.
+    if (isClap) {
+      const badFlag = ["fps", "max-frames", "sampling"].find((f) => ctx.opts[f] != null);
+      if (badFlag) return [err(`similar ${action}: --${badFlag} doesn't apply to a basic-clap (audio) index — audio is embedded in --window second chunks`)];
+    }
+
     const indexDir = localIndexDir(ctx.case, idx.id!);
     // member embeddings follow the PERSISTED index config — a per-add override
     // would persist a config_hash queries (keyed on config.json) never reuse, so
     // reject the flags outright rather than silently ignoring them.
     if (action === "add") {
       const flag = ["pooling", "granularity", "sampling", "window", "fps", "max-frames"].find((f) => ctx.opts[f] != null);
-      if (flag) return [err(`similar add: --${flag} doesn't apply per-add — member embedding follows the index config; set it at \`index create --type basic-clip\``)];
+      if (flag) return [err(`similar add: --${flag} doesn't apply per-add — member embedding follows the index config; set it at \`index create --type ${type}\``)];
     }
-    const cfg = action === "add" ? readClipConfig(indexDir) : effectiveConfig(indexDir, ctx.opts);
+    const cfg = action === "add" ? readCfg(indexDir, type) : effectiveConfig(indexDir, ctx.opts, type);
 
-    // ONE shared opts block for all three actions, carrying the FULL sampling
-    // config (the index config for `add`, effective config for queries). `add`
-    // keys the member cache on it (config_hash); for match/search it shapes only
-    // the QUERY embedding — the Python side pins member-cache reads to the
-    // persisted index config (config.json) and never writes the cache at query
-    // time, so a one-off override can't re-key or mutate stored member vectors.
+    const queryOpts = {
+      minSimilarity: ctx.opts["min-similarity"] != null ? Number(ctx.opts["min-similarity"]) : undefined,
+      limit: ctx.opts.limit != null ? Number(ctx.opts.limit) : undefined,
+      offset: ctx.opts.offset != null ? Number(ctx.opts.offset) : undefined,
+    };
+
+    // ---- search (text → image/audio) ----
+    if (action === "search") {
+      const text = ctx.rest.join(" ").trim();
+      if (!text) return [err("similar search requires a text query")];
+      const rec = isClap
+        ? await runLocalClap(ctx.case, text, { indexId: idx.id!, op: "search", pooling: cfg.pooling, granularity: cfg.granularity, window: cfg.window, ...queryOpts, signal: ctx.signal })
+        : await runLocalClip(ctx.case, text, { indexId: idx.id!, op: "search", pooling: cfg.pooling, granularity: cfg.granularity, sampling: cfg.sampling, window: cfg.window, maxFrames: cfg.maxFrames ?? undefined, fps: cfg.fps ?? undefined, ...queryOpts, signal: ctx.signal });
+      return [rec];
+    }
+
+    // ---- add / match (both take a media arg: image/video for CLIP, audio/video for CLAP) ----
+    const arg = ctx.rest[0];
+    if (!arg) return [err(`similar ${action} requires an ${isClap ? "audio/video" : "image/video"} input`)];
+    const q = isClap
+      ? { ...resolveVideoArg(ctx.case, arg, `similar ${action}`), kind: "video" as const }
+      : resolveVisualArg(ctx.case, arg, `similar ${action}`);
+    if (q.error) return [err(q.error)];
+    if (!/^https?:\/\//i.test(q.ref!) && !existsSync(q.ref!)) return [err(`similar ${action}: input not found: ${q.ref}`)];
+
+    // ---- CLAP (audio) path: no frame/shot machinery ----
+    if (isClap) {
+      if (action === "add") {
+        mkdirSync(indexDir, { recursive: true });
+        const rec = await runLocalClap(ctx.case, q.ref!, { indexId: idx.id!, op: "add", pooling: cfg.pooling, granularity: cfg.granularity, window: cfg.window, signal: ctx.signal });
+        if (isReady(rec)) {
+          const entry = findIndex(ctx.case, idx.id!);
+          if (!entry?.members.some((m) => m.ref === q.ref)) addMember(ctx.case, idx.id!, { ref: q.ref!, recordId: q.recordId });
+        }
+        return [rec];
+      }
+      const rec = await runLocalClap(ctx.case, q.ref!, { indexId: idx.id!, op: "match", pooling: cfg.pooling, granularity: cfg.granularity, window: cfg.window, ...queryOpts, signal: ctx.signal });
+      stampProvenance(rec, provenanceFromCapture(ctx.case, q.ref));
+      return [rec];
+    }
+
+    // ---- CLIP (image/video) path ----
     const baseOpts = {
       indexId: idx.id!,
       pooling: cfg.pooling,
@@ -179,26 +234,6 @@ export const similarVerb: VerbSpec = {
       fps: cfg.fps ?? undefined,
       signal: ctx.signal,
     };
-    const queryOpts = {
-      minSimilarity: ctx.opts["min-similarity"] != null ? Number(ctx.opts["min-similarity"]) : undefined,
-      limit: ctx.opts.limit != null ? Number(ctx.opts.limit) : undefined,
-      offset: ctx.opts.offset != null ? Number(ctx.opts.offset) : undefined,
-    };
-
-    // ---- search (text → image) ----
-    if (action === "search") {
-      const text = ctx.rest.join(" ").trim();
-      if (!text) return [err("similar search requires a text query")];
-      const rec = await runLocalClip(ctx.case, text, { ...baseOpts, ...queryOpts, op: "search" });
-      return [rec];
-    }
-
-    // ---- add / match (both take a visual arg) ----
-    const arg = ctx.rest[0];
-    if (!arg) return [err(`similar ${action} requires an image/video input`)];
-    const q = resolveVisualArg(ctx.case, arg, `similar ${action}`);
-    if (q.error) return [err(q.error)];
-    if (!/^https?:\/\//i.test(q.ref!) && !existsSync(q.ref!)) return [err(`similar ${action}: input not found: ${q.ref}`)];
 
     // shot markers only apply to video sampling; resolve them in TS so the local
     // clip provider stays pure-CLIP (no tinycloud coupling). A freshly-run watch

--- a/test/e2e/live/cases/28_audio_match_local.sh
+++ b/test/e2e/live/cases/28_audio_match_local.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Local Shazam-style audio fingerprint matching — the CORE with no external
+# source and no API creds. Synthesize a spectrally-rich FM-chirp "original",
+# fingerprint it into a local audio-fp index (as a VIDEO, proving audio-track
+# extraction), then a transcoded+noised+clipped COPY of an 8s segment and an
+# UNRELATED chirp. Assert the matcher CONFIRMS the copy at the right time offset
+# and REJECTS the unrelated clip — indexed AND clip-to-clip (pairwise) — then
+# showcases it as a finding + note + brief. Needs only ffmpeg + numpy/scipy;
+# skips otherwise. Deterministic (no pure sine tones, seeded noise).
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; source "$LIVE/lib.sh"
+C=audio_match_local
+
+have_cmd ffmpeg || { skip "$C" "no ffmpeg on PATH"; exit 0; }
+PY="${OC_VISUAL_DB_PY:-${OVERCAST_VISUAL_DB_PY:-python3}}"
+if ! "$PY" - <<'PY' >/dev/null 2>&1
+import numpy, scipy.signal, scipy.ndimage  # noqa
+PY
+then
+  skip "$C.deps" "audio fingerprint deps missing in $PY (need numpy scipy — run scripts/visual-db-uv.sh --audio)"
+  exit 0
+fi
+
+CASE=$(case_dir audio_match_local)
+WORK="$SMOKE_DIR/audio_match_local"; mkdir -p "$WORK"
+
+# spectrally-rich, non-stationary signals (3 FM tones) — a pure sine would smear
+# the offset histogram; these give a dense, unambiguous constellation.
+ORIG_EXPR='0.5*sin(2*PI*(300+120*sin(2*PI*0.31*t))*t)+0.3*sin(2*PI*(800+250*sin(2*PI*0.13*t))*t)+0.2*sin(2*PI*(1500+400*sin(2*PI*0.07*t))*t)'
+UNREL_EXPR='0.5*sin(2*PI*(520+200*sin(2*PI*0.5*t))*t)+0.3*sin(2*PI*(2200+300*sin(2*PI*0.23*t))*t)'
+
+# --- synthesize the original (30s) and mux it under video → original.mp4 -------
+cond "fingerprint a synthesized original (as a VIDEO member) into a local audio-fp index"
+"$FFMPEG" -y -v error -f lavfi -i "aevalsrc=${ORIG_EXPR}:s=44100:d=30" -c:a pcm_s16le "$WORK/original.wav" 2>/dev/null
+"$FFMPEG" -y -v error -f lavfi -i "testsrc=size=320x240:rate=10:d=30" -i "$WORK/original.wav" \
+  -c:v libx264 -preset veryfast -c:a aac -shortest "$WORK/original.mp4" 2>/dev/null
+if [ ! -s "$WORK/original.mp4" ]; then fail "$C.build" "ffmpeg could not synthesize the original clip"; exit 0; fi
+created="$(oc "$CASE" index create jingles --type audio-fp --local --json)"
+IDX="$(echo "$created" | jq -r '.payload.index // empty')"
+assert_nonempty "$C.index" "$IDX" "local audio-fp index created"
+add="$(oc "$CASE" audio add "$WORK/original.mp4" --to "$IDX" --json)"
+save_json "28_add" "$add" >/dev/null
+assert_eq "$C.add_state" "ready" "$(echo "$add" | jq -r '.state')" "fingerprinted the original video's audio track"
+hashes="$(echo "$add" | jq -r '.payload.hashes // 0')"
+[ "${hashes:-0}" -ge 50 ] && ok "$C.add_hashes" "constellation built ($hashes hashes)" || fail "$C.add_hashes" "too few hashes ($hashes) — weak fingerprint"
+
+# --- a transcoded + noised + clipped COPY of the 12s..20s segment → CONFIRM ----
+cond "a transcoded/noised/volume-shifted copy of the 12s segment is CONFIRMED at offset ~12s"
+"$FFMPEG" -y -v error -ss 12 -t 8 -i "$WORK/original.wav" \
+  -f lavfi -i "anoisesrc=color=pink:seed=7:amplitude=0.08:d=8:s=48000" \
+  -filter_complex "[0]aresample=48000,volume=0.8[a];[a][1]amix=inputs=2:duration=shortest" \
+  -c:a aac "$WORK/copy.m4a" 2>/dev/null
+if [ ! -s "$WORK/copy.m4a" ]; then fail "$C.copy_build" "ffmpeg could not build the copy clip"; exit 0; fi
+mr="$(oc "$CASE" audio match "$WORK/copy.m4a" --index "$IDX" --json)"
+save_json "28_match_copy" "$mr" >/dev/null
+assert_eq "$C.copy_state" "ready" "$(echo "$mr" | jq -r '.state')" "copy match ran"
+rc="$(echo "$mr" | jq -r '.payload.count // 0')"
+if [ "${rc:-0}" -ge 1 ]; then
+  ref="$(echo "$mr" | jq -r '.payload.matches[0].ref')"
+  votes="$(echo "$mr" | jq -r '.payload.matches[0].aligned_votes')"
+  offset="$(echo "$mr" | jq -r '.payload.matches[0].offset_seconds')"
+  case "$ref" in *original.mp4) ok "$C.copy_ref" "matched the original ($votes aligned votes)";; *) fail "$C.copy_ref" "matched the wrong member: $ref";; esac
+  if awk -v o="$offset" 'BEGIN{d=o-12; if(d<0)d=-d; exit !(d<=0.6)}'; then
+    ok "$C.copy_offset" "aligned at offset ${offset}s (expected ~12s)"
+  else
+    fail "$C.copy_offset" "offset ${offset}s not within 12±0.6s"
+  fi
+else
+  fail "$C.copy_confirmed" "copy produced 0 confident matches (expected >=1)"
+fi
+
+# --- an UNRELATED chirp must be REJECTED (0 matches) ---------------------------
+cond "an unrelated chirp is REJECTED (0 confident matches — no false positive)"
+"$FFMPEG" -y -v error -f lavfi -i "aevalsrc=${UNREL_EXPR}:s=44100:d=10" -c:a aac "$WORK/unrelated.m4a" 2>/dev/null
+mu="$(oc "$CASE" audio match "$WORK/unrelated.m4a" --index "$IDX" --json)"
+save_json "28_match_unrelated" "$mu" >/dev/null
+uc="$(echo "$mu" | jq -r '.payload.count // 0')"
+[ "${uc:-0}" -eq 0 ] && ok "$C.unrelated_rejected" "unrelated clip correctly rejected (0 matches)" || fail "$C.unrelated_rejected" "unrelated clip false-matched $uc time(s)"
+
+# --- clip-to-clip (pairwise) — confirm the copy, reject the unrelated ----------
+cond "clip-to-clip (pairwise) confirms the copy and rejects the unrelated clip (no index)"
+pw="$(oc "$CASE" audio match "$WORK/copy.m4a" "$WORK/original.mp4" --json)"
+save_json "28_pairwise_copy" "$pw" >/dev/null
+pwc="$(echo "$pw" | jq -r '.payload.count // 0')"
+[ "${pwc:-0}" -ge 1 ] && ok "$C.pairwise_confirm" "pairwise CONFIRMED the copy vs the original" || fail "$C.pairwise_confirm" "pairwise found 0 matches (expected >=1)"
+pu="$(oc "$CASE" audio match "$WORK/unrelated.m4a" "$WORK/original.mp4" --json)"
+puc="$(echo "$pu" | jq -r '.payload.count // 0')"
+[ "${puc:-0}" -eq 0 ] && ok "$C.pairwise_reject" "pairwise correctly rejected the unrelated clip" || fail "$C.pairwise_reject" "pairwise false-matched $puc time(s)"
+
+# --- showcase: finding + note + brief -----------------------------------------
+cond "the confirmed match becomes a finding and lands in the brief"
+MR_ID="$(echo "$mr" | jq -r '.id // empty')"
+if [ -n "$MR_ID" ] && [ "${rc:-0}" -ge 1 ]; then
+  oc "$CASE" finding create "audio copy CONFIRMED: a transcoded/noised copy of the original appears at offset ${offset}s (${votes} aligned hash votes)" --ref "$MR_ID" --confidence high --json >/dev/null
+  oc "$CASE" note "local audio fingerprint test — fingerprinted the original, CONFIRMED a transcoded/noised/clipped copy at ~12s (${votes} votes), and REJECTED an unrelated chirp. No external source or API used." --tag tldr,audio --confidence high --json >/dev/null
+  BRIEF="$WORK/28_audio_match_brief.html"
+  oc "$CASE" brief --export "$BRIEF" --theme csi --json >/dev/null
+  [ -s "$BRIEF" ] && ok "$C.showcase" "brief HTML written: $BRIEF ($(wc -c <"$BRIEF" | tr -d ' ') bytes)" || fail "$C.showcase" "brief HTML missing at $BRIEF"
+else
+  skip "$C.showcase" "no confirmed match to showcase"
+fi

--- a/test/e2e/live/cases/29_clap_db.sh
+++ b/test/e2e/live/cases/29_clap_db.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Local CLAP audio-embedding DB (`basic-clap`) — audio->audio similarity +
+# text->audio search over a local vector index. Self-contained: synthesizes a
+# tonal clip A and a noise clip B, embeds both, then queries with a different
+# segment of A (top match must be A, not B) and a free-text query. HARD-GATED on
+# OC_CLAP_E2E=1 because the first run downloads ~776MB of model weights — never
+# implicitly in CI. Assertions are RANK/shape based (synthetic audio has no
+# meaningful absolute CLAP scores).
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; source "$LIVE/lib.sh"
+C=clap_db
+
+have_cmd ffmpeg || { skip "$C" "no ffmpeg on PATH"; exit 0; }
+case "${OC_CLAP_E2E:-}" in
+  1|true|yes|on) : ;;
+  *) skip "$C" "set OC_CLAP_E2E=1 to run (first run downloads ~776MB CLAP weights)"; exit 0 ;;
+esac
+PY="${OC_VISUAL_DB_PY:-${OVERCAST_VISUAL_DB_PY:-python3}}"
+if ! "$PY" - <<'PY' >/dev/null 2>&1
+import numpy, torch, transformers  # noqa
+PY
+then
+  skip "$C.deps" "CLAP deps missing in $PY (need transformers torch — run scripts/visual-db-uv.sh --clap)"
+  exit 0
+fi
+
+CASE=$(case_dir clap_db)
+WORK="$SMOKE_DIR/clap_db"; mkdir -p "$WORK"
+
+cond "embed a tonal clip and a noise clip into a local basic-clap index"
+"$FFMPEG" -y -v error -f lavfi -i "aevalsrc=0.5*sin(2*PI*440*t)+0.3*sin(2*PI*660*t):s=48000:d=20" -c:a pcm_s16le "$WORK/tone.wav" 2>/dev/null
+"$FFMPEG" -y -v error -f lavfi -i "anoisesrc=color=pink:seed=11:amplitude=0.5:d=20:s=48000" -c:a pcm_s16le "$WORK/noise.wav" 2>/dev/null
+"$FFMPEG" -y -v error -ss 10 -t 8 -i "$WORK/tone.wav" -c:a aac "$WORK/tone_q.m4a" 2>/dev/null
+if [ ! -s "$WORK/tone.wav" ] || [ ! -s "$WORK/noise.wav" ]; then fail "$C.build" "ffmpeg could not synthesize audio fixtures"; exit 0; fi
+created="$(oc "$CASE" index create sounds --type basic-clap --local --json)"
+IDX="$(echo "$created" | jq -r '.payload.index // empty')"
+assert_nonempty "$C.index" "$IDX" "local basic-clap index created"
+a="$(OC_TIMEOUT=600 oc "$CASE" similar add "$WORK/tone.wav" --index "$IDX" --json)"
+save_json "29_add_tone" "$a" >/dev/null
+assert_eq "$C.add_tone" "ready" "$(echo "$a" | jq -r '.state')" "embedded the tonal clip"
+b="$(OC_TIMEOUT=600 oc "$CASE" similar add "$WORK/noise.wav" --index "$IDX" --json)"
+assert_eq "$C.add_noise" "ready" "$(echo "$b" | jq -r '.state')" "embedded the noise clip"
+
+cond "audio->audio: a segment of the tonal clip ranks the tonal member above the noise member"
+m="$(OC_TIMEOUT=600 oc "$CASE" similar match "$WORK/tone_q.m4a" --index "$IDX" --json)"
+save_json "29_match" "$m" >/dev/null
+assert_eq "$C.match_state" "ready" "$(echo "$m" | jq -r '.state')" "audio match ran"
+top="$(echo "$m" | jq -r '.payload.matches[0].ref // empty')"
+case "$top" in *tone.wav) ok "$C.match_rank" "tonal query ranked the tonal member first";; "") fail "$C.match_rank" "no matches returned";; *) fail "$C.match_rank" "top match was $top (expected tone.wav)";; esac
+
+cond "text->audio search returns a well-formed ranked result set"
+s="$(OC_TIMEOUT=600 oc "$CASE" similar search "a steady musical tone" --index "$IDX" --json)"
+save_json "29_search" "$s" >/dev/null
+assert_eq "$C.search_state" "ready" "$(echo "$s" | jq -r '.state')" "text search ran"
+n="$(echo "$s" | jq -r '.payload.matches | length')"
+[ "${n:-0}" -ge 1 ] && ok "$C.search_shape" "search returned $n ranked match(es)" || fail "$C.search_shape" "search returned no matches"

--- a/test/e2e/live/cases/30_audio_match_realmedia.sh
+++ b/test/e2e/live/cases/30_audio_match_realmedia.sh
@@ -90,6 +90,26 @@ else
   fail "$C.speed_margin" "--min-margin 2 still confirmed the sped copy (margin ${spd_margin})"
 fi
 
+# --- --draw: render the alignment visualization + embed it in a brief ---------
+cond "audio match --draw renders an SVG alignment plot that embeds in a CSI brief"
+dr="$(oc "$CASE" audio match "$WORK/mid.m4a" --index "$IDX" --draw --json)"
+save_json "30_draw" "$dr" >/dev/null
+DRAW_PATH="$(echo "$dr" | jq -r '.payload.matches[0].match_draw_path // empty')"
+DR_ID="$(echo "$dr" | jq -r '.id // empty')"
+if [ -n "$DRAW_PATH" ] && [ -s "$DRAW_PATH" ] && head -c 64 "$DRAW_PATH" | grep -q "<svg"; then
+  ok "$C.draw" "wrote SVG alignment plot ($(wc -c <"$DRAW_PATH" | tr -d ' ')B): $DRAW_PATH"
+  oc "$CASE" finding create "audio self-location CONFIRMED at ~${CUT}s (alignment plotted)" --ref "$DR_ID" --confidence high --json >/dev/null
+  BRIEF="$WORK/30_audio_brief.html"
+  oc "$CASE" brief --export "$BRIEF" --theme csi --json >/dev/null
+  if [ -s "$BRIEF" ] && grep -q 'data-csi-overlays' "$BRIEF" && grep -q 'data:image/svg' "$BRIEF"; then
+    ok "$C.draw_brief" "brief HTML embeds the SVG alignment overlay ($(wc -c <"$BRIEF" | tr -d ' ')B)"
+  else
+    fail "$C.draw_brief" "brief did not embed the audio-match SVG at $BRIEF"
+  fi
+else
+  fail "$C.draw" "audio match --draw did not write a valid SVG (got '$DRAW_PATH')"
+fi
+
 # --- negative: a different real video is rejected -----------------------------
 cond "a different real video is rejected (no false positive)"
 NEG=""

--- a/test/e2e/live/cases/30_audio_match_realmedia.sh
+++ b/test/e2e/live/cases/30_audio_match_realmedia.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Real-media audio fingerprint matching. Unlike 28 (self-contained synthetic
+# chirps), this drives `audio` against a REAL video with a real audio track
+# (OC_VIDEO_SPEECH — a longer clip), proving the flows that matter in the field:
+#   • self-location: a clip from the middle → WHERE it appears in the full video
+#   • re-upload robustness: a heavily transcoded segment still matches the original
+#   • speed-drift rejection: a slightly sped-up copy confirms on raw votes but is
+#     rejected by --min-margin (the exact-copy vs evasive-reupload discriminator)
+#   • negative: a different real video is rejected
+# Needs ffmpeg + numpy/scipy + OC_VIDEO_SPEECH; skips otherwise.
+LIVE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; source "$LIVE/lib.sh"
+C=audio_match_realmedia
+
+have_cmd ffmpeg || { skip "$C" "no ffmpeg on PATH"; exit 0; }
+have_media "$VIDEO_SPEECH_SRC" || { skip "$C" "no OC_VIDEO_SPEECH (a longer real video with an audio track)"; exit 0; }
+PY="${OC_VISUAL_DB_PY:-${OVERCAST_VISUAL_DB_PY:-python3}}"
+if ! "$PY" - <<'PY' >/dev/null 2>&1
+import numpy, scipy.signal, scipy.ndimage  # noqa
+PY
+then
+  skip "$C.deps" "audio fingerprint deps missing in $PY (need numpy scipy — run scripts/visual-db-uv.sh --audio)"
+  exit 0
+fi
+# the source must actually carry audio (a silent screen-recording fingerprints to 0 hashes)
+if [ "$(ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$VIDEO_SPEECH_SRC" 2>/dev/null | head -1)" != "audio" ]; then
+  skip "$C.audio" "OC_VIDEO_SPEECH has no audio stream"; exit 0
+fi
+
+CASE=$(case_dir audio_match_realmedia)
+WORK="$SMOKE_DIR/audio_match_realmedia"; mkdir -p "$WORK"
+SRC="$VIDEO_SPEECH_SRC"
+DUR="$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$SRC" 2>/dev/null | cut -d. -f1)"
+[ -z "$DUR" ] && DUR=0
+if [ "$DUR" -lt 30 ]; then skip "$C.dur" "OC_VIDEO_SPEECH is only ${DUR}s; need >=30s for a middle-clip test"; exit 0; fi
+CUT=$(( DUR * 40 / 100 ))   # cut a clip starting 40% in
+SEG=15; [ "$SEG" -gt $(( DUR - CUT - 1 )) ] && SEG=$(( DUR - CUT - 1 ))
+
+# --- fingerprint the full real video ------------------------------------------
+cond "fingerprint a real video into a local audio-fp index"
+created="$(oc "$CASE" index create realsrc --type audio-fp --local --json)"
+IDX="$(echo "$created" | jq -r '.payload.index // empty')"
+assert_nonempty "$C.index" "$IDX" "audio-fp index created"
+add="$(OC_TIMEOUT=420 oc "$CASE" audio add "$SRC" --to "$IDX" --json)"
+save_json "30_add" "$add" >/dev/null
+hh="$(echo "$add" | jq -r '.payload.hashes // 0')"
+assert_eq "$C.add_state" "ready" "$(echo "$add" | jq -r '.state')" "fingerprinted the real audio track"
+[ "${hh:-0}" -ge 100 ] && ok "$C.add_hashes" "built $hh constellation hashes over ${DUR}s" || { fail "$C.add_hashes" "only $hh hashes — audio too quiet to test"; exit 0; }
+
+# --- self-location: a clip from the MIDDLE → correct offset --------------------
+cond "a clip from the middle of the real video is located at the right offset (~${CUT}s)"
+ffmpeg -y -v error -ss "$CUT" -t "$SEG" -i "$SRC" -map 0:a:0 -c:a aac "$WORK/mid.m4a" 2>/dev/null
+loc="$(oc "$CASE" audio match "$WORK/mid.m4a" --index "$IDX" --json)"
+save_json "30_selfloc" "$loc" >/dev/null
+lc="$(echo "$loc" | jq -r '.payload.count // 0')"
+if [ "${lc:-0}" -ge 1 ]; then
+  off="$(echo "$loc" | jq -r '.payload.matches[0].offset_seconds')"
+  vt="$(echo "$loc" | jq -r '.payload.matches[0].aligned_votes')"
+  if awk -v o="$off" -v c="$CUT" 'BEGIN{d=o-c; if(d<0)d=-d; exit !(d<=1.0)}'; then
+    ok "$C.selfloc" "located at ${off}s (cut @${CUT}s), $vt aligned votes"
+  else
+    fail "$C.selfloc" "offset ${off}s not within ${CUT}±1s"
+  fi
+else
+  fail "$C.selfloc" "middle clip not found (count 0)"
+fi
+
+# --- re-upload robustness: heavy transcode of a segment still matches ----------
+cond "a heavily transcoded segment (22kHz mono mp3, low bitrate) still matches the original"
+ffmpeg -y -v error -ss "$CUT" -t "$SEG" -i "$SRC" -map 0:a:0 -ac 1 -ar 22050 -b:a 64k -c:a libmp3lame "$WORK/reup.mp3" 2>/dev/null
+ru="$(oc "$CASE" audio match "$WORK/reup.mp3" --index "$IDX" --json)"
+save_json "30_reupload" "$ru" >/dev/null
+ruc="$(echo "$ru" | jq -r '.payload.count // 0')"
+[ "${ruc:-0}" -ge 1 ] && ok "$C.reupload" "transcoded re-upload CONFIRMED ($(echo "$ru" | jq -r '.payload.matches[0].aligned_votes') votes, margin $(echo "$ru" | jq -r '.payload.matches[0].margin'))" || fail "$C.reupload" "transcoded segment failed to match"
+
+# --- speed-drift: confirms on raw votes but --min-margin 2 rejects it ----------
+cond "a 1.08x sped-up copy is a WEAK partial alignment: default confirms, --min-margin 2 rejects"
+ffmpeg -y -v error -ss "$CUT" -t "$SEG" -i "$SRC" -filter:a "atempo=1.08" -map 0:a:0 -c:a aac "$WORK/sped.m4a" 2>/dev/null
+sp_def="$(oc "$CASE" audio match "$WORK/sped.m4a" --index "$IDX" --json)"
+sp_mrg="$(oc "$CASE" audio match "$WORK/sped.m4a" --index "$IDX" --min-margin 2 --json)"
+save_json "30_sped_default" "$sp_def" >/dev/null
+save_json "30_sped_margin" "$sp_mrg" >/dev/null
+spd_margin="$(echo "$sp_def" | jq -r '.payload.matches[0].margin // .payload.best_rejected.margin // 0')"
+mrg_count="$(echo "$sp_mrg" | jq -r '.payload.count // 0')"
+# the discriminator: the speed-drift alignment has a weak margin (~1.x), so a
+# margin gate rejects it. (We don't assert the default count — a strong FM copy
+# could legitimately vary — we assert the MARGIN GATE rejects the weak alignment.)
+if [ "${mrg_count:-0}" -eq 0 ]; then
+  ok "$C.speed_margin" "--min-margin 2 rejected the sped copy (weak margin ${spd_margin})"
+else
+  fail "$C.speed_margin" "--min-margin 2 still confirmed the sped copy (margin ${spd_margin})"
+fi
+
+# --- negative: a different real video is rejected -----------------------------
+cond "a different real video is rejected (no false positive)"
+NEG=""
+for cand in "$VIDEO_SMALL" "$VIDEO_OBJECTS" "$OC_LOCAL_IMAGE_VIDEO_A"; do
+  if have_media "$cand" && [ "$cand" != "$SRC" ] && \
+     [ "$(ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$cand" 2>/dev/null | head -1)" = "audio" ]; then NEG="$cand"; break; fi
+done
+if [ -n "$NEG" ]; then
+  ng="$(oc "$CASE" audio match "$NEG" --index "$IDX" --json)"
+  ngc="$(echo "$ng" | jq -r '.payload.count // 0')"
+  [ "${ngc:-0}" -eq 0 ] && ok "$C.negative" "different video ($(basename "$NEG")) correctly rejected" || fail "$C.negative" "different video false-matched $ngc time(s)"
+else
+  skip "$C.negative" "no second real video with audio available for the negative case"
+fi

--- a/test/unit/audio-index.test.ts
+++ b/test/unit/audio-index.test.ts
@@ -27,7 +27,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // or clap_match.py) → picks the record `verb`.
 const STUB = `#!/usr/bin/env bash
 script="$1"; shift
-op=""; against=""; minvotes=""; minratio=""; minmargin=""; minsim=""; index=""; gran=""; samp=""; win=""; input=""
+op=""; against=""; minvotes=""; minratio=""; minmargin=""; minsim=""; index=""; gran=""; samp=""; win=""; draw="no"; input=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --op) op="$2"; shift 2;;
@@ -40,6 +40,7 @@ while [ $# -gt 0 ]; do
     --granularity) gran="$2"; shift 2;;
     --sampling) samp="$2"; shift 2;;
     --window) win="$2"; shift 2;;
+    --draw) draw="yes"; shift;;
     --index-dir|--limit|--offset|--pooling) shift 2;;
     *) input="$1"; shift;;
   esac
@@ -48,7 +49,7 @@ case "$script" in
   *clap_match.py) verb="similar";;
   *) verb="audio";;
 esac
-printf '{"verb":"%s","format":"json","payload":{"op":"%s","against":"%s","min_votes":"%s","min_ratio":"%s","min_margin":"%s","min_similarity":"%s","index":"%s","granularity":"%s","sampling":"%s","window":"%s","input":"%s","matches":[],"count":0},"state":"ready","meta":{"provider":"fake-audio"}}\\n' "$verb" "$op" "$against" "$minvotes" "$minratio" "$minmargin" "$minsim" "$index" "$gran" "$samp" "$win" "$input"
+printf '{"verb":"%s","format":"json","payload":{"op":"%s","against":"%s","min_votes":"%s","min_ratio":"%s","min_margin":"%s","min_similarity":"%s","index":"%s","granularity":"%s","sampling":"%s","window":"%s","draw":"%s","input":"%s","matches":[],"count":0},"state":"ready","meta":{"provider":"fake-audio"}}\\n' "$verb" "$op" "$against" "$minvotes" "$minratio" "$minmargin" "$minsim" "$index" "$gran" "$samp" "$win" "$draw" "$input"
 `;
 
 // A fake that always fails (deps-missing style) to test the ready-gated add.
@@ -231,6 +232,21 @@ test("audio match forwards --op/--min-votes/--min-margin to the provider (indexe
     assert.equal(p.min_votes, "8");
     assert.equal(p.min_margin, "2"); // the speed-drift gate is forwarded
     assert.equal(p.against, ""); // indexed mode → no pairwise reference
+  });
+});
+
+test("audio match forwards --draw to the provider", async () => {
+  await withStub(STUB, async (dir) => {
+    const q = join(dir, "q.wav");
+    writeFileSync(q, "x");
+    const id = await createIndex(dir, "audio-fp");
+    addMember(openCase(dir), id, { ref: q });
+    const [rec] = await audioVerb.run(mk(dir, "match", [q], { index: id, draw: true }));
+    assert.equal(rec.state, "ready", rec.error);
+    assert.equal((rec.payload as Record<string, unknown>).draw, "yes");
+    // no --draw → not forwarded
+    const [plain] = await audioVerb.run(mk(dir, "match", [q], { index: id }));
+    assert.equal((plain.payload as Record<string, unknown>).draw, "no");
   });
 });
 
@@ -425,6 +441,16 @@ test("audio_match.py gates confirmation on margin and warns on a 0-hash (silent)
   // …and a silent/tonal member (0 hashes) must be flagged, not silently registered
   assert.match(src, /if hashes\.size == 0:/);
   assert.match(src, /"warning"\] = "no fingerprint hashes/);
+});
+
+test("audio_match.py --draw renders a dependency-free SVG under audio-matches/", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "audio-db", "audio_match.py"), "utf8");
+  // the alignment visualization is hand-rolled SVG (no matplotlib dep) written to
+  // the case media store, surfaced to the record as match_draw_path
+  assert.match(src, /def render_match_svg\(/);
+  assert.match(src, /"audio-matches"/);
+  assert.match(src, /item\["match_draw_path"\] = p/);
+  assert.match(src, /<svg xmlns=/);
 });
 
 test("clap_match.py uses the basic-clip emb/ cache layout and clap deps hint", () => {

--- a/test/unit/audio-index.test.ts
+++ b/test/unit/audio-index.test.ts
@@ -1,0 +1,403 @@
+// audio-fp (local fingerprint DB) + basic-clap (local CLAP DB) coverage. The
+// uv-managed Python is faked (a bash stub echoing an `audio`/`similar` record) so
+// the TS verb/arg-mapping, config.json plumbing, and index redirects run offline
+// with NO numpy/scipy/torch. Mirrors similar-index.test.ts / face-index.test.ts.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+
+import { openCase } from "../../src/case.ts";
+import { defaultProfile, type Profile } from "../../src/profile.ts";
+import { makeRecord } from "../../src/record.ts";
+import { normalizeIndexType, findIndex, addMember, addIndex, LOCAL_INDEX_TYPES } from "../../src/state/index.ts";
+import { indexVerb } from "../../src/verbs/index.ts";
+import { audioVerb } from "../../src/verbs/audio.ts";
+import { similarVerb } from "../../src/verbs/similar.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// A fake OC_VISUAL_DB_PY that echoes the resolved op + forwarded flags so the
+// test can assert what the verb forwarded. $1 is the script path (audio_match.py
+// or clap_match.py) → picks the record `verb`.
+const STUB = `#!/usr/bin/env bash
+script="$1"; shift
+op=""; against=""; minvotes=""; minratio=""; index=""; gran=""; samp=""; win=""; input=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --op) op="$2"; shift 2;;
+    --against) against="$2"; shift 2;;
+    --min-votes) minvotes="$2"; shift 2;;
+    --min-ratio) minratio="$2"; shift 2;;
+    --index) index="$2"; shift 2;;
+    --granularity) gran="$2"; shift 2;;
+    --sampling) samp="$2"; shift 2;;
+    --window) win="$2"; shift 2;;
+    --index-dir|--min-similarity|--limit|--offset|--pooling) shift 2;;
+    *) input="$1"; shift;;
+  esac
+done
+case "$script" in
+  *clap_match.py) verb="similar";;
+  *) verb="audio";;
+esac
+printf '{"verb":"%s","format":"json","payload":{"op":"%s","against":"%s","min_votes":"%s","min_ratio":"%s","index":"%s","granularity":"%s","sampling":"%s","window":"%s","input":"%s","matches":[],"count":0},"state":"ready","meta":{"provider":"fake-audio"}}\\n' "$verb" "$op" "$against" "$minvotes" "$minratio" "$index" "$gran" "$samp" "$win" "$input"
+`;
+
+// A fake that always fails (deps-missing style) to test the ready-gated add.
+const STUB_FAIL = `#!/usr/bin/env bash
+script="$1"
+case "$script" in
+  *clap_match.py) verb="similar";;
+  *) verb="audio";;
+esac
+printf '{"verb":"%s","format":"json","payload":{"op":"add","matches":[],"count":0},"error":"deps missing","state":"error"}\\n' "$verb"
+`;
+
+async function withStub(stubBody: string, fn: (dir: string, stub: string) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "oc-audio-"));
+  const stub = join(dir, "fake-audio.sh");
+  writeFileSync(stub, stubBody);
+  chmodSync(stub, 0o755);
+  const saved = process.env.OC_VISUAL_DB_PY;
+  process.env.OC_VISUAL_DB_PY = stub;
+  try {
+    await fn(dir, stub);
+  } finally {
+    if (saved === undefined) delete process.env.OC_VISUAL_DB_PY;
+    else process.env.OC_VISUAL_DB_PY = saved;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function mk(dir: string, input: string | undefined, rest: string[] = [], opts: VerbContext["opts"] = {}, profile?: Profile): VerbContext {
+  const c = openCase(dir);
+  c.ensure();
+  return { input, rest, opts, case: c, profile: profile ?? defaultProfile() };
+}
+
+async function createIndex(dir: string, type: string, opts: VerbContext["opts"] = {}): Promise<string> {
+  const [created] = await indexVerb.run(mk(dir, "create", ["idx"], { type, local: true, ...opts }));
+  assert.equal(created.state, "ready", created.error);
+  return String((created.payload as Record<string, unknown>).index);
+}
+
+// ---- index type registration ----------------------------------------------
+
+test("normalizeIndexType maps audio aliases", () => {
+  for (const a of ["audio-fp", "audio", "audio-fingerprint", "fingerprint"]) assert.equal(normalizeIndexType(a), "audio-fp");
+  for (const a of ["basic-clap", "clap", "audio-clip", "audio-semantic"]) assert.equal(normalizeIndexType(a), "basic-clap");
+  assert.ok(LOCAL_INDEX_TYPES.has("audio-fp"));
+  assert.ok(LOCAL_INDEX_TYPES.has("basic-clap"));
+});
+
+test("index create --type audio-fp --local writes the fingerprint config.json", async () => {
+  await withStub(STUB, async (dir) => {
+    const id = await createIndex(dir, "audio-fp");
+    assert.match(id, /^local_audio_fp_/);
+    assert.equal(findIndex(openCase(dir), id)?.backend, "local");
+    const cfg = JSON.parse(readFileSync(join(dir, ".overcast", "index", id, "config.json"), "utf8"));
+    assert.equal(cfg.sampleRate, 11025);
+    assert.equal(cfg.fanOut, 15);
+  });
+});
+
+test("index create --type basic-clap --local writes clap defaults (pooling mean)", async () => {
+  await withStub(STUB, async (dir) => {
+    const id = await createIndex(dir, "basic-clap");
+    assert.match(id, /^local_basic_clap_/);
+    const cfg = JSON.parse(readFileSync(join(dir, ".overcast", "index", id, "config.json"), "utf8"));
+    assert.equal(cfg.pooling, "mean");
+    assert.equal(cfg.granularity, "video");
+    assert.equal(cfg.window, 10);
+  });
+});
+
+test("index create --type basic-clap rejects a frame-sampling flag", async () => {
+  await withStub(STUB, async (dir) => {
+    const [rec] = await indexVerb.run(mk(dir, "create", ["x"], { type: "basic-clap", local: true, sampling: "shots" }));
+    assert.equal(rec.state, "error");
+    assert.match(rec.error ?? "", /doesn't apply to a basic-clap/);
+  });
+});
+
+test("audio-fp and basic-clap are local-only (attach rejected)", async () => {
+  await withStub(STUB, async (dir) => {
+    for (const type of ["audio-fp", "basic-clap"]) {
+      const [rec] = await indexVerb.run(mk(dir, "attach", ["remote_x"], { type }));
+      assert.equal(rec.state, "error");
+      assert.match(rec.error ?? "", /local-only/);
+    }
+  });
+});
+
+test("index add redirects to the fingerprint/embed verbs", async () => {
+  await withStub(STUB, async (dir) => {
+    const clip = join(dir, "a.mp3");
+    writeFileSync(clip, "x");
+    const fpId = await createIndex(dir, "audio-fp");
+    const [fp] = await indexVerb.run(mk(dir, "add", [clip], { to: fpId }));
+    assert.equal(fp.state, "error");
+    assert.match(fp.error ?? "", /audio add/);
+
+    const clapId = await createIndex(dir, "basic-clap");
+    const [clap] = await indexVerb.run(mk(dir, "add", [clip], { to: clapId }));
+    assert.equal(clap.state, "error");
+    assert.match(clap.error ?? "", /similar add/);
+  });
+});
+
+// ---- audio verb guards -----------------------------------------------------
+
+test("audio verb: bad action / missing input / wrong index type", async () => {
+  await withStub(STUB, async (dir) => {
+    const clip = join(dir, "a.mp3");
+    writeFileSync(clip, "x");
+    const [bad] = await audioVerb.run(mk(dir, "frobnicate", [clip], { index: "x" }));
+    assert.equal(bad.state, "error");
+    assert.match(bad.error ?? "", /usage: audio/);
+
+    const [noInput] = await audioVerb.run(mk(dir, "match", [], { index: "x" }));
+    assert.equal(noInput.state, "error");
+    assert.match(noInput.error ?? "", /requires an audio\/video input/);
+
+    // a basic-clap index is not an audio-fp index
+    const clapId = await createIndex(dir, "basic-clap");
+    const [wrong] = await audioVerb.run(mk(dir, "match", [clip], { index: clapId }));
+    assert.equal(wrong.state, "error");
+    assert.match(wrong.error ?? "", /not audio-fp/);
+  });
+});
+
+test("audio match: reference XOR --index (both/neither is an error)", async () => {
+  await withStub(STUB, async (dir) => {
+    const q = join(dir, "q.wav");
+    const r = join(dir, "r.wav");
+    writeFileSync(q, "x");
+    writeFileSync(r, "x");
+    const id = await createIndex(dir, "audio-fp");
+
+    const [both] = await audioVerb.run(mk(dir, "match", [q, r], { index: id }));
+    assert.equal(both.state, "error");
+    assert.match(both.error ?? "", /not both/);
+
+    const [neither] = await audioVerb.run(mk(dir, "match", [q]));
+    assert.equal(neither.state, "error");
+    assert.match(neither.error ?? "", /--index .* or a second clip/);
+  });
+});
+
+test("audio add rejects a reference positional and a bad --min-votes / image input", async () => {
+  await withStub(STUB, async (dir) => {
+    const a = join(dir, "a.mp3");
+    const b = join(dir, "b.mp3");
+    const jpg = join(dir, "q.jpg");
+    for (const f of [a, b, jpg]) writeFileSync(f, "x");
+    const id = await createIndex(dir, "audio-fp");
+
+    const [ref] = await audioVerb.run(mk(dir, "add", [a, b], { to: id }));
+    assert.equal(ref.state, "error");
+    assert.match(ref.error ?? "", /audio add takes one input/);
+
+    const [votes] = await audioVerb.run(mk(dir, "match", [a], { index: id, "min-votes": 0 }));
+    assert.equal(votes.state, "error");
+    assert.match(votes.error ?? "", /min-votes/);
+
+    const [img] = await audioVerb.run(mk(dir, "add", [jpg], { to: id }));
+    assert.equal(img.state, "error");
+    assert.match(img.error ?? "", /not a video\/audio file/);
+  });
+});
+
+// ---- audio verb wiring (fake provider) -------------------------------------
+
+test("audio match forwards --op/--min-votes to the provider (indexed)", async () => {
+  await withStub(STUB, async (dir) => {
+    const q = join(dir, "q.wav");
+    writeFileSync(q, "x");
+    const id = await createIndex(dir, "audio-fp");
+    addMember(openCase(dir), id, { ref: q });
+    const [rec] = await audioVerb.run(mk(dir, "match", [q], { index: id, "min-votes": 8 }));
+    assert.equal(rec.state, "ready", rec.error);
+    const p = rec.payload as Record<string, unknown>;
+    assert.equal(p.op, "match");
+    assert.equal(p.min_votes, "8");
+    assert.equal(p.against, ""); // indexed mode → no pairwise reference
+  });
+});
+
+test("audio match pairwise forwards --against and no index dir", async () => {
+  await withStub(STUB, async (dir) => {
+    const q = join(dir, "q.wav");
+    const r = join(dir, "r.wav");
+    writeFileSync(q, "x");
+    writeFileSync(r, "x");
+    const [rec] = await audioVerb.run(mk(dir, "match", [q, r]));
+    assert.equal(rec.state, "ready", rec.error);
+    const p = rec.payload as Record<string, unknown>;
+    assert.equal(p.op, "match");
+    assert.equal(p.against, r);
+    assert.equal(p.index, ""); // pairwise → no index forwarded
+  });
+});
+
+test("audio add registers the member only on a ready fingerprint", async () => {
+  await withStub(STUB, async (dir) => {
+    const clip = join(dir, "a.mp3");
+    writeFileSync(clip, "x");
+    const id = await createIndex(dir, "audio-fp");
+    const [ok] = await audioVerb.run(mk(dir, "add", [clip], { to: id }));
+    assert.equal(ok.state, "ready");
+    assert.equal(findIndex(openCase(dir), id)?.members.length, 1);
+    // dedupe: a second add short-circuits as already_member
+    const [dupe] = await audioVerb.run(mk(dir, "add", [clip], { to: id }));
+    assert.equal((dupe.payload as Record<string, unknown>).already_member, true);
+    assert.equal(findIndex(openCase(dir), id)?.members.length, 1);
+  });
+});
+
+test("audio add does NOT register the member when the fingerprint fails", async () => {
+  await withStub(STUB_FAIL, async (dir) => {
+    const clip = join(dir, "a.mp3");
+    writeFileSync(clip, "x");
+    const id = await createIndex(dir, "audio-fp");
+    const [rec] = await audioVerb.run(mk(dir, "add", [clip], { to: id }));
+    assert.equal(rec.state, "error");
+    assert.equal(findIndex(openCase(dir), id)?.members.length, 0);
+  });
+});
+
+test("audio match stamps capture provenance on the query", async () => {
+  await withStub(STUB, async (dir) => {
+    const q = join(dir, "q.wav");
+    writeFileSync(q, "x");
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({ verb: "capture", payload: { path: q, source_url: "https://x.test/post" }, media: { ref: q }, state: "ready" }));
+    const id = await createIndex(dir, "audio-fp");
+    addMember(openCase(dir), id, { ref: q });
+    const [rec] = await audioVerb.run(mk(dir, "match", [q], { index: id }));
+    assert.equal((rec.payload as Record<string, unknown>).source_url, "https://x.test/post");
+  });
+});
+
+// ---- similar (basic-clap) guards + wiring ----------------------------------
+
+test("similar rejects a frame-sampling flag against a basic-clap index", async () => {
+  await withStub(STUB, async (dir) => {
+    const clip = join(dir, "a.mp3");
+    writeFileSync(clip, "x");
+    const id = await createIndex(dir, "basic-clap");
+    for (const opt of [{ fps: 1 }, { sampling: "shots" }] as VerbContext["opts"][]) {
+      const [rec] = await similarVerb.run(mk(dir, "match", [clip], { index: id, ...opt }));
+      assert.equal(rec.state, "error");
+      assert.match(rec.error ?? "", /basic-clap \(audio\) index/);
+    }
+  });
+});
+
+test("similar match against basic-clap rejects an image and dispatches to clap", async () => {
+  await withStub(STUB, async (dir) => {
+    const jpg = join(dir, "q.jpg");
+    const wav = join(dir, "q.wav");
+    writeFileSync(jpg, "x");
+    writeFileSync(wav, "x");
+    const id = await createIndex(dir, "basic-clap");
+    addMember(openCase(dir), id, { ref: wav });
+
+    const [img] = await similarVerb.run(mk(dir, "match", [jpg], { index: id }));
+    assert.equal(img.state, "error");
+    assert.match(img.error ?? "", /not a video\/audio file/);
+
+    const [rec] = await similarVerb.run(mk(dir, "match", [wav], { index: id }));
+    assert.equal(rec.state, "ready", rec.error);
+    assert.equal((rec.payload as Record<string, unknown>).op, "match");
+  });
+});
+
+test("similar search reaches the clap provider with --op search", async () => {
+  await withStub(STUB, async (dir) => {
+    const wav = join(dir, "q.wav");
+    writeFileSync(wav, "x");
+    const id = await createIndex(dir, "basic-clap");
+    addMember(openCase(dir), id, { ref: wav });
+    const [rec] = await similarVerb.run(mk(dir, "search", ["crowd", "chanting"], { index: id }));
+    assert.equal(rec.state, "ready", rec.error);
+    assert.equal((rec.payload as Record<string, unknown>).op, "search");
+  });
+});
+
+test("similar add embeds an audio member into a basic-clap index (ready-gated)", async () => {
+  await withStub(STUB, async (dir) => {
+    const wav = join(dir, "clip.wav");
+    writeFileSync(wav, "x");
+    const id = await createIndex(dir, "basic-clap");
+    const [rec] = await similarVerb.run(mk(dir, "add", [wav], { index: id }));
+    assert.equal(rec.state, "ready", rec.error);
+    assert.equal(findIndex(openCase(dir), id)?.members.length, 1);
+  });
+});
+
+// ---- index remove cache cleanup --------------------------------------------
+
+test("index remove drops the cached fingerprint / embedding", async () => {
+  await withStub(STUB, async (dir) => {
+    const clip = join(dir, "clip.wav");
+    writeFileSync(clip, "x");
+    // audio-fp: fp/<sha1>.npz
+    const fpId = await createIndex(dir, "audio-fp");
+    addMember(openCase(dir), fpId, { ref: clip });
+    const key = createHash("sha1").update(clip).digest("hex");
+    const npz = join(dir, ".overcast", "index", fpId, "fp", `${key}.npz`);
+    mkdirSync(dirname(npz), { recursive: true });
+    writeFileSync(npz, "x");
+    const [rmFp] = await indexVerb.run(mk(dir, "remove", [clip], { from: fpId }));
+    assert.equal((rmFp.payload as Record<string, unknown>).removed, true);
+    assert.ok(!existsSync(npz), "fingerprint npz deleted");
+
+    // basic-clap: emb/<sha1>.npy (shared basic-clip layout)
+    const clapId = await createIndex(dir, "basic-clap");
+    addMember(openCase(dir), clapId, { ref: clip });
+    const npy = join(dir, ".overcast", "index", clapId, "emb", `${key}.npy`);
+    mkdirSync(dirname(npy), { recursive: true });
+    writeFileSync(npy, "x");
+    const [rmClap] = await indexVerb.run(mk(dir, "remove", [clip], { from: clapId }));
+    assert.equal((rmClap.payload as Record<string, unknown>).removed, true);
+    assert.ok(!existsSync(npy), "clap npy deleted");
+  });
+});
+
+// ---- Python provider source invariants (cheap, offline) --------------------
+
+test("audio_match.py anchors media on the query and never persists at query time", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "audio-db", "audio_match.py"), "utf8");
+  // media anchors the QUERY input (member offsets live in matches[])
+  assert.match(src, /"media": \{"ref": args\.input\}/);
+  // query-time member rebuilds must not write the cache
+  assert.match(src, /persist=False/);
+  // deps-missing hint points at the right installer flag
+  assert.match(src, /run scripts\/visual-db-uv\.sh --audio/);
+});
+
+test("clap_match.py uses the basic-clip emb/ cache layout and clap deps hint", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "audio-db", "clap_match.py"), "utf8");
+  assert.match(src, /emb_dir = Path\(index_dir\) \/ "emb"/);
+  assert.match(src, /"%s\.npy" % key/);
+  assert.match(src, /run scripts\/visual-db-uv\.sh --clap/);
+});
+
+test("clap_match.py handles the transformers v4↔v5 CLAP API differences", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "audio-db", "clap_match.py"), "utf8");
+  // v5 renamed the processor kwarg audios→audio (fall back for pinned v4)…
+  assert.match(src, /processor\(audio=batch/);
+  assert.match(src, /processor\(audios=batch/);
+  // …and get_audio/text_features returns an output object (pooler_output) in v5,
+  // a bare tensor in v4 — both must be unwrapped to the projected embedding.
+  assert.match(src, /def _features\(out\)/);
+  assert.match(src, /"audio_embeds", "text_embeds", "pooler_output"/);
+});

--- a/test/unit/audio-index.test.ts
+++ b/test/unit/audio-index.test.ts
@@ -27,18 +27,20 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // or clap_match.py) → picks the record `verb`.
 const STUB = `#!/usr/bin/env bash
 script="$1"; shift
-op=""; against=""; minvotes=""; minratio=""; index=""; gran=""; samp=""; win=""; input=""
+op=""; against=""; minvotes=""; minratio=""; minmargin=""; minsim=""; index=""; gran=""; samp=""; win=""; input=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --op) op="$2"; shift 2;;
     --against) against="$2"; shift 2;;
     --min-votes) minvotes="$2"; shift 2;;
     --min-ratio) minratio="$2"; shift 2;;
+    --min-margin) minmargin="$2"; shift 2;;
+    --min-similarity) minsim="$2"; shift 2;;
     --index) index="$2"; shift 2;;
     --granularity) gran="$2"; shift 2;;
     --sampling) samp="$2"; shift 2;;
     --window) win="$2"; shift 2;;
-    --index-dir|--min-similarity|--limit|--offset|--pooling) shift 2;;
+    --index-dir|--limit|--offset|--pooling) shift 2;;
     *) input="$1"; shift;;
   esac
 done
@@ -46,7 +48,7 @@ case "$script" in
   *clap_match.py) verb="similar";;
   *) verb="audio";;
 esac
-printf '{"verb":"%s","format":"json","payload":{"op":"%s","against":"%s","min_votes":"%s","min_ratio":"%s","index":"%s","granularity":"%s","sampling":"%s","window":"%s","input":"%s","matches":[],"count":0},"state":"ready","meta":{"provider":"fake-audio"}}\\n' "$verb" "$op" "$against" "$minvotes" "$minratio" "$index" "$gran" "$samp" "$win" "$input"
+printf '{"verb":"%s","format":"json","payload":{"op":"%s","against":"%s","min_votes":"%s","min_ratio":"%s","min_margin":"%s","min_similarity":"%s","index":"%s","granularity":"%s","sampling":"%s","window":"%s","input":"%s","matches":[],"count":0},"state":"ready","meta":{"provider":"fake-audio"}}\\n' "$verb" "$op" "$against" "$minvotes" "$minratio" "$minmargin" "$minsim" "$index" "$gran" "$samp" "$win" "$input"
 `;
 
 // A fake that always fails (deps-missing style) to test the ready-gated add.
@@ -216,18 +218,31 @@ test("audio add rejects a reference positional and a bad --min-votes / image inp
 
 // ---- audio verb wiring (fake provider) -------------------------------------
 
-test("audio match forwards --op/--min-votes to the provider (indexed)", async () => {
+test("audio match forwards --op/--min-votes/--min-margin to the provider (indexed)", async () => {
   await withStub(STUB, async (dir) => {
     const q = join(dir, "q.wav");
     writeFileSync(q, "x");
     const id = await createIndex(dir, "audio-fp");
     addMember(openCase(dir), id, { ref: q });
-    const [rec] = await audioVerb.run(mk(dir, "match", [q], { index: id, "min-votes": 8 }));
+    const [rec] = await audioVerb.run(mk(dir, "match", [q], { index: id, "min-votes": 8, "min-margin": 2 }));
     assert.equal(rec.state, "ready", rec.error);
     const p = rec.payload as Record<string, unknown>;
     assert.equal(p.op, "match");
     assert.equal(p.min_votes, "8");
+    assert.equal(p.min_margin, "2"); // the speed-drift gate is forwarded
     assert.equal(p.against, ""); // indexed mode → no pairwise reference
+  });
+});
+
+test("audio match rejects a --min-margin below 1", async () => {
+  await withStub(STUB, async (dir) => {
+    const q = join(dir, "q.wav");
+    writeFileSync(q, "x");
+    const id = await createIndex(dir, "audio-fp");
+    addMember(openCase(dir), id, { ref: q });
+    const [rec] = await audioVerb.run(mk(dir, "match", [q], { index: id, "min-margin": 0.5 }));
+    assert.equal(rec.state, "error");
+    assert.match(rec.error ?? "", /min-margin/);
   });
 });
 
@@ -332,6 +347,24 @@ test("similar search reaches the clap provider with --op search", async () => {
   });
 });
 
+test("similar accepts a NEGATIVE --min-similarity (CLAP text→audio scores near/below 0)", async () => {
+  await withStub(STUB, async (dir) => {
+    const wav = join(dir, "q.wav");
+    writeFileSync(wav, "x");
+    const id = await createIndex(dir, "basic-clap");
+    addMember(openCase(dir), id, { ref: wav });
+    // -100 must be accepted (not rejected as out-of-range) and forwarded so a
+    // negative-cosine best match is retrievable instead of filtered to [].
+    const [rec] = await similarVerb.run(mk(dir, "search", ["a person speaking"], { index: id, "min-similarity": -100 }));
+    assert.equal(rec.state, "ready", rec.error);
+    assert.equal((rec.payload as Record<string, unknown>).min_similarity, "-100");
+    // out-of-range still rejected
+    const [bad] = await similarVerb.run(mk(dir, "search", ["x"], { index: id, "min-similarity": -101 }));
+    assert.equal(bad.state, "error");
+    assert.match(bad.error ?? "", /min-similarity/);
+  });
+});
+
 test("similar add embeds an audio member into a basic-clap index (ready-gated)", async () => {
   await withStub(STUB, async (dir) => {
     const wav = join(dir, "clip.wav");
@@ -382,6 +415,16 @@ test("audio_match.py anchors media on the query and never persists at query time
   assert.match(src, /persist=False/);
   // deps-missing hint points at the right installer flag
   assert.match(src, /run scripts\/visual-db-uv\.sh --audio/);
+});
+
+test("audio_match.py gates confirmation on margin and warns on a 0-hash (silent) add", () => {
+  const src = readFileSync(join(HERE, "..", "..", "examples", "providers", "audio-db", "audio_match.py"), "utf8");
+  // the confirm criterion must include the margin gate (rejects speed-drift
+  // partial alignments the raw vote floor would otherwise confirm)…
+  assert.match(src, /aligned_votes >= min_votes and match_ratio >= min_ratio and margin >= min_margin/);
+  // …and a silent/tonal member (0 hashes) must be flagged, not silently registered
+  assert.match(src, /if hashes\.size == 0:/);
+  assert.match(src, /"warning"\] = "no fingerprint hashes/);
 });
 
 test("clap_match.py uses the basic-clip emb/ cache layout and clap deps hint", () => {

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -800,6 +800,37 @@ test("brief synthesis: TL;DR note, sources-checked rollup, and findings surface 
   }
 });
 
+test("brief embeds an audio-match alignment SVG overlay (like the image RANSAC overlay)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-brief-audio-svg-"));
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    // an audio match record carrying an SVG alignment overlay; a finding cites it
+    const svgPath = join(dir, "match_draw_audio.svg");
+    writeFileSync(svgPath, '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>');
+    const audioRec = makeRecord({
+      verb: "audio",
+      payload: { op: "match", index: "local_audio_fp_x", count: 1, matches: [{ ref: "/m/orig.mp4", offset_seconds: 12.0, aligned_votes: 900, match_draw_path: svgPath }] },
+      media: { ref: "/m/suspect.mp4" },
+      state: "ready",
+    });
+    c.writeRecord(audioRec);
+    c.writeRecord(makeRecord({ verb: "finding", payload: { text: "audio copy CONFIRMED at 00:12", status: "open", confidence: "high", source_record: audioRec.id, source_verb: "audio", trigger: "human" }, state: "ready" }));
+    const html = join(dir, "brief.html");
+    const [rec] = await briefVerb.run({ input: undefined, rest: [], opts: { export: html, theme: "csi" }, case: c, profile: defaultProfile() });
+    // the finding's overlay resolves from its cited audio-match record
+    const syn = (rec.payload as Record<string, unknown>).synthesis as Record<string, unknown>;
+    const synFindings = syn.findings as Array<Record<string, unknown>>;
+    assert.deepEqual(synFindings[0].overlays, [svgPath]);
+    // csi html inlines the SVG file as an image/svg+xml data URI
+    const out = readFileSync(html, "utf8");
+    assert.match(out, /data-csi-overlays="true"/);
+    assert.match(out, /<img[^>]*src="data:image\/svg\+xml;base64,/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("brief synthesis: a clean sweep says so explicitly (checked, found none)", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-brief-clean-"));
   try {


### PR DESCRIPTION
## What

Adds the audio analog of the `image`/`similar` visual matching pair — two local, offline audio senses, each selected by a new local index type. Greenfield feature (no prior audio-matching code).

### `audio` verb — Shazam-style exact matching (`audio-fp` index)
- Wang-2003 constellation fingerprinting in pure numpy/scipy (`examples/providers/audio-db/audio_match.py`): STFT → spectral peak picking → anchor/target-zone pair hashing → offset-histogram voting. Reimplemented from the paper + MIT references.
- `audio add` fingerprints + caches a recording (`fp/<sha1>.npz`, cache-on-add like basic-clip; reads never write). `audio match` finds which indexed recording contains a query **and where** (time-offset alignment), or compares two clips directly with `audio match <query> <reference>` (no index).
- Reports per member: `offset_seconds`, `aligned_votes`, `match_ratio`, `margin`, `span_seconds`. `--min-votes` (default 6) is the confidence floor. Videos accepted (audio track extracted). Robust to transcode/noise/clipping; **not** to pitch/speed change (classic Wang).

### CLAP audio embeddings — folded into `similar` (`basic-clap` index)
- LAION `laion/larger_clap_general` via `transformers` (`clap_match.py`), reusing basic-clip's `emb/<sha1>.npy` cache layout + brute-force cosine. `removeClipEmbedding` cleans it for free.
- `similar add/match/search` → audio↔audio and text→audio; audio chunked into `--window`-second slices (default 10s), pooled to a track vector, or per-window moments with `--granularity frame`.

### Plumbing
`IndexType` + `LOCAL_INDEX_TYPES` + aliases; `runLocalAudio`/`runLocalClap` shims (reuse the visual-DB venv + Python locator); `index create` configs, add-redirects, and remove cache-cleanup; provider catalog choices + presets; doctor `audio-db` check (imports only — never triggers a model download); memory `FIELD_POLICY` (evidence, compact summaries only — no hashes/vectors); `visual-db-uv.sh --audio`/`--clap`; docs (CLAUDE.md, README, flows.md, providers.md, .env.example) + regenerated skills.

## Verification (real models, not just tests)
- **564 unit tests pass**, typecheck + build clean, shellcheck clean.
- **Fingerprint (real audio):** a 48k-AAC-transcoded + noised + volume-shifted 8s copy matched its 30s source at **offset 11.98s** (segment starts at 12s) with **39 aligned votes**; unrelated chirp rejected (2 votes); pairwise confirms/rejects; cache written→reused→cleaned on `index remove`; match surfaces in case memory as evidence.
- **CLAP (real model):** same-source cosine **90.6** vs cross-source **25.1**; text→audio ranks the tone correctly; `granularity=frame` yields moments with `at`.
- e2e cases 28 (fingerprint, self-contained) and 29 (CLAP, gated on `OC_CLAP_E2E=1`) pass through their real harness; case 29 skips cleanly without the flag (never surprise-downloads ~776MB in CI).

One bug caught only by running it: transformers v5 renamed the CLAP processor kwarg `audios`→`audio` and now returns an output object (`pooler_output`) instead of a bare tensor. Fixed with version-robust fallbacks in `clap_match.py`, guarded by a source-invariant test.

## Deferred to v2 (noted in docs)
Pitch/speed `--speed-sweep`; overlapping CLAP windows + `--hop`; wall/view spectrogram overlay; chromaprint dedup pre-filter; ANN index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface (verb, providers, index lifecycle, brief embedding) with heavy optional Python/torch deps; core paths are local-only and well-tested, but first CLAP use downloads ~776MB and fingerprint behavior differs from pitch/speed-shifted audio.
> 
> **Overview**
> Introduces **offline audio matching** parallel to the existing image/CLIP stack: a new **`audio`** sense for exact recording match and **`basic-clap`** indexes that extend **`similar`** for audio↔audio and text→audio search.
> 
> The **`audio`** verb fingerprints members into **`audio-fp`** indexes (`audio add`) and matches queries with **time-offset alignment** (`audio match`), including **clip-to-clip** mode without an index. Matching uses a new **`audio_match.py`** provider (numpy/scipy, ffmpeg decode), with **`--min-margin`** to reject weak sped-up re-uploads and **`--draw`** for SVG alignment plots that embed in briefs like image match overlays.
> 
> **`basic-clap`** reuses the **`similar`** grammar via **`clap_match.py`** (LAION CLAP, same `emb/` cache layout as basic-clip). **`similar`** now dispatches CLIP vs CLAP by index type; **`--min-similarity`** accepts **-100…100** so low CLAP text scores are not filtered to empty.
> 
> **Plumbing:** `audioVerb` in the registry; `runLocalAudio` / `runLocalClap`; index types **`audio-fp`** / **`basic-clap`** with create configs, add redirects, and cache cleanup on remove; catalog presets; doctor **`audio-db`** check; memory field policy for `audio`; brief/HTML support for **SVG** overlays. **`visual-db-uv.sh`** gains **`--audio`** / **`--clap`** / updated **`--all`**. Docs, skills, and e2e cases **28–30** (CLAP gated on **`OC_CLAP_E2E`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 030939519512684c150a4e1b6f623b8234d6ff7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->