### PR TITLE
docs(.env.example): optional OSINT-source knobs + forensic-sense tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,17 @@ APIFY_TOKEN=
 # Windy Webcams API — the `webcam` source (geolocated live public webcams). Free
 # tier is enough for scan + still capture + monitor. https://api.windy.com/webcams
 WINDY_API_KEY=
-# gdelttv source needs no key (public GDELT TV API).
-# Optional actor overrides: OVERCAST_INSTAGRAM_ACTOR, OVERCAST_TELEGRAM_ACTOR,
-# OVERCAST_FACE_SEARCH_ACTOR, OVERCAST_X_ACTOR, OVERCAST_LENS_ACTOR.
+# gdelttv source needs no key (public GDELT TV API); dl uses yt-dlp on PATH.
+# Forensic senses need no key — `exif` uses system `exiftool`, `verify` uses
+# `c2patool` (both report needs_credentials / exit 13 when absent).
+# Optional source overrides (defaults are fine — uncomment to change):
+# OVERCAST_INSTAGRAM_ACTOR=
+# OVERCAST_TELEGRAM_ACTOR=
+# OVERCAST_LENS_ACTOR=
+# OVERCAST_FACE_SEARCH_ACTOR=
+# OVERCAST_X_ACTOR=
+# OVERCAST_WEBCAM_API=              # Windy Webcams API base URL override
+# APIFY_RUN_SYNC_TIMEOUT_MS=        # run-sync budget for the Apify-backed sources
 
 # ── Test media (LIVE e2e) — one full path per file ─────────────────────────
 # Point each at a real local file (absolute path). No file names are baked into


### PR DESCRIPTION
Follow-up polish to **#51** (new OSINT sources + forensic senses). #51 shipped the sources/senses, their required keys (`WINDY_API_KEY`; `APIFY_TOKEN` reused by instagram/telegram/lens/facesearch), and the full docs (README, CLAUDE.md, flows.md, providers.md, skills). This just fills the remaining `.env.example` gaps for the **optional** knobs — already documented in `README.md` / `docs/providers.md`, but not yet in the env template.

## Changes (`.env.example` only)
- Optional actor / endpoint overrides as commented `# KEY=` lines (matching the file's `# OVERCAST_GRID_FONT=` style): `OVERCAST_INSTAGRAM_ACTOR`, `OVERCAST_TELEGRAM_ACTOR`, `OVERCAST_LENS_ACTOR`, `OVERCAST_FACE_SEARCH_ACTOR`, `OVERCAST_X_ACTOR`, plus the two that weren't listed anywhere in the template: `OVERCAST_WEBCAM_API` and `APIFY_RUN_SYNC_TIMEOUT_MS`.
- Note that the `exif` / `verify` forensic senses need **no key** (system `exiftool` / `c2patool`, `needs_credentials`/exit 13 when absent).
- Note that `dl` uses `yt-dlp`.

## Notes
- **No secret values** — every added line is a comment or an empty commented key.
- No code/docs changes; the prose docs already cover these knobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the sample env file; no runtime or credential behavior changes.
> 
> **Overview**
> **`.env.example` only** — aligns the env template with knobs already described in README / `docs/providers.md` (no code or other doc edits).
> 
> Replaces the old inline “optional actor overrides” line with a clearer block: **`gdelttv`** (no key), **`dl`** (`yt-dlp` on PATH), and forensic senses **`exif`** / **`verify`** (system `exiftool` / `c2patool`, `needs_credentials` / exit 13 when missing). Adds **commented `# KEY=`** optional overrides in the same style as `OVERCAST_GRID_FONT`: Apify actor env vars (`OVERCAST_INSTAGRAM_ACTOR`, `TELEGRAM`, `LENS`, `FACE_SEARCH`, `X`) plus **`OVERCAST_WEBCAM_API`** and **`APIFY_RUN_SYNC_TIMEOUT_MS`**, which were not previously listed in the template.
> 
> All new lines are comments or empty commented keys — **no secret values**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8288b241272710afbd02c92e78afab61c637bec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->