### PR TITLE
Fix crop evidence overwrite: fold box/pad/square/source into output filename

### DIFF
--- a/src/verbs/crop.ts
+++ b/src/verbs/crop.ts
@@ -3,6 +3,7 @@
 // and bounding box. The crop record is the memory-friendly evidence artifact;
 // the source detection record remains the full audit trail.
 
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
 import { makeRecord, type OvercastRecord } from "../record.js";
@@ -33,6 +34,14 @@ interface Candidate {
 
 function err(message: string): OvercastRecord {
   return makeRecord({ verb: "crop", format: "json", payload: { error: message }, error: message, state: "error" });
+}
+
+/** Collision-free default crop name: same box/pad/square/source → same name
+ *  (idempotent), different params → different name — a re-crop with new padding
+ *  must not overwrite the first crop's pixels out from under its record
+ *  (mirrors shortHash in src/media/ffmpeg.ts). */
+function cropSig(parts: unknown): string {
+  return createHash("sha1").update(JSON.stringify(parts)).digest("hex").slice(0, 10);
 }
 
 function num(v: unknown): number | undefined {
@@ -406,7 +415,8 @@ export const cropVerb: VerbSpec = {
       }
       const base = basename(sourceMedia ?? media, extname(sourceMedia ?? media));
       const atPart = cand.at != null ? `_t${String(cand.at).replace(".", "p")}` : "";
-      const out = join(outDir, `${safePart(base)}_${safePart(cand.className)}_${safePart(cand.id)}${atPart}.jpg`);
+      const sig = cropSig({ box, pad, square, source: source.id });
+      const out = join(outDir, `${safePart(base)}_${safePart(cand.className)}_${safePart(cand.id)}${atPart}_${sig}.jpg`);
       try {
         const seek = usingThumbnail
           ? undefined

--- a/test/unit/senses.test.ts
+++ b/test/unit/senses.test.ts
@@ -293,6 +293,79 @@ test("crop materializes a data URL thumbnail before cropping", async () => {
   assert.ok(existsSync(rec.media!.ref));
 });
 
+test("crop output name is idempotent for identical params", async () => {
+  const c = openCase(dir);
+  c.ensure();
+  const face = makeRecord({
+    verb: "face",
+    payload: {
+      op: "detect",
+      summary: "one face for idempotency",
+      faces: [{ face_id: "f_idem", at: 0.2, box: { left: 0.25, top: 0.25, width: 0.5, height: 0.5 } }],
+    },
+    media: { ref: clip, at: 0.2 },
+  });
+  c.writeRecord(face);
+  const [first] = await cropVerb.run({ input: face.id, rest: [], opts: { all: true }, case: c, profile: defaultProfile() });
+  const [second] = await cropVerb.run({ input: face.id, rest: [], opts: { all: true }, case: c, profile: defaultProfile() });
+  assert.equal(first.state, "ready");
+  assert.equal(second.state, "ready");
+  // Same box/pad/square/source → same output path (no spurious churn).
+  assert.equal(second.media!.ref, first.media!.ref);
+  assert.equal(
+    (second.payload as Record<string, unknown>).crop,
+    (first.payload as Record<string, unknown>).crop,
+  );
+  assert.ok(existsSync(first.media!.ref));
+});
+
+test("crop with --pad writes a different file than the un-padded crop (no overwrite)", async () => {
+  const c = openCase(dir);
+  c.ensure();
+  const face = makeRecord({
+    verb: "face",
+    payload: {
+      op: "detect",
+      summary: "one face for pad divergence",
+      faces: [{ face_id: "f_pad", at: 0.2, box: { left: 0.25, top: 0.25, width: 0.5, height: 0.5 } }],
+    },
+    media: { ref: clip, at: 0.2 },
+  });
+  c.writeRecord(face);
+  const [plain] = await cropVerb.run({ input: face.id, rest: [], opts: { all: true }, case: c, profile: defaultProfile() });
+  const [padded] = await cropVerb.run({ input: face.id, rest: [], opts: { all: true, pad: 0.3 }, case: c, profile: defaultProfile() });
+  assert.equal(plain.state, "ready");
+  assert.equal(padded.state, "ready");
+  // Different padding → different pixels → different path, so the re-crop cannot
+  // silently overwrite the first crop's evidence.
+  assert.notEqual(padded.media!.ref, plain.media!.ref);
+  assert.ok(existsSync(plain.media!.ref));
+  assert.ok(existsSync(padded.media!.ref));
+});
+
+test("crop names disambiguate by source record id, not just class/id/at", async () => {
+  const c = openCase(dir);
+  c.ensure();
+  const payload = {
+    op: "detect",
+    summary: "same face_id/box across two records",
+    faces: [{ face_id: "f_dup", at: 0.2, box: { left: 0.25, top: 0.25, width: 0.5, height: 0.5 } }],
+  };
+  const a = makeRecord({ verb: "face", payload, media: { ref: clip, at: 0.2 } });
+  const b = makeRecord({ verb: "face", payload, media: { ref: clip, at: 0.2 } });
+  c.writeRecord(a);
+  c.writeRecord(b);
+  const [ra] = await cropVerb.run({ input: a.id, rest: [], opts: { all: true }, case: c, profile: defaultProfile() });
+  const [rb] = await cropVerb.run({ input: b.id, rest: [], opts: { all: true }, case: c, profile: defaultProfile() });
+  assert.equal(ra.state, "ready");
+  assert.equal(rb.state, "ready");
+  // Identical detection over identical media from two different source records
+  // must not collide (source.id is folded into the crop signature).
+  assert.notEqual(rb.media!.ref, ra.media!.ref);
+  assert.ok(existsSync(ra.media!.ref));
+  assert.ok(existsSync(rb.media!.ref));
+});
+
 test("crop keeps tiny pixel boxes in pixel space unless explicitly normalized", async () => {
   assert.deepEqual(
     normalizeBox({ xmin: 0, ymin: 0, xmax: 1, ymax: 1 }, { width: 128, height: 96 }, 0, false),


### PR DESCRIPTION
## What & why

Fixes an **evidence-overwrite bug** in `crop`. `crop` materializes detection boxes into cropped image *evidence records*, but the output filename was `${base}_${class}_${id}${at}.jpg` — omitting the box geometry, `--pad`, and `--square` parameters. So `crop <rec> --id face_1` followed by `crop <rec> --id face_1 --pad 0.3 --square` wrote to the **same path** and silently overwrote the first crop, leaving its record pointing at pixels that no longer matched the recorded box — corrupting evidence provenance. The sibling modules `grid`/`enhance` already avoid this by hashing parameters into the name.

**Fix:** a module-local `cropSig()` helper folds a 10-char sha1 signature over `{ box, pad, square, source.id }` into the output filename:

- old: `${base}_${class}_${id}${at}.jpg`
- new: `${base}_${class}_${id}${at}_${sig}.jpg`

Identical params → identical name (idempotent, no churn); any change to geometry/pad/square/source → a different name, so a re-crop can't clobber an earlier crop. `shortHash` is **not** exported from `ffmpeg.ts` (per plan scope) — the helper is defined locally in `crop.ts`. CLI flags, record payload shape, and `--out` handling are untouched.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **778 pass / 0 fail** (+3 new regression tests)
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- `node --test --import tsx test/unit/senses.test.ts` — ✅ 25 pass / 0 fail (all 6 crop tests green)
- `rg -n 'cropSig' src/verbs/crop.ts` — ✅ defined once, used once in the out-path

New regression tests (in `test/unit/senses.test.ts`, reusing existing crop fixtures): idempotency (same params → same name), pad-divergence (adding `--pad` → different file, no overwrite), and source-id disambiguation (same detection from two different source records → different paths).

## Deviations

None. Extended the existing crop test file (`senses.test.ts`, where crop coverage already lives) rather than creating `crop-naming.test.ts` — the plan explicitly permits either.

## Scope

In-scope: `src/verbs/crop.ts`, `test/unit/senses.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evidence artifact paths on disk (existing workflows may see new filenames), but the behavior fix is localized to crop naming with regression tests and no API/CLI shape changes.
> 
> **Overview**
> Fixes an **evidence overwrite** bug where re-running `crop` with different `--pad`, `--square`, or box geometry reused the same `${base}_${class}_${id}${at}.jpg` path and could replace pixels while an older crop record still pointed at that file.
> 
> **`crop`** now appends a 10-character SHA-1 signature via local **`cropSig()`** over `{ box, pad, square, source.id }`, matching the parameter-hashing pattern used by **`grid`** / **`enhance`**. Identical inputs keep the same path (idempotent); any change to geometry, padding, square mode, or source record gets a distinct file.
> 
> Three unit tests in **`senses.test.ts`** cover idempotency, pad vs no-pad paths, and disambiguation when two source records share the same detection id/box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca208bba03d94874bcda9a86860ed42649fdb194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->