### PR TITLE
docs(.env.example): document OVERCAST_GRID_FONT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,15 @@ DETECT_PY=
 # DETECT_THRESHOLD=0.1
 # DETECT_MAX_FRAMES=8
 
+# ── Contact sheets (grid / grid --view) ─────────────────────────────────────
+# grid tiles video frames into a contact sheet for one-shot VLM triage; it needs
+# NO keys (pure ffmpeg — the see / frame-verify CoT steps reuse the brain +
+# Cloudglue configured above). Burned cell labels need an ffmpeg built with
+# drawtext (libfreetype); when a system font isn't auto-found, point this at a
+# .ttf — else cells are numbered positionally (and `grid --view` labels them in
+# CSS regardless). Leave unset unless you want labels burned into the PNG:
+# OVERCAST_GRID_FONT=/System/Library/Fonts/Supplemental/Arial.ttf
+
 # ── Runner knobs (env only; not secrets) ───────────────────────────────────
 # OVERCAST_USE_NODE=1   # run `node dist/bin/overcast.js` instead of the bun binary
 # SKIP_BUILD=1          # reuse an existing dist build (skip the build step)


### PR DESCRIPTION
The `grid` verb (merged in #48) introduced one optional env knob — `OVERCAST_GRID_FONT` — that was never added to the shipped `.env.example` template. This adds a short **Contact sheets (grid / grid --view)** section documenting it.

- **Additive only** — 9 lines, no deletions.
- Notes that `grid` needs **no keys** (pure ffmpeg; the see / frame-verify CoT steps reuse the brain + Cloudglue already configured above).
- Documents `OVERCAST_GRID_FONT` as an optional `.ttf` path for burned cell labels (needs an ffmpeg built with `drawtext`/libfreetype); left commented, since without it cells are numbered positionally and `grid --view` labels them in CSS regardless.

Matches the file's existing `# ── … ──` section style and placement (between the detector and runner-knob sections).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `.env.example` with no runtime or config behavior changes.
> 
> **Overview**
> Adds a **Contact sheets (`grid` / `grid --view`)** block to `.env.example` so the optional `OVERCAST_GRID_FONT` knob from the `grid` verb is documented in the shipped env template.
> 
> The section explains that `grid` itself needs no API keys (ffmpeg-only tiling), while optional burned-in cell labels depend on ffmpeg `drawtext` and an optional `.ttf` path via `OVERCAST_GRID_FONT` when auto font discovery fails; otherwise numbering is positional and `grid --view` can label cells in CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974ebdf44540b614c80d091a9a64beaf39c043b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->