### PR TITLE
Remediate audit hardening findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ the CLI, or pull them straight from this repo with the harness-agnostic
 [`skills`](https://github.com/vercel-labs/skills) installer:
 
 ```bash
-overcast skills install                        # copies the shipped skills into ~/.claude/skills
-overcast skills install --harness claude-code  # explicit harness (claude-code is the only target today)
+overcast skills install --dest ~/.codex/skills # recommended for Codex/Cursor/other agents
+overcast skills install                        # Claude Code default: copies into ~/.claude/skills
+overcast skills install --harness claude-code  # explicit Claude Code target
 npx skills add kdr/overcast                    # vercel-labs/skills; pulls skills from this repo
 ```
 
@@ -582,7 +583,7 @@ Three surfaces from one source of truth (`src/registry/verbs.ts`):
 
 - **pi package** (`@kdrrr/overcast`) — `tsup` bundles `dist/{bin,index,extension}.js`; pi + ffmpeg/ffprobe stay external (pinned / runtime-resolved). A `postinstall` brands the pinned pi host as "overcast" without moving `~/.pi`.
 - **standalone binary** — `bun build --compile` → a single executable (+ a sidecar `package.json` for branding).
-- **agent skills + Claude Code plugin** — `skills generate` renders `skills/overcast/{SKILL.md, reference/verbs.md}` from the registry; `skills install` copies them into a harness.
+- **agent skills + Claude Code plugin** — `skills generate` renders `skills/overcast/{SKILL.md, reference/verbs.md}` from the registry; `skills install --dest <dir>` copies them into any agent skills directory, while bare `skills install` targets Claude Code.
 
 ---
 
@@ -596,6 +597,11 @@ npm run test:e2e    # offline e2e (fixture providers, no creds)
 npm run test:e2e:live  # live real-data e2e (builds the bun binary, sources .env)
 E2E_VERBOSE=1 npm run test:e2e  # include exact commands + output snippets in report.md
 npm run build:bun   # bun build --compile → dist/bin/overcast
+npm run pack:check  # verify synced versions + fresh dist/bin/overcast.js before npm pack
 overcast commands --json   # the authoritative verb registry
 overcast doctor            # preflight
 ```
+
+`npm pack` runs `npm run pack:check` first. Build with `npm run build` before
+packing; if the ignored `dist/` tree is missing or stale, the pack fails with a
+message showing the version or command-registry drift.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "build:bun": "npm run build:web && bun build --compile bin/overcast.ts --outfile dist/bin/overcast && node scripts/bun-sidecar.mjs",
     "dev": "tsx bin/overcast.ts",
     "sync-version": "node scripts/sync-version.mjs",
+    "pack:check": "node scripts/sync-version.mjs --check && node scripts/check-dist-fresh.mjs",
     "version": "node scripts/sync-version.mjs && git add -A src/version.ts .claude-plugin/plugin.json .claude-plugin/marketplace.json",
+    "prepack": "npm run pack:check",
     "prepublishOnly": "npm run build",
     "postinstall": "node scripts/brand-pi.mjs",
     "brand": "node scripts/brand-pi.mjs"

--- a/scripts/check-dist-fresh.mjs
+++ b/scripts/check-dist-fresh.mjs
@@ -68,6 +68,26 @@ function verbNames(value, label) {
     .sort((a, b) => a.localeCompare(b));
 }
 
+function stableJson(value) {
+  if (Array.isArray(value)) return value.map(stableJson);
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = stableJson(value[key]);
+    return out;
+  }
+  return value;
+}
+
+function normalizedCommands(value, label) {
+  if (!value || !Array.isArray(value.verbs)) fail(`${label} commands output is missing .verbs[]`);
+  return JSON.stringify(
+    stableJson({
+      ...value,
+      verbs: [...value.verbs].sort((a, b) => String(a?.name ?? "").localeCompare(String(b?.name ?? ""))),
+    }),
+  );
+}
+
 function diffNames(source, dist) {
   const sourceSet = new Set(source);
   const distSet = new Set(dist);
@@ -114,6 +134,8 @@ const sourceNames = verbNames(sourceCommands, "source CLI");
 const distNames = verbNames(distCommands, "dist CLI");
 if (sourceNames.join("\0") !== distNames.join("\0")) {
   drift.push(`commands --json verb names differ (${diffNames(sourceNames, distNames).join("; ") || "same names in different order"})`);
+} else if (normalizedCommands(sourceCommands, "source CLI") !== normalizedCommands(distCommands, "dist CLI")) {
+  drift.push("commands --json registry differs beyond verb names (args, flags, descriptions, groups, output kinds, or provider keys)");
 }
 
 if (drift.length) {

--- a/scripts/check-dist-fresh.mjs
+++ b/scripts/check-dist-fresh.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Guard npm packaging against a stale ignored dist/. npm pack runs this via
+// prepack after release builds; local packs fail with an actionable message
+// when dist/bin/overcast.js is missing, not runnable, or no longer matches src.
+
+import { accessSync, constants, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const ROOT = resolve(process.env.OVERCAST_DIST_FRESH_ROOT ?? join(dirname(fileURLToPath(import.meta.url)), ".."));
+const DIST_FILE = resolve(process.env.OVERCAST_DIST_FRESH_DIST_FILE ?? join(ROOT, "dist", "bin", "overcast.js"));
+
+function parseCommand(envName, fallback) {
+  const raw = process.env[envName];
+  if (!raw) return fallback;
+  try {
+    const parts = JSON.parse(raw);
+    if (!Array.isArray(parts) || parts.length === 0 || parts.some((p) => typeof p !== "string")) {
+      throw new Error("expected a JSON array of strings");
+    }
+    return { cmd: parts[0], args: parts.slice(1) };
+  } catch (e) {
+    fail(`${envName} must be a JSON array of strings: ${e?.message ?? e}`);
+  }
+}
+
+function fail(message) {
+  console.error(`[check-dist-fresh] ${message}`);
+  console.error("[check-dist-fresh] Run `npm run build` and retry.");
+  process.exit(1);
+}
+
+function run(label, command, args) {
+  const res = spawnSync(command.cmd, [...command.args, ...args], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      OVERCAST_NO_DOTENV: "1",
+      PI_SKIP_VERSION_CHECK: "1",
+    },
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (res.error) fail(`${label} is not runnable: ${res.error.message}`);
+  if (res.status !== 0) {
+    const stderr = (res.stderr ?? "").trim();
+    const stdout = (res.stdout ?? "").trim();
+    fail(`${label} exited ${res.status}${stderr || stdout ? `: ${stderr || stdout}` : ""}`);
+  }
+  return res.stdout;
+}
+
+function readJson(label, command, args) {
+  const stdout = run(label, command, args);
+  try {
+    return JSON.parse(stdout);
+  } catch (e) {
+    fail(`${label} did not emit valid JSON for \`${args.join(" ")}\`: ${e?.message ?? e}`);
+  }
+}
+
+function verbNames(value, label) {
+  if (!value || !Array.isArray(value.verbs)) fail(`${label} commands output is missing .verbs[]`);
+  return value.verbs
+    .map((v) => v?.name)
+    .filter((name) => typeof name === "string")
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function diffNames(source, dist) {
+  const sourceSet = new Set(source);
+  const distSet = new Set(dist);
+  const missing = source.filter((name) => !distSet.has(name));
+  const extra = dist.filter((name) => !sourceSet.has(name));
+  const details = [];
+  if (missing.length) details.push(`missing in dist: ${missing.join(", ")}`);
+  if (extra.length) details.push(`extra in dist: ${extra.join(", ")}`);
+  return details;
+}
+
+if (!existsSync(DIST_FILE)) {
+  fail(`dist CLI is missing at ${DIST_FILE}`);
+}
+if (process.platform !== "win32") {
+  try {
+    accessSync(DIST_FILE, constants.X_OK);
+  } catch {
+    fail(`dist CLI is not executable at ${DIST_FILE}`);
+  }
+}
+
+const sourceCommand = parseCommand("OVERCAST_DIST_FRESH_SOURCE_CMD", {
+  cmd: process.execPath,
+  args: ["--import", "tsx", join(ROOT, "bin", "overcast.ts")],
+});
+const distCommand = parseCommand("OVERCAST_DIST_FRESH_DIST_CMD", {
+  cmd: process.execPath,
+  args: [DIST_FILE],
+});
+
+const sourceVersion = readJson("source CLI", sourceCommand, ["--version", "--json"]);
+const distVersion = readJson("dist CLI", distCommand, ["--version", "--json"]);
+const drift = [];
+for (const field of ["overcast", "pi"]) {
+  if (sourceVersion[field] !== distVersion[field]) {
+    drift.push(`--version --json ${field}: source=${sourceVersion[field] ?? "<missing>"} dist=${distVersion[field] ?? "<missing>"}`);
+  }
+}
+
+const sourceCommands = readJson("source CLI", sourceCommand, ["commands", "--json"]);
+const distCommands = readJson("dist CLI", distCommand, ["commands", "--json"]);
+const sourceNames = verbNames(sourceCommands, "source CLI");
+const distNames = verbNames(distCommands, "dist CLI");
+if (sourceNames.join("\0") !== distNames.join("\0")) {
+  drift.push(`commands --json verb names differ (${diffNames(sourceNames, distNames).join("; ") || "same names in different order"})`);
+}
+
+if (drift.length) {
+  console.error("[check-dist-fresh] dist/bin/overcast.js is stale:");
+  for (const d of drift) console.error(`  - ${d}`);
+  console.error("[check-dist-fresh] Run `npm run build` and retry.");
+  process.exit(1);
+}
+
+console.error(`[check-dist-fresh] dist/bin/overcast.js matches source (${sourceVersion.overcast}, pi ${sourceVersion.pi}; ${sourceNames.length} verbs)`);

--- a/skills/overcast-init/SKILL.md
+++ b/skills/overcast-init/SKILL.md
@@ -12,18 +12,27 @@ One-time setup for overcast.
 
 1. **Install the CLI** — `pi install npm:@kdrrr/overcast` (inside pi) or
    `npm i -g @kdrrr/overcast` for the standalone binary.
-2. **Install/update tinycloud** — the default perception backend. Get the latest
+2. **Install bundled skills for this agent** — for Codex, Cursor, and other
+   non-Claude harnesses, copy the shipped skills into the agent's skills
+   directory explicitly:
+   ```bash
+   overcast skills install --dest ~/.codex/skills
+   ```
+   Bare `overcast skills install` remains the Claude Code default
+   (`~/.claude/skills`), and `--harness claude-code` is the explicit Claude
+   target.
+3. **Install/update tinycloud** — the default perception backend. Get the latest
    (`npm i -g @cloudglue/tinycloud@0.3.8` then `tinycloud install --latest`, or
    `tinycloud update`). The `face` + `index` verbs need **tinycloud ≥ 0.3.4**,
    and overcast currently recommends **0.3.8** (the image `see`/`extract`
    verbs behind the opt-in `see:tinycloud` provider need ≥ 0.3.7);
    override the invocation with `OVERCAST_TINYCLOUD_CMD` if it isn't on `PATH`.
-3. **Verify** — `overcast doctor --json` (pi pinned, ffmpeg/ffprobe runnable,
+4. **Verify** — `overcast doctor --json` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI + version, optional uv/visual-db readiness).
-4. **Cloudglue key** — the default `watch`/`listen`/`face`/`index` providers
+5. **Cloudglue key** — the default `watch`/`listen`/`face`/`index` providers
    reach Cloudglue via the tinycloud CLI; configure it (`tinycloud setup cloudglue`)
    or export `CLOUDGLUE_API_KEY`.
-5. **Provider profile setup** — choose reusable providers once per profile, not
+6. **Provider profile setup** — choose reusable providers once per profile, not
    once per case. Always preview before applying:
    ```bash
    overcast provider setup show --profile default --json
@@ -41,7 +50,7 @@ One-time setup for overcast.
      file-level image analysis via `tinycloud see`/`extract` (needs tinycloud
      ≥ 0.3.7; `--detect` facts are boxless — no `crop`).
    - `deepface-local` for local face detect/match through DeepFace.
-6. **Optional visual DB setup** — prepare visual DB Python once per
+7. **Optional visual DB setup** — prepare visual DB Python once per
    checkout/machine. DeepFace can be selected as a profile provider for the
    `face` verb, while image/face DBs are still case-owned local indexes:
    ```bash
@@ -51,7 +60,7 @@ One-time setup for overcast.
    overcast index create logos --type image-ransac --local --json
    overcast index create localfaces --type deepface-local --local --json
    ```
-7. **Case setup later** — use the main `overcast` skill per investigation to run
+8. **Case setup later** — use the main `overcast` skill per investigation to run
    `case setup`, select targets/sources/indexes, and optionally set case-level
    automation such as `--auto-sense`, `--auto-index-new`, and `--findings`
    (defaults to `suggest` — score/text triggers auto-suggest leads; `review` is

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -48,7 +48,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `setup` — Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|memory|show).
 - `provider` — Run provider setup/init hooks, or list/describe bound providers (provider setup|init|list|describe).
 - `doctor` — Preflight: check pi version, ffmpeg/ffprobe, Cloudglue creds, tinycloud, provider bindings.
-- `skills` — Generate shipped overcast skills + reference from the registry, or install into a harness.
+- `skills` — Generate shipped overcast skills + reference from the registry, or install into a harness/directory.
 
 ## How to drive it
 

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -16,8 +16,6 @@ overcast watch <input> [options]
 
   Analyze a video into a reusable, time-anchored record (content/transcript/detailed).
 
-  Runs the bound sense provider (default: tinycloud, exec) over a video file or URL and emits a video.analysis record with markdown content, a transcript (when speech is present), and the full structured describe in `detailed`.
-
 Arguments:
   input            Video file path or URL
 
@@ -36,8 +34,6 @@ Default provider: tinycloud. Speech-only transcript by default; --describe runs 
 overcast listen <input> [options]
 
   Transcribe and analyze audio (or a video's audio track) into an audio.analysis record.
-
-  Default provider: tinycloud. Speech-only transcript by default; --describe runs the full multimodal describe to surface the AUDIO-SCENE description (sounds, music, events, ambience), not just speech. Emits transcript, speaker-tagged segments[] with media.at anchors, language.
 
 Arguments:
   input            Audio/video file path or URL
@@ -61,8 +57,6 @@ overcast see <input> [options]
 
   Understand an image or a single video frame (caption, OCR, detections).
 
-  Defaults to the BRAIN LLM when it supports images: a direct 'describe this image in detail' call (turnkey with the Cloudglue brain, or any image-capable `setup llm`). Falls back to a Hugging Face captioner when HF_TOKEN is set (override with HF_SEE_MODEL), else a placeholder until a VLM is bound. Switch backends via `setup provider see builtin:hf` (classic HF) or `builtin:brain`; disable the brain default with OVERCAST_SEE_BRAIN=off. Forwards --ocr/--prompt; --detect needs a detection provider (OWLv2 for boxes, or the opt-in Cloudglue tinycloud see/extract provider for boxless facts, tinycloud >= 0.3.7). Accepts frame://rec@sec (resolved via the internal ffmpeg toolkit) and http(s) image URLs, fetched into the case media dir first (meta.source_url keeps the origin).
-
 Arguments:
   input            Image path, http(s) image URL, video frame, or frame://rec@sec
 
@@ -84,8 +78,6 @@ Default provider: tinycloud. `face <video>` detects faces — one box per sample
 overcast face [input] [options]
 
   Detect, match, or search faces in video (and across face-analysis indexes).
-
-  Default provider: tinycloud. `face <video>` detects faces — one box per sampled frame, so the count is detections, NOT unique people (detect doesn't cluster). To find or count a PERSON, use `face <video> --match ref.jpg` (locates that person in the clip, ranked by similarity), or `face --match ref.jpg --index <id>` to search a registered face-analysis index (case-wide); `face <video> --index <id>` lists that video's stored detections. The video/reference may be a path, URL, or a case record id; the reference image for --match must be JPEG/PNG. Emits a face.analysis record whose `summary` is the headline, plus faces[] (at, box, similarity, thumbnail?) and the full provider data in `detailed`.
 
 Arguments:
   input            Video to analyze (path/URL/record-id); omit with --match + --index to search the index
@@ -118,8 +110,6 @@ overcast image <action> [input] [options]
 
   Match images or video frames against a local RANSAC image index.
 
-  `image add <image|record-id> --index <local-image-index>` stores a reference image in a local image-ransac index. `image match <image|video|record-id> --index <local-image-index>` searches that DB using OpenCV SIFT/ORB + RANSAC.
-
 Arguments:
   action           add | match
   input            image/video path, URL, or record id
@@ -148,8 +138,6 @@ overcast audio <action> [input] [reference] [options]
 
   Shazam-style exact audio matching: fingerprint clips into a local audio-fp index, or match clip-to-clip with time-offset alignment.
 
-  `audio add <audio|video|record-id> --index <local-audio-fp-index>` fingerprints a recording (Wang 2003 constellation hashes) and caches it in a local audio-fp index. `audio match <query> --index <id>` finds which indexed recording contains the query and WHERE (offset-histogram alignment: 'query audio appears at 01:23 in recording Y'). `audio match <query> <reference>` compares two clips directly, no index needed. Videos are accepted — their audio track is extracted. Robust to transcode/noise/clipping; NOT robust to pitch/speed change.
-
 Arguments:
   action           add | match
   input            audio/video path, URL, or record id (the query for match)
@@ -176,8 +164,6 @@ A persistent LOCAL face database backed by the deepface provider (clustering nee
 overcast cluster <action> [arg] [arg2] [options]
 
   Build and browse a local face-cluster DB: group faces into people, identify, label, and view.
-
-  A persistent LOCAL face database backed by the deepface provider (clustering needs face embeddings, which the tinycloud face path doesn't expose). `cluster add <media>` detects faces, embeds them, and ASSIGN-OR-CREATEs each into a person (nearest existing person above --min-similarity, else a new one); `cluster identify <image|video>` surfaces the most similar person for a probe (or flags it as a likely new person) without writing; `cluster recluster` re-groups every stored face and carries human labels forward; `cluster list`/`show` read the DB and `cluster view` renders a self-contained HTML contact sheet. Needs a face-cluster index (`index create <name> --type face-cluster --local`); resolves the case's sole one when --index is omitted. Emits a `cluster` record.
 
 Arguments:
   action           add | ingest | identify | list | show | label | recluster | view
@@ -212,8 +198,6 @@ overcast similar <action> [input]... [options]
 
   Find images/video moments or audio by visual, audio, or text similarity in a local CLIP (basic-clip) or CLAP (basic-clap) index.
 
-  `similar add <image|video> --index <basic-clip-index>` embeds and caches a reference in a local CLIP DB (videos are frame-sampled and pooled); a `basic-clap` index instead embeds audio (or a video's audio track) with CLAP. `similar match <image|video|audio> --index <id>` ranks members by image→image (CLIP) or audio→audio (CLAP) similarity; `similar search "<text>" --index <id>` ranks members by text→image (CLIP) or text→audio (CLAP) similarity. Runs OpenAI CLIP / LAION CLAP locally; scores are cosine×100 (0–100).
-
 Arguments:
   action           add | match | search
   input            image/video/audio path, URL, record id (add/match) — or a text query (search)
@@ -245,8 +229,6 @@ overcast exif <input> [options]
 
   Extract embedded metadata — GPS, capture time, device — from an image or video (ExifTool).
 
-  Runs ExifTool over an image or video and emits a media.metadata record: a searchable summary plus GPS coordinates (signed decimals), capture time, camera make/model, editing software, MIME/dimensions/duration, and a total tag count. The default backend is the shipped ExifTool provider (system `exiftool` on PATH; install with `brew install exiftool` / `apt install libimage-exiftool-perl`); bind your own with `setup provider exif <spec>`. Accepts a path, a case record/capture id, or an http(s) URL (fetched into the case media dir first). The full raw tag dump stays in-provider — only the compact summary is indexed.
-
 Arguments:
   input            Image/video/file path, case record id, or http(s) URL
 
@@ -266,8 +248,6 @@ overcast verify <input> [options]
 
   Check a media file's C2PA / Content Credentials provenance manifest (c2patool).
 
-  Reads the embedded C2PA / Content Credentials manifest of an image or video and emits a media.provenance record: whether a signed manifest is present, the claim generator, the signer/certificate issuer, the signature algorithm, the validation state + codes, and assertion/ingredient counts. Media with no credentials is a clean `ready` record (`has_manifest: false`), not an error. The default backend is the shipped c2patool provider (system `c2patool` on PATH; install with `brew install c2patool`); bind your own with `setup provider verify <spec>`. Accepts a path, a case record/capture id, or an http(s) URL. Distinct from source-post provenance (where a record came from) — this checks the media's own embedded credentials.
-
 Arguments:
   input            Image/video/file path, case record id, or http(s) URL
 
@@ -286,8 +266,6 @@ Default: deterministic, modality-dispatched ops on the bundled ffmpeg (denoise/n
 overcast enhance <input> [options]
 
   Produce better media (denoise/normalize/upscale) or split it (separate voices / segment objects) via ffmpeg or a bound model provider.
-
-  Default: deterministic, modality-dispatched ops on the bundled ffmpeg (denoise/normalize/voice-isolate/upscale/stabilize/grayscale). Bind a model provider for AI restoration or the SPLIT ops via `setup provider enhance <spec>`: `--ops separate` splits an audio/video's voices into per-speaker tracks (add --summarize to transcribe each), `--ops segment --prompt "<thing>"` cuts requested objects out of an image as mask + cutout evidence. separate/segment need a bound provider (local-models = pyannote + GroundingDINO/SAM2, or fal = sam-audio + sam-3); image segmentation of a video is out of scope (segment a frame:// still). Emits a media.enhanced record per output — for the split ops, one child record per track/mask whose media.ref chains into watch/listen/see/view/crop.
 
 Arguments:
   input            Media file path
@@ -316,8 +294,6 @@ overcast view <ref> [options]
 
   Open media in a lightweight local viewer (scrubbable player) or hand off to the OS.
 
-  For video/audio, generates a self-contained HTML player (timeline + markers for a referenced record's media.at) and opens it. For other files, uses the OS open command. Given an `enhance` split-op PARENT record (--ops separate/segment), renders a GALLERY of its fanned-out children instead — per-speaker audio players + spectrograms for separate (with cross-talk regions), or cutout/mask images for segment. --no-open writes the viewer and emits a view record with its path.
-
 Arguments:
   ref              Media path, capture-id, or record-id
 
@@ -339,8 +315,6 @@ Takes a face or see detection record and writes cropped still images under .over
 overcast crop <input> [options]
 
   Materialize face/object detections as cropped image records with provenance.
-
-  Takes a face or see detection record and writes cropped still images under .overcast/media/crops/. For detections with frame thumbnails, crop uses the supplied frame image as the crop source. Each crop record preserves the source record, source media, crop source media, timestamp/frame, class/id, confidence, and box. Use --all, --id, --class, or --kind to select detections; crops are memory-friendly evidence artifacts.
 
 Arguments:
   input            Detection record id (face/see)
@@ -368,8 +342,6 @@ Samples frames from a video — uniformly across a --start/--end window (default
 overcast grid <input> [options]
 
   Tile timestamped video frames into a labeled contact sheet for one-shot VLM triage.
-
-  Samples frames from a video — uniformly across a --start/--end window (default the whole clip, --count frames) or at an explicit --at timestamp list — and tiles them into ONE contact-sheet image via the internal ffmpeg toolkit, burning each cell's number + timestamp when the ffmpeg build has drawtext (else the sheet is unlabeled and cells are numbered left-to-right, top-to-bottom). Emits a media.grid record whose media.ref is the montage and whose payload.cells maps cell number → exact timestamp. Chain it: `overcast see <montage-path> --prompt "which numbered cell best shows X? give the cell number"` then read payload.cells to recover the source time — one VLM call triages a long clip before a frame-precise zoom-in (see frame://<record>@<sec>). Add --view for a clickable HTML contact sheet (cells labeled with their timestamp even when ffmpeg can't burn labels, each seeking the source video on click); --no-open writes it without launching.
 
 Arguments:
   input            Video file path or case record id
@@ -399,8 +371,6 @@ overcast wall  [options]
 
   Open a control-room monitor wall: case videos looping at their evidence moments.
 
-  Generates a self-contained HTML wall of muted, looping video tiles — each anchored to its best evidence moment (open finding > face hit > record anchor) — overlaid with case state: sense-coverage badges, findings, per-source scan / monitor / brief freshness. Local media is referenced by file:// URL (not embedded); missing or browser-hostile media renders a NO SIGNAL / STILL tile (with an ffmpeg poster frame when extractable). Click a tile to open the media at its anchor; hover for the intel card. --infinite repeats the real feeds to fill the screen and keeps extending the grid as it scrolls — an endless monitor bank even from a handful of feeds. --no-open writes the wall and emits a record with its path instead of launching.
-
 Options:
   --limit <number>       Max tiles, most evidentiary/recent first (~25 is a practical decode ceiling) (default: 12)
   --source <string>      Only media from this source type (youtube | tiktok | x | web | lens | local)
@@ -427,8 +397,6 @@ overcast scan  [options]
 
   Sweep sources, or local case media/indexes when no sources exist; emit scan.hit records (--pull to capture+sense).
 
-  Enumerates each enabled source by its bound ref (channel/handle/hashtag/keyword); an explicit --query overrides, and the active target is the fallback when a source has no ref. With --pull, each hit uses the same media.ref/payload.url, capture, sense, and failure semantics as monitor. If the case has no enabled external sources, scan falls back to local case media/indexes and can run a face-index search when an image target and face-analysis index are available.
-
 Options:
   --query <string>       Ad-hoc keyword search across sources
   --source <string>      Restrict to source ids/types (comma list)
@@ -453,8 +421,6 @@ overcast capture <ref> [options]
 
   Fetch a resource (URL / scan.hit / local path) into the case as a capture record.
 
-  Acquires media/content into .overcast/media/: a local path is copied in; a URL is downloaded via the matching source provider. Emits a capture record with a capture_id usable by the senses.
-
 Arguments:
   ref              URL, scan.hit id, local path, or - for stdin
 
@@ -475,8 +441,6 @@ Enumerates sources, diffs against .overcast/seen.json, and for each NEW item use
 overcast monitor  [options]
 
   scan on a loop; diff against the seen-set; pipe new items into a sense. --once or --every <interval>.
-
-  Enumerates sources, diffs against .overcast/seen.json, and for each NEW item uses the shared scan --pull processor: resolve media.ref/payload.url, capture when needed, then run explicit --pipe or setup automation/default watch. Hard processing failures are surfaced and marked seen; pending/credential gaps remain retryable. --once = single diff pass (scheduler-friendly). --every <15m|6h|…> = continuous blocking loop (run under tmux; Ctrl-C to stop); each pass streams its records. --brief summarizes the new batch; --alert <stdout|file> mirrors new records to a sink.
 
 Options:
   --source <string>      Restrict to source ids/types
@@ -503,8 +467,6 @@ An index is a Cloudglue-backed searchable corpus of videos, searched one way per
 overcast index <action> [arg] [arg2] [options]
 
   Manage tinycloud indexes that index a target's videos (create/attach/add/list/show/delete/remove/entities).
-
-  An index is a Cloudglue-backed searchable corpus of videos, searched one way per TYPE: media-descriptions (ask/probe), entities (same-schema extraction), face-analysis (detect + find a person). `create <name> --type <media|entities|face>` (entities needs --prompt/--schema); `attach <remote-id-or-name>` mirrors an existing remote index into this case; `add <video> --to <id>` registers a video (a path, URL, or a case record id) — `--all` registers every video the case has captured or sensed (watch/listen/face) for the target; `list`/`show <id>` inspect; `delete <id>`/`remove <video> --from <id>` prune; `entities <id> <video>` fetches a video's extracted entities. Then read with `ask --index <id>`, `face --match … --index <id>`, or `index entities`. Backed by tinycloud (≥ 0.3.4).
 
 Arguments:
   action           create | attach | add | list | show | delete | remove | entities
@@ -546,8 +508,6 @@ overcast ask <question> [options]
 
   Natural-language query over the case memory; answers with record.id + media.at citations.
 
-  Retrieves over bound case-search memory providers (local-grep always on; optional qmd) and answers with citations to record.id and media.at. Plain ask uses local-grep; use --deep or --memory qmd after `setup memory qmd` for qmd-backed local semantic search.
-
 Arguments:
   question         The question to answer
 
@@ -575,8 +535,6 @@ overcast brief  [options]
 
   Synthesize the case records into a report (timeline + findings); --export to md/html.
 
-  Produces a structured report from accumulated records. --export writes a shareable md/html artifact (format inferred from the file extension).
-
 Options:
   --scope <string>       Filter, e.g. since:24h or verb:watch
   --full                 Include the full verbatim record timeline (audit dump) instead of the compact appendix
@@ -598,8 +556,6 @@ A target is a line of investigation. `add --question` records what would resolve
 overcast target <action> [value] [options]
 
   Define/refine the standing scope, a.k.a. a line of investigation (add|list|rm|show|close|reopen). Persisted to .overcast/target.json.
-
-  A target is a line of investigation. `add --question` records what would resolve it; `close <id> --as answered|dead-end --note` marks the line done (closed lines stop seeding scan/monitor); `reopen <id>` reactivates it. Status feeds the brief/status thread cards.
 
 Arguments:
   action           add | list | rm | show | close | reopen
@@ -646,8 +602,6 @@ overcast note <text> [options]
 
   Add a human observation/finding to the case, optionally anchored to evidence.
 
-  Creates a primary human-authored `note` record. Notes are searchable by `ask`, included in `brief`, visible in `case records`, and can cite media via `--ref <record-id|capture-id|path|url>` plus `--at <seconds|start-end|timecode>`. Use `--tag` for comma-separated labels and `--confidence` for the analyst's confidence marker.
-
 Arguments:
   text             Observation/finding text
 
@@ -671,8 +625,6 @@ Creates manual findings and lists/reviews automated findings. Score/text trigger
 overcast finding [action] [id] [options]
 
   Create and review findings (create|list|accept|dismiss).
-
-  Creates manual findings and lists/reviews automated findings. Score/text triggers emit `suggested` findings (leads) that stay OUT of memory/brief evidence until reviewed — `finding list --state triage` queues them newest-first, `accept` promotes a lead into evidence, `dismiss` rejects it (a dismissed suggestion never re-fires for the same match). Review records reference the original finding; dismissed findings remain auditable.
 
 Arguments:
   action           create | list | accept | dismiss (default: list)
@@ -698,8 +650,6 @@ A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands
 overcast case <action> [sub] [arg] [options]
 
   Inspect/manage the current case: init | setup | status | info | records | memory | clear.
-
-  A case is the cwd folder + its .overcast/ store. `case init [dir] --name` stands it up; `case setup` runs/saves first-run setup and `case setup status|show|edit|plan` manages it; `case status` reports setup/store/memory health; `case info` shows state; `case records [--verb] [--since]` lists records; `case memory <list|get|search|index> [q]` routes to the bound memory providers. `case clear` previews what would be lost; add `--yes` to clear records/media/state and configured materialized memory indexes while preserving the case id. `case memory get <id>` returns a field manifest (sizes); add `--field <name> [--offset N] [--limit M]` to page a large field (e.g. a watch `content`) in full — never head/tail the raw jsonl.
 
 Arguments:
   action           init | setup | status | info | records | memory | clear
@@ -756,8 +706,6 @@ overcast prebrief [name] [options]
 
   Stand up a case: name + target + source in one shot (non-interactive via flags).
 
-  A lightweight case kickoff. Initializes the .overcast/ store, sets the case name, and optionally seeds a target (--target) and a source (--source <type>:<ref>).
-
 Arguments:
   name             Case name
 
@@ -778,8 +726,6 @@ Configure and persist profiles under ~/.overcast/profiles/. `setup provider <ver
 overcast setup [action] [a] [b] [options]
 
   Bind the brain LLM + per-verb providers and manage profiles (setup provider|llm|memory|show).
-
-  Configure and persist profiles under ~/.overcast/profiles/. `setup provider <verb> <spec>` binds a verb to a provider (exec:<cmd> | http(s)://… | inproc:<module>). `setup llm <provider> <model>` sets the brain. `setup memory <local-grep|qmd>` configures case search. `setup show` prints the active profile.
 
 Arguments:
   action           provider | llm | memory | show (default: show)
@@ -802,8 +748,6 @@ Emits `setup` records.
 overcast provider [action] [verb] [options]
 
   Run provider setup/init hooks, or list/describe bound providers (provider setup|init|list|describe).
-
-  `provider setup plan|apply|show` configures catalog-backed provider choices for a profile. `provider init <verb>` runs the bound provider's init step — a command, or guidance for a skill-based init (not wired yet). `provider list` shows the active bindings.
 
 Arguments:
   action           setup | init | list | describe (default: list)
@@ -840,20 +784,19 @@ Emits `doctor` records.
 
 ### `overcast skills`
 
-`skills generate` (re)writes shipped skills including skills/overcast/{SKILL.md,reference/verbs.md}, skills/overcast-init, and focused workflow examples from the verb registry. `skills install [--harness claude-code]` copies them into the harness skills dir.
+`skills generate` (re)writes shipped skills including skills/overcast/{SKILL.md,reference/verbs.md}, skills/overcast-init, and focused workflow examples from the verb registry. `skills install [--harness claude-code]` copies them into the Claude Code skills dir by default; `skills install --dest <dir>` is the explicit path for Codex, Cursor, and other agents.
 
 ```
 overcast skills <action> [options]
 
-  Generate shipped overcast skills + reference from the registry, or install into a harness.
-
-  `skills generate` (re)writes shipped skills including skills/overcast/{SKILL.md,reference/verbs.md}, skills/overcast-init, and focused workflow examples from the verb registry. `skills install [--harness claude-code]` copies them into the harness skills dir.
+  Generate shipped overcast skills + reference from the registry, or install into a harness/directory.
 
 Arguments:
   action           generate | install
 
 Options:
   --harness <string>     Target harness for install (claude-code)
+  --dest <string>        Install shipped skills into this directory (recommended for Codex/Cursor/other agents)
   --json                 JSON output
   --format <string>      json | md | txt
 ```

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -54,7 +54,9 @@ function argSchema(arg: ArgSpec): TSchema {
   const desc = { description: arg.summary };
   if (arg.variadic) {
     const array = Type.Array(Type.String(desc), desc);
-    return arg.required ? array : Type.Optional(array);
+    const legacyString = Type.String(desc);
+    const schema = Type.Union([array, legacyString], desc);
+    return arg.required ? schema : Type.Optional(schema);
   }
   const string = Type.String(desc);
   return arg.required ? string : Type.Optional(string);

--- a/src/registry/to-agent-tool.ts
+++ b/src/registry/to-agent-tool.ts
@@ -8,7 +8,7 @@
 import { Type, type TSchema } from "@earendil-works/pi-ai";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
-import type { VerbSpec, VerbContext, FlagSpec } from "./types.js";
+import type { VerbSpec, VerbContext, FlagSpec, ArgSpec } from "./types.js";
 import { makeRecord, type OvercastRecord, type JsonMap } from "../record.js";
 import { persistRecords } from "./persist.js";
 import { expandHome, expandHomeArg } from "../fs-path.js";
@@ -50,13 +50,20 @@ function flagSchema(f: FlagSpec): TSchema {
   return Type.Optional(Type.String(desc));
 }
 
+function argSchema(arg: ArgSpec): TSchema {
+  const desc = { description: arg.summary };
+  if (arg.variadic) {
+    const array = Type.Array(Type.String(desc), desc);
+    return arg.required ? array : Type.Optional(array);
+  }
+  const string = Type.String(desc);
+  return arg.required ? string : Type.Optional(string);
+}
+
 /** Build the TypeBox params object for a verb (all positional args + flags). */
 export function verbParams(spec: VerbSpec): TSchema {
   const props: Record<string, TSchema> = {};
-  for (const arg of spec.args) {
-    const s = Type.String({ description: arg.summary });
-    props[arg.name] = arg.required ? s : Type.Optional(s);
-  }
+  for (const arg of spec.args) props[arg.name] = argSchema(arg);
   for (const f of spec.flags) props[f.name] = flagSchema(f);
   return Type.Object(props);
 }
@@ -167,7 +174,7 @@ export function verbCallLine(spec: VerbSpec, args: Record<string, unknown>): str
   const primaryName = spec.args[0]?.name;
   const raw = primaryName ? args?.[primaryName] : undefined;
   if (raw === undefined || raw === null || raw === "") return tag;
-  let v = String(raw);
+  let v = Array.isArray(raw) ? raw.map((x) => String(x)).join(" ") : String(raw);
   if (v.length > 80) v = v.slice(0, 79) + "…";
   return `${tag} ${HUD_DIM}▸${HUD_RESET} ${HUD_PALE}${v}${HUD_RESET}`;
 }
@@ -238,7 +245,13 @@ export function toAgentTool(spec: VerbSpec, deps: ToolDeps): ToolDefinition {
       // reconstruct positional input + rest from the declared args
       const positionals: string[] = [];
       for (const arg of spec.args) {
-        if (params[arg.name] !== undefined) positionals.push(expandHome(String(params[arg.name])));
+        const raw = params[arg.name];
+        if (raw === undefined) continue;
+        const values = arg.variadic && Array.isArray(raw) ? raw : [raw];
+        for (const value of values) {
+          if (value === undefined || value === null) continue;
+          positionals.push(expandHome(String(value)));
+        }
       }
       const input = positionals[0];
 

--- a/src/registry/to-cli.ts
+++ b/src/registry/to-cli.ts
@@ -106,8 +106,13 @@ export function parseVerbArgs(spec: VerbSpec, argv: string[]): ParsedInvocation 
   };
 }
 
+export interface RenderVerbHelpOptions {
+  includeDescription?: boolean;
+}
+
 /** Render `--help` text for a verb from its spec. */
-export function renderVerbHelp(spec: VerbSpec): string {
+export function renderVerbHelp(spec: VerbSpec, opts: RenderVerbHelpOptions = {}): string {
+  const includeDescription = opts.includeDescription ?? true;
   const lines: string[] = [];
   const argSig = spec.args
     .map((a) => (a.required ? `<${a.name}>` : `[${a.name}]`) + (a.variadic ? "..." : ""))
@@ -115,7 +120,7 @@ export function renderVerbHelp(spec: VerbSpec): string {
   lines.push(`overcast ${spec.name} ${argSig} [options]`);
   lines.push("");
   lines.push(`  ${spec.summary}`);
-  if (spec.description) {
+  if (includeDescription && spec.description) {
     lines.push("");
     lines.push(`  ${spec.description}`);
   }

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -45,7 +45,7 @@ export function generateVerbReference(): string {
       lines.push(`### \`overcast ${v.name}\``, "");
       lines.push(v.description ?? v.summary, "");
       lines.push("```");
-      lines.push(renderVerbHelp(v).trimEnd());
+      lines.push(renderVerbHelp(v, { includeDescription: false }).trimEnd());
       lines.push("```", "");
       lines.push(`Emits \`${v.outputKind}\` records.`, "");
     }
@@ -316,18 +316,27 @@ One-time setup for overcast.
 
 1. **Install the CLI** — \`pi install npm:@kdrrr/overcast\` (inside pi) or
    \`npm i -g @kdrrr/overcast\` for the standalone binary.
-2. **Install/update tinycloud** — the default perception backend. Get the latest
+2. **Install bundled skills for this agent** — for Codex, Cursor, and other
+   non-Claude harnesses, copy the shipped skills into the agent's skills
+   directory explicitly:
+   \`\`\`bash
+   overcast skills install --dest ~/.codex/skills
+   \`\`\`
+   Bare \`overcast skills install\` remains the Claude Code default
+   (\`~/.claude/skills\`), and \`--harness claude-code\` is the explicit Claude
+   target.
+3. **Install/update tinycloud** — the default perception backend. Get the latest
    (\`npm i -g @cloudglue/tinycloud@0.3.8\` then \`tinycloud install --latest\`, or
    \`tinycloud update\`). The \`face\` + \`index\` verbs need **tinycloud ≥ 0.3.4**,
    and overcast currently recommends **0.3.8** (the image \`see\`/\`extract\`
    verbs behind the opt-in \`see:tinycloud\` provider need ≥ 0.3.7);
    override the invocation with \`OVERCAST_TINYCLOUD_CMD\` if it isn't on \`PATH\`.
-3. **Verify** — \`overcast doctor --json\` (pi pinned, ffmpeg/ffprobe runnable,
+4. **Verify** — \`overcast doctor --json\` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI + version, optional uv/visual-db readiness).
-4. **Cloudglue key** — the default \`watch\`/\`listen\`/\`face\`/\`index\` providers
+5. **Cloudglue key** — the default \`watch\`/\`listen\`/\`face\`/\`index\` providers
    reach Cloudglue via the tinycloud CLI; configure it (\`tinycloud setup cloudglue\`)
    or export \`CLOUDGLUE_API_KEY\`.
-5. **Provider profile setup** — choose reusable providers once per profile, not
+6. **Provider profile setup** — choose reusable providers once per profile, not
    once per case. Always preview before applying:
    \`\`\`bash
    overcast provider setup show --profile default --json
@@ -345,7 +354,7 @@ One-time setup for overcast.
      file-level image analysis via \`tinycloud see\`/\`extract\` (needs tinycloud
      ≥ 0.3.7; \`--detect\` facts are boxless — no \`crop\`).
    - \`deepface-local\` for local face detect/match through DeepFace.
-6. **Optional visual DB setup** — prepare visual DB Python once per
+7. **Optional visual DB setup** — prepare visual DB Python once per
    checkout/machine. DeepFace can be selected as a profile provider for the
    \`face\` verb, while image/face DBs are still case-owned local indexes:
    \`\`\`bash
@@ -355,7 +364,7 @@ One-time setup for overcast.
    overcast index create logos --type image-ransac --local --json
    overcast index create localfaces --type deepface-local --local --json
    \`\`\`
-7. **Case setup later** — use the main \`overcast\` skill per investigation to run
+8. **Case setup later** — use the main \`overcast\` skill per investigation to run
    \`case setup\`, select targets/sources/indexes, and optionally set case-level
    automation such as \`--auto-sense\`, \`--auto-index-new\`, and \`--findings\`
    (defaults to \`suggest\` — score/text triggers auto-suggest leads; \`review\` is

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -149,6 +149,9 @@ export const similarVerb: VerbSpec = {
     if (action !== "add" && action !== "match" && action !== "search") {
       return [err("usage: similar <add|match|search> <image|video|audio|text> --index <local-basic-clip|basic-clap-index>")];
     }
+    if ((action === "add" || action === "match") && ctx.rest.length > 1) {
+      return [err(`similar ${action}: expected exactly one input; got ${ctx.rest.length}`)];
+    }
     const indexValue = ctx.opts.index ?? ctx.opts.to;
     const idx = localClipIndex(ctx.case, indexValue);
     if (idx.error) return [err(`similar ${action}: ${idx.error}`)];

--- a/src/verbs/skills.ts
+++ b/src/verbs/skills.ts
@@ -236,7 +236,8 @@ export const skillsVerb: VerbSpec = {
       }
       const explicitDest = rawDest != null ? expandHome(rawDest) : undefined;
       const hasExplicitDest = explicitDest != null;
-      const suppliedHarness = ctx.opts.harness != null ? String(ctx.opts.harness) : undefined;
+      const rawHarness = ctx.opts.harness != null ? String(ctx.opts.harness) : undefined;
+      const suppliedHarness = rawHarness != null && rawHarness.trim() !== "" ? rawHarness.trim() : undefined;
       const harness = suppliedHarness ?? "claude-code";
       const installDest = hasExplicitDest ? explicitDest : HARNESS_DESTS[harness];
       // an unknown harness must not be silently redirected to a default dir

--- a/src/verbs/skills.ts
+++ b/src/verbs/skills.ts
@@ -230,10 +230,15 @@ export const skillsVerb: VerbSpec = {
       if (!SKILLS_DIR || !existsSync(join(SKILLS_DIR, "overcast", "SKILL.md"))) {
         return fail("no shipped skills/ in this distribution (install the npm package, or run from source)");
       }
-      const explicitDest = ctx.opts.dest != null ? expandHome(String(ctx.opts.dest)) : undefined;
+      const rawDest = ctx.opts.dest != null ? String(ctx.opts.dest) : undefined;
+      if (rawDest != null && rawDest.trim() === "") {
+        return fail("skills install: --dest requires a non-empty directory");
+      }
+      const explicitDest = rawDest != null ? expandHome(rawDest) : undefined;
+      const hasExplicitDest = explicitDest != null;
       const suppliedHarness = ctx.opts.harness != null ? String(ctx.opts.harness) : undefined;
       const harness = suppliedHarness ?? "claude-code";
-      const installDest = explicitDest ?? HARNESS_DESTS[harness];
+      const installDest = hasExplicitDest ? explicitDest : HARNESS_DESTS[harness];
       // an unknown harness must not be silently redirected to a default dir
       // unless the caller supplied an explicit destination.
       if (!installDest) {
@@ -241,7 +246,7 @@ export const skillsVerb: VerbSpec = {
       }
       try {
         const { dest, copied, missing } = installSkills(SKILLS_DIR, installDest);
-        const payload = explicitDest
+        const payload = hasExplicitDest
           ? suppliedHarness != null
             ? { harness: suppliedHarness, dest, installed: copied }
             : { dest, installed: copied }

--- a/src/verbs/skills.ts
+++ b/src/verbs/skills.ts
@@ -1,12 +1,13 @@
 // `skills` verb: generate the flagship skill + reference from the registry, and
-// install skills into a harness (Claude Code). Keeps the skill docs in sync with
-// the verb surface (invariant #5).
+// install skills into a harness (Claude Code) or explicit skills directory. Keeps
+// the skill docs in sync with the verb surface (invariant #5).
 
 import { writeFileSync, mkdirSync, existsSync, cpSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { makeRecord } from "../record.js";
+import { expandHome } from "../fs-path.js";
 import {
   generateVerbReference,
   generateFlagshipSkill,
@@ -189,13 +190,15 @@ function installSkills(
 export const skillsVerb: VerbSpec = {
   name: "skills",
   group: "config",
-  summary: "Generate shipped overcast skills + reference from the registry, or install into a harness.",
+  summary: "Generate shipped overcast skills + reference from the registry, or install into a harness/directory.",
   description:
     "`skills generate` (re)writes shipped skills including skills/overcast/{SKILL.md,reference/verbs.md}, skills/overcast-init, and focused workflow examples " +
-    "from the verb registry. `skills install [--harness claude-code]` copies them into the harness skills dir.",
+    "from the verb registry. `skills install [--harness claude-code]` copies them into the Claude Code skills dir by default; " +
+    "`skills install --dest <dir>` is the explicit path for Codex, Cursor, and other agents.",
   args: [{ name: "action", summary: "generate | install", required: true }],
   flags: [
     { name: "harness", summary: "Target harness for install (claude-code)", type: "string" },
+    { name: "dest", summary: "Install shipped skills into this directory (recommended for Codex/Cursor/other agents)", type: "string" },
     { name: "json", summary: "JSON output", type: "boolean" },
     { name: "format", summary: "json | md | txt", type: "string", choices: ["json", "md", "txt"] },
   ],
@@ -227,19 +230,27 @@ export const skillsVerb: VerbSpec = {
       if (!SKILLS_DIR || !existsSync(join(SKILLS_DIR, "overcast", "SKILL.md"))) {
         return fail("no shipped skills/ in this distribution (install the npm package, or run from source)");
       }
-      const harness = ctx.opts.harness ? String(ctx.opts.harness) : "claude-code";
-      const harnessDest = HARNESS_DESTS[harness];
+      const explicitDest = ctx.opts.dest != null ? expandHome(String(ctx.opts.dest)) : undefined;
+      const suppliedHarness = ctx.opts.harness != null ? String(ctx.opts.harness) : undefined;
+      const harness = suppliedHarness ?? "claude-code";
+      const installDest = explicitDest ?? HARNESS_DESTS[harness];
       // an unknown harness must not be silently redirected to a default dir
-      if (!harnessDest) {
+      // unless the caller supplied an explicit destination.
+      if (!installDest) {
         return fail(`unknown harness '${harness}' (supported: ${Object.keys(HARNESS_DESTS).join(", ")})`);
       }
       try {
-        const { dest, copied, missing } = installSkills(SKILLS_DIR, harnessDest);
+        const { dest, copied, missing } = installSkills(SKILLS_DIR, installDest);
+        const payload = explicitDest
+          ? suppliedHarness != null
+            ? { harness: suppliedHarness, dest, installed: copied }
+            : { dest, installed: copied }
+          : { harness, dest, installed: copied };
         // a partial install (e.g. overcast-init missing) is not a success
         if (missing.length) {
-          return [makeRecord({ verb: "skills", format: "json", payload: { harness, dest, installed: copied, missing }, error: `partial install — missing skill(s): ${missing.join(", ")}`, state: "error" })];
+          return [makeRecord({ verb: "skills", format: "json", payload: { ...payload, missing }, error: `partial install — missing skill(s): ${missing.join(", ")}`, state: "error" })];
         }
-        return [makeRecord({ verb: "skills", format: "json", payload: { harness, dest, installed: copied }, state: "ready" })];
+        return [makeRecord({ verb: "skills", format: "json", payload, state: "ready" })];
       } catch (e) {
         return fail(`skills install failed: ${(e as Error).message}`);
       }

--- a/test/unit/dist-fresh.test.ts
+++ b/test/unit/dist-fresh.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const script = join(process.cwd(), "scripts", "check-dist-fresh.mjs");
+
+function writeCli(path: string, version: { overcast: string; pi: string }, verbs: string[]): void {
+  writeFileSync(
+    path,
+    `#!/usr/bin/env node
+const argv = process.argv.slice(2);
+if (argv[0] === "--version" && argv[1] === "--json") {
+  console.log(${JSON.stringify(JSON.stringify({ ...version, node: "test" }))});
+} else if (argv[0] === "commands" && argv[1] === "--json") {
+  console.log(${JSON.stringify(JSON.stringify({ verbs: verbs.map((name) => ({ name })) }))});
+} else {
+  console.error("unexpected argv: " + argv.join(" "));
+  process.exit(2);
+}
+`,
+    "utf8",
+  );
+  chmodSync(path, 0o755);
+}
+
+test("check-dist-fresh fails clearly when dist CLI is missing", () => {
+  const root = mkdtempSync(join(tmpdir(), "oc-dist-missing-"));
+  try {
+    const res = spawnSync(process.execPath, [script], {
+      cwd: process.cwd(),
+      env: { ...process.env, OVERCAST_DIST_FRESH_ROOT: root },
+      encoding: "utf8",
+    });
+    assert.notEqual(res.status, 0);
+    assert.match(res.stderr, /dist CLI is missing/);
+    assert.match(res.stderr, /npm run build/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("check-dist-fresh fails clearly when dist version or commands drift", () => {
+  const root = mkdtempSync(join(tmpdir(), "oc-dist-stale-"));
+  try {
+    const source = join(root, "source-cli.mjs");
+    const distDir = join(root, "dist", "bin");
+    const dist = join(distDir, "overcast.js");
+    mkdirSync(distDir, { recursive: true });
+    writeCli(source, { overcast: "1.2.3", pi: "0.80.3" }, ["watch", "listen"]);
+    writeCli(dist, { overcast: "1.2.2", pi: "0.80.1" }, ["watch", "scan"]);
+
+    const res = spawnSync(process.execPath, [script], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        OVERCAST_DIST_FRESH_ROOT: root,
+        OVERCAST_DIST_FRESH_SOURCE_CMD: JSON.stringify([process.execPath, source]),
+        OVERCAST_DIST_FRESH_DIST_CMD: JSON.stringify([process.execPath, dist]),
+      },
+      encoding: "utf8",
+    });
+    assert.notEqual(res.status, 0);
+    assert.match(res.stderr, /dist\/bin\/overcast\.js is stale/);
+    assert.match(res.stderr, /overcast: source=1\.2\.3 dist=1\.2\.2/);
+    assert.match(res.stderr, /pi: source=0\.80\.3 dist=0\.80\.1/);
+    assert.match(res.stderr, /missing in dist: listen/);
+    assert.match(res.stderr, /extra in dist: scan/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/dist-fresh.test.ts
+++ b/test/unit/dist-fresh.test.ts
@@ -7,7 +7,10 @@ import { spawnSync } from "node:child_process";
 
 const script = join(process.cwd(), "scripts", "check-dist-fresh.mjs");
 
-function writeCli(path: string, version: { overcast: string; pi: string }, verbs: string[]): void {
+type FixtureVerb = string | Record<string, unknown>;
+
+function writeCli(path: string, version: { overcast: string; pi: string }, verbs: FixtureVerb[]): void {
+  const payloadVerbs = verbs.map((verb) => (typeof verb === "string" ? { name: verb } : verb));
   writeFileSync(
     path,
     `#!/usr/bin/env node
@@ -15,7 +18,7 @@ const argv = process.argv.slice(2);
 if (argv[0] === "--version" && argv[1] === "--json") {
   console.log(${JSON.stringify(JSON.stringify({ ...version, node: "test" }))});
 } else if (argv[0] === "commands" && argv[1] === "--json") {
-  console.log(${JSON.stringify(JSON.stringify({ verbs: verbs.map((name) => ({ name })) }))});
+  console.log(${JSON.stringify(JSON.stringify({ verbs: payloadVerbs }))});
 } else {
   console.error("unexpected argv: " + argv.join(" "));
   process.exit(2);
@@ -37,6 +40,42 @@ test("check-dist-fresh fails clearly when dist CLI is missing", () => {
     assert.notEqual(res.status, 0);
     assert.match(res.stderr, /dist CLI is missing/);
     assert.match(res.stderr, /npm run build/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("check-dist-fresh fails when command registry details drift under the same verb names", () => {
+  const root = mkdtempSync(join(tmpdir(), "oc-dist-registry-stale-"));
+  try {
+    const source = join(root, "source-cli.mjs");
+    const distDir = join(root, "dist", "bin");
+    const dist = join(distDir, "overcast.js");
+    mkdirSync(distDir, { recursive: true });
+    writeCli(source, { overcast: "1.2.3", pi: "0.80.3" }, [
+      { name: "skills", summary: "skills", args: [{ name: "action", required: true }], flags: [{ name: "dest", type: "string" }] },
+      { name: "watch", summary: "watch", args: [], flags: [] },
+    ]);
+    writeCli(dist, { overcast: "1.2.3", pi: "0.80.3" }, [
+      { name: "watch", summary: "watch", args: [], flags: [] },
+      { name: "skills", summary: "skills", args: [{ name: "action", required: true }], flags: [] },
+    ]);
+
+    const res = spawnSync(process.execPath, [script], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        OVERCAST_DIST_FRESH_ROOT: root,
+        OVERCAST_DIST_FRESH_SOURCE_CMD: JSON.stringify([process.execPath, source]),
+        OVERCAST_DIST_FRESH_DIST_CMD: JSON.stringify([process.execPath, dist]),
+      },
+      encoding: "utf8",
+    });
+    assert.notEqual(res.status, 0);
+    assert.match(res.stderr, /dist\/bin\/overcast\.js is stale/);
+    assert.match(res.stderr, /commands --json registry differs beyond verb names/);
+    assert.doesNotMatch(res.stderr, /missing in dist/);
+    assert.doesNotMatch(res.stderr, /extra in dist/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/similar-index.test.ts
+++ b/test/unit/similar-index.test.ts
@@ -107,6 +107,26 @@ test("similar add embeds via the local provider and registers the member", async
   });
 });
 
+test("similar add/match reject multiple media inputs instead of dropping extras", async () => {
+  await withStub(async (dir) => {
+      const one = join(dir, "one.jpg");
+      const two = join(dir, "two.jpg");
+      writeFileSync(one, "x");
+      writeFileSync(two, "x");
+      const [created] = await indexVerb.run(mk(dir, "create", ["scenes"], { type: "basic-clip", local: true }));
+      const id = String((created.payload as Record<string, unknown>).index);
+
+      const [add] = await similarVerb.run(mk(dir, "add", [one, two], { index: id }));
+      assert.equal(add.state, "error");
+      assert.match(add.error ?? "", /similar add: expected exactly one input; got 2/);
+      assert.equal(findIndex(openCase(dir), id)?.members.length, 0);
+
+      const [match] = await similarVerb.run(mk(dir, "match", [one, two], { index: id }));
+      assert.equal(match.state, "error");
+      assert.match(match.error ?? "", /similar match: expected exactly one input; got 2/);
+  });
+});
+
 test("similar search forwards the text query as the positional input", async () => {
   await withStub(async (dir) => {
       const img = join(dir, "photo.jpg");

--- a/test/unit/skill-gen.test.ts
+++ b/test/unit/skill-gen.test.ts
@@ -241,6 +241,13 @@ test("skills verb: --dest installs shipped skills into an explicit directory", a
     const [badHarness] = await skillsVerb.run(mk("install", { harness: "unknown-agent" }));
     assert.equal(badHarness.state, "error");
     assert.match(badHarness.error ?? "", /unknown harness/);
+
+    for (const emptyDest of ["", "   "]) {
+      const [badDest] = await skillsVerb.run(mk("install", { dest: emptyDest }));
+      assert.equal(badDest.state, "error");
+      assert.match(badDest.error ?? "", /--dest requires a non-empty directory/);
+      assert.doesNotMatch(badDest.error ?? "", /unknown harness/);
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(dest, { recursive: true, force: true });

--- a/test/unit/skill-gen.test.ts
+++ b/test/unit/skill-gen.test.ts
@@ -187,10 +187,18 @@ test("reference stays in sync with commands --json (same verb set)", () => {
   assert.equal(headings.length, names.length);
 });
 
+test("verb reference does not duplicate long verb descriptions inside help blocks", () => {
+  const ref = generateVerbReference();
+  const skills = VERBS.find((v) => v.name === "skills");
+  assert.ok(skills?.description);
+  const occurrences = ref.split(skills.description).length - 1;
+  assert.equal(occurrences, 1);
+});
+
 import { skillsVerb } from "../../src/verbs/skills.ts";
 import { openCase } from "../../src/case.ts";
 import { defaultProfile } from "../../src/profile.ts";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -206,5 +214,36 @@ test("skills verb: generate/install succeed in the source repo, unknown action e
     assert.match(bad.error ?? "", /usage: skills/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("skills verb: --dest installs shipped skills into an explicit directory", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-sk-case-"));
+  const dest = mkdtempSync(join(tmpdir(), "oc-sk-dest-"));
+  const otherDest = mkdtempSync(join(tmpdir(), "oc-sk-dest-harness-"));
+  try {
+    const c = openCase(dir); c.ensure();
+    const mk = (input: string, opts = {}) => ({ input, rest: [], opts, case: c, profile: defaultProfile() });
+    const [rec] = await skillsVerb.run(mk("install", { dest }));
+    assert.equal(rec.state, "ready");
+    const payload = rec.payload as { dest?: string; harness?: string; installed?: string[] };
+    assert.equal(payload.dest, dest);
+    assert.equal(payload.harness, undefined);
+    assert.ok((payload.installed?.length ?? 0) >= 20);
+    assert.ok(existsSync(join(dest, "overcast", "SKILL.md")));
+    assert.ok(existsSync(join(dest, "overcast-init", "SKILL.md")));
+    assert.equal(readdirSync(dest).filter((name) => name.startsWith("overcast")).length, payload.installed?.length);
+
+    const [withHarness] = await skillsVerb.run(mk("install", { dest: otherDest, harness: "unknown-agent" }));
+    assert.equal(withHarness.state, "ready");
+    assert.equal((withHarness.payload as { harness?: string }).harness, "unknown-agent");
+
+    const [badHarness] = await skillsVerb.run(mk("install", { harness: "unknown-agent" }));
+    assert.equal(badHarness.state, "error");
+    assert.match(badHarness.error ?? "", /unknown harness/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+    rmSync(otherDest, { recursive: true, force: true });
   }
 });

--- a/test/unit/skill-gen.test.ts
+++ b/test/unit/skill-gen.test.ts
@@ -221,6 +221,7 @@ test("skills verb: --dest installs shipped skills into an explicit directory", a
   const dir = mkdtempSync(join(tmpdir(), "oc-sk-case-"));
   const dest = mkdtempSync(join(tmpdir(), "oc-sk-dest-"));
   const otherDest = mkdtempSync(join(tmpdir(), "oc-sk-dest-harness-"));
+  const emptyHarnessDest = mkdtempSync(join(tmpdir(), "oc-sk-dest-empty-harness-"));
   try {
     const c = openCase(dir); c.ensure();
     const mk = (input: string, opts = {}) => ({ input, rest: [], opts, case: c, profile: defaultProfile() });
@@ -238,6 +239,13 @@ test("skills verb: --dest installs shipped skills into an explicit directory", a
     assert.equal(withHarness.state, "ready");
     assert.equal((withHarness.payload as { harness?: string }).harness, "unknown-agent");
 
+    const [emptyHarness] = await skillsVerb.run(mk("install", { dest: emptyHarnessDest, harness: "" }));
+    assert.equal(emptyHarness.state, "ready");
+    const emptyHarnessPayload = emptyHarness.payload as { dest?: string; harness?: string; installed?: string[] };
+    assert.equal(emptyHarnessPayload.dest, emptyHarnessDest);
+    assert.equal(emptyHarnessPayload.harness, undefined);
+    assert.ok((emptyHarnessPayload.installed?.length ?? 0) >= 20);
+
     const [badHarness] = await skillsVerb.run(mk("install", { harness: "unknown-agent" }));
     assert.equal(badHarness.state, "error");
     assert.match(badHarness.error ?? "", /unknown harness/);
@@ -252,5 +260,6 @@ test("skills verb: --dest installs shipped skills into an explicit directory", a
     rmSync(dir, { recursive: true, force: true });
     rmSync(dest, { recursive: true, force: true });
     rmSync(otherDest, { recursive: true, force: true });
+    rmSync(emptyHarnessDest, { recursive: true, force: true });
   }
 });

--- a/test/unit/to-agent-tool.test.ts
+++ b/test/unit/to-agent-tool.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { openCase } from "../../src/case.ts";
 import { defaultProfile } from "../../src/profile.ts";
 import { makeRecord, type OvercastRecord } from "../../src/record.ts";
-import { toAgentTool, verbCallLine } from "../../src/registry/to-agent-tool.ts";
+import { toAgentTool, verbCallLine, verbParams } from "../../src/registry/to-agent-tool.ts";
 import type { VerbSpec } from "../../src/registry/types.ts";
 import { caseVerb } from "../../src/verbs/case.ts";
 
@@ -21,6 +21,59 @@ test("verbCallLine: class-colored ⟦ TAG ⟧ ▸ arg (semantic split + primary 
   assert.match(s, /⟦ SCAN ⟧/);
   assert.ok(s.includes("\x1b[38;2;255;46;151m"), "osint verb → magenta tag");
   assert.ok(!s.includes("▸"), "no separator when no primary arg");
+});
+
+test("agent variadic args use string[] schema and reconstruct ctx.input/rest", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-agent-var-"));
+  try {
+    const schema = verbParams({
+      name: "var",
+      args: [
+        { name: "action", summary: "action", required: true },
+        { name: "items", summary: "items", required: false, variadic: true },
+        { name: "required_items", summary: "required items", required: true, variadic: true },
+      ],
+      flags: [],
+    } as VerbSpec) as {
+      properties: Record<string, { type?: string; items?: { type?: string } }>;
+      required?: string[];
+    };
+    assert.equal(schema.properties.items.type, "array");
+    assert.equal(schema.properties.items.items?.type, "string");
+    assert.equal(schema.properties.required_items.type, "array");
+    assert.equal(schema.properties.required_items.items?.type, "string");
+    assert.ok(schema.required?.includes("action"));
+    assert.ok(schema.required?.includes("required_items"));
+    assert.ok(!schema.required?.includes("items"));
+
+    const seen: Array<{ input?: string; rest: string[] }> = [];
+    const spec: VerbSpec = {
+      name: "similar",
+      group: "sense",
+      summary: "similar",
+      args: [
+        { name: "action", summary: "action", required: true },
+        { name: "input", summary: "input", required: false, variadic: true },
+      ],
+      flags: [],
+      outputKind: "similar",
+      run: async (ctx) => {
+        seen.push({ input: ctx.input, rest: ctx.rest });
+        return [makeRecord({ verb: "similar", payload: { input: ctx.input, rest: ctx.rest } })];
+      },
+    };
+    const c = openCase(dir); c.ensure();
+    const tool = toAgentTool(spec, { getCase: () => c, getProfile: () => defaultProfile() });
+
+    await tool.execute("call_1", { action: "search", input: ["white", "van"] }, undefined as never);
+    await tool.execute("call_2", { action: "search", input: "white van" }, undefined as never);
+
+    assert.deepEqual(seen[0], { input: "search", rest: ["white", "van"] });
+    assert.deepEqual(seen[1], { input: "search", rest: ["white van"] });
+    assert.match(verbCallLine(spec, { action: ["search", "white", "van"] }), /search white van/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("renderResult: collapses long output to a preview + expand hint (full when expanded)", () => {

--- a/test/unit/to-agent-tool.test.ts
+++ b/test/unit/to-agent-tool.test.ts
@@ -23,9 +23,14 @@ test("verbCallLine: class-colored ⟦ TAG ⟧ ▸ arg (semantic split + primary 
   assert.ok(!s.includes("▸"), "no separator when no primary arg");
 });
 
-test("agent variadic args use string[] schema and reconstruct ctx.input/rest", async () => {
+test("agent variadic args prefer string[] schema, accept legacy strings, and reconstruct ctx.input/rest", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-agent-var-"));
   try {
+    type JsonSchema = { type?: string; items?: JsonSchema; anyOf?: JsonSchema[]; oneOf?: JsonSchema[] };
+    const variants = (s: JsonSchema) => s.anyOf ?? s.oneOf ?? [s];
+    const hasStringArray = (s: JsonSchema) => variants(s).some((v) => v.type === "array" && v.items?.type === "string");
+    const hasString = (s: JsonSchema) => variants(s).some((v) => v.type === "string");
+
     const schema = verbParams({
       name: "var",
       args: [
@@ -35,13 +40,13 @@ test("agent variadic args use string[] schema and reconstruct ctx.input/rest", a
       ],
       flags: [],
     } as VerbSpec) as {
-      properties: Record<string, { type?: string; items?: { type?: string } }>;
+      properties: Record<string, JsonSchema>;
       required?: string[];
     };
-    assert.equal(schema.properties.items.type, "array");
-    assert.equal(schema.properties.items.items?.type, "string");
-    assert.equal(schema.properties.required_items.type, "array");
-    assert.equal(schema.properties.required_items.items?.type, "string");
+    assert.ok(hasStringArray(schema.properties.items));
+    assert.ok(hasString(schema.properties.items));
+    assert.ok(hasStringArray(schema.properties.required_items));
+    assert.ok(hasString(schema.properties.required_items));
     assert.ok(schema.required?.includes("action"));
     assert.ok(schema.required?.includes("required_items"));
     assert.ok(!schema.required?.includes("items"));

--- a/web/chair/tsconfig.json
+++ b/web/chair/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "types": [],
+    "types": ["node"],
     "noEmit": true,
     "declaration": false,
     "rootDir": "../.."

--- a/web/chair/vite.config.ts
+++ b/web/chair/vite.config.ts
@@ -6,10 +6,13 @@
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, type ProxyOptions } from "vite";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const CHAIR = "http://127.0.0.1:7373";
+const configureChairProxy: NonNullable<ProxyOptions["configure"]> = (proxy) => {
+  proxy.on("proxyReq", (proxyReq) => proxyReq.setHeader("origin", CHAIR));
+};
 
 export default defineConfig({
   root: here,
@@ -28,9 +31,7 @@ export default defineConfig({
       "/api": {
         target: CHAIR,
         changeOrigin: true,
-        configure: (proxy) => {
-          proxy.on("proxyReq", (proxyReq) => proxyReq.setHeader("origin", CHAIR));
-        },
+        configure: configureChairProxy,
       },
       "/events": { target: CHAIR, changeOrigin: true },
     },


### PR DESCRIPTION
## Summary

Remediates the audit findings with focused hardening across packaging, chair typechecking, agent-tool parity, generated skills, and cross-agent skill installation.

## Changes

- Add a `prepack`/`pack:check` guard that fails when ignored `dist/bin/overcast.js` is missing, not executable, or stale against source version/verb registry.
- Fix chair typechecking after clean installs by enabling Node types and typing the Vite proxy callback.
- Represent variadic agent positional parameters as `string[]` while still accepting legacy string values internally.
- Avoid duplicate long descriptions in generated verb reference help blocks.
- Add `overcast skills install --dest <dir>` for Codex, Cursor, and other agents while preserving Claude Code defaults.
- Regenerate shipped skills and update README guidance.

## Validation

- `npm ci`
- `npm run typecheck`
- `npm test` (`739` passing)
- `npm run build`
- `npm run pack:check`
- `npm pack --dry-run --json`
- `node dist/bin/overcast.js skills generate --json`
- `node dist/bin/overcast.js skills install --dest /tmp/overcast-skills-check --json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly packaging checks, docs, and install-path ergonomics; behavioral changes are narrow (similar input validation, skills install routing) with unit test coverage.
> 
> **Overview**
> Adds **`npm pack` / `prepack` guards** so publishing fails when `dist/bin/overcast.js` is missing, not executable, or out of sync with source (`--version --json` and `commands --json`), via new `scripts/check-dist-fresh.mjs` and `pack:check`.
> 
> **`overcast skills install --dest <dir>`** copies bundled skills into any agent skills folder (Codex/Cursor, etc.); bare install still targets Claude Code. README, `overcast-init`, and generated skill docs are updated accordingly.
> 
> **Agent/CLI parity:** variadic positionals use `string[]` in tool schemas (legacy strings still work); generated `reference/verbs.md` drops duplicate long descriptions inside help blocks; **`similar add`/`match`** error on multiple inputs instead of ignoring extras.
> 
> **Chair dev:** Node types in `web/chair/tsconfig.json` and a typed Vite proxy helper for dev POST CSRF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125ee570f79c169f7af85dc650943ca6a4a4ff29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->