### PR TITLE
Docs truth pass: truthful e2e header + doc-drift lint coverage

### DIFF
--- a/docs/flows.md
+++ b/docs/flows.md
@@ -212,9 +212,10 @@ Raw detection payloads are intentionally not searchable. Use exact record reads
 - **Detection crops:** `crop <face-or-see-record-id> --all [--class person]`
   writes crop images and searchable crop records.
 
-When you add a raw local video to a remote index (`index add ./video.mp4 --to
-<id>`), overcast first creates missing `watch` evidence if the video hasn't been
-watched — so local-grep can search it immediately (qmd on the next rebuild). It
+When you add a raw local video to a remote index
+(`index add ./video.mp4 --to <id>`), overcast first creates missing
+`watch` evidence if the video hasn't been watched — so local-grep can
+search it immediately (qmd on the next rebuild). It
 does **not** create a `face` detect record just to populate memory; run `face` or
 `see --detect` when you actually need detections, then `crop` for cropped images.
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -8,8 +8,9 @@
 # ./.dev/smoke/<UTC>/ holding every case's raw JSON plus a generated report.md
 # (timestamp + phase + git SHA, what was tested, per-case results, summary).
 #
-# Cases hit real clips (~/Downloads/test-videos) and the Cloudglue LLM — kept
-# small/few. Only test/e2e/ is committed; .dev/smoke/* stays local.
+# The committed suite is OFFLINE: fixture providers, no network, no creds, no
+# real clips (see test/e2e/README.md). Live-flavored cases self-skip unless
+# OVERCAST_E2E_LIVE=1. Only test/e2e/ is committed; .dev/smoke/* stays local.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/test/unit/doc-references.test.ts
+++ b/test/unit/doc-references.test.ts
@@ -21,6 +21,8 @@ const DOC_FILES = [
   "README.md",
   "CLAUDE.md",
   "docs/providers.md",
+  "docs/flows.md",
+  "RELEASING.md",
   "prompts/ask.md",
   "prompts/brief.md",
   "prompts/debrief.md",


### PR DESCRIPTION
## What & why

A docs-truth pass. Stale docs that are *actively wrong* are worse than missing docs:

- **`planning/REMAINING.md`** was actively wrong and had already misled audit briefings into re-scoping shipped work. It's rewritten to a dated, accurate roadmap. **Note:** `planning/` is gitignored (`.gitignore:13`), so this rewrite is intentionally local-only and does **not** appear in this diff — it keeps the working copy honest for anyone reading it locally.
- **`test/e2e/run.sh` header** falsely claimed the suite hits "real clips (~/Downloads/test-videos) and the Cloudglue LLM" when the committed suite is offline/fixture-driven — discouraging contributors from running it. Header now states the truth (offline, no creds; live cases self-skip unless `OVERCAST_E2E_LIVE=1`).
- **Doc-drift lint coverage** — `docs/flows.md` (the largest usage doc) and `RELEASING.md` were excluded from `test/unit/doc-references.test.ts`, so renamed subcommands could rot there silently. Both are now in `DOC_FILES`.
- The widened lint flagged one line in `docs/flows.md` (`overcast first`) — a **false positive** caused by a multi-line inline-code span desyncing the lint's backtick pairing. Fixed by reflowing the span onto one line; prose meaning unchanged.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **775 pass / 0 fail**
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- `bash test/e2e/run.sh phase0` — ✅ 2/2 passed
- `node --test --import tsx test/unit/doc-references.test.ts` — ✅ pass 1 / fail 0 (drift list: 1 ref, under the ~15 STOP threshold, fixed)
- Step-1 grep for stale tokens (`ffmpeg-static|96 unit|18 verbs|0.80.1|no-op`) — ✅ no matches

## Deviations

None affecting scope. `plans/README.md` status is maintained by the orchestrator, not committed (per stack rules).

## Scope

In-scope, committed: `test/e2e/run.sh` (header only), `test/unit/doc-references.test.ts`, `docs/flows.md`. Local-only (gitignored): `planning/REMAINING.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-lint coverage only; no runtime, auth, or product logic changes.
> 
> **Overview**
> Corrects **misleading e2e documentation** and **extends doc-drift protection** so renamed CLI surface is harder to rot in big docs.
> 
> The `test/e2e/run.sh` header no longer claims the committed suite uses real clips under `~/Downloads/test-videos` and the Cloudglue LLM. It now states the default suite is **offline** (fixture providers, no network/creds) and points readers at `test/e2e/README.md`, with live cases gated behind `OVERCAST_E2E_LIVE=1`.
> 
> `test/unit/doc-references.test.ts` now lint-checks **`docs/flows.md`** and **`RELEASING.md`** alongside the existing doc set, so `overcast <verb>` references there must match the registry.
> 
> In `docs/flows.md`, one paragraph about `index add` was **reflowed** (same meaning) so a multi-line inline-code span does not break the lint’s backtick pairing—no behavior or CLI change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e970f114edb189d7c1724ddc48441cd1b815c28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->