### PR TITLE
Consolidate --at/duration parsing into shared parsers

### DIFF
--- a/src/media/ffmpeg.ts
+++ b/src/media/ffmpeg.ts
@@ -530,20 +530,37 @@ export interface FrameRef {
   second: number;
 }
 
-/** Parse a seek/timestamp value: plain seconds ("42", "42.5") or a timecode
- *  ("1:02", "1:02:14"). Returns undefined for anything unparseable or negative —
- *  the single implementation shared by `grid` window flags and `view --at` so the
- *  two can't disagree on a malformed string. */
+/** Parse a seek/timestamp: plain seconds ("42", "42.5") or a timecode with 2–3
+ *  segments ("1:02", "1:02:14"; decimals allowed in any segment). Returns
+ *  undefined for negatives, >3 segments, or non-numeric segments. THE single
+ *  implementation for every --at/--start/--end across verbs. */
 export function parseTimecode(s: string): number | undefined {
   const str = s.trim();
   if (!str) return undefined;
   if (str.includes(":")) {
-    const parts = str.split(":").map((p) => Number(p));
-    if (parts.some((p) => !Number.isFinite(p) || p < 0)) return undefined;
-    return parts.reduce((acc, p) => acc * 60 + p, 0);
+    const parts = str.split(":");
+    if (parts.length < 2 || parts.length > 3) return undefined;
+    if (!parts.every((p) => /^\d+(?:\.\d+)?$/.test(p))) return undefined;
+    const nums = parts.map(Number);
+    return nums.length === 2 ? nums[0] * 60 + nums[1] : nums[0] * 3600 + nums[1] * 60 + nums[2];
   }
   const n = Number(str);
   return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+/** Parse a point ("90", "1:30") or span ("80-95", "1:20-1:35") --at value.
+ *  A span with end < start is invalid. */
+export function parseAtSpan(s: string): number | [number, number] | undefined {
+  const raw = s.trim();
+  if (!raw) return undefined;
+  const span = raw.match(/^(.+)-(.+)$/);
+  if (span) {
+    const start = parseTimecode(span[1]);
+    const end = parseTimecode(span[2]);
+    if (start == null || end == null || end < start) return undefined;
+    return [start, end];
+  }
+  return parseTimecode(raw);
 }
 
 /** Parse a `frame://rec_xxx@134` reference. Returns null if not a frame ref. */

--- a/src/providers/memory/local.ts
+++ b/src/providers/memory/local.ts
@@ -155,14 +155,16 @@ export class LocalMemoryProvider implements MemoryProvider {
   }
 }
 
-/** Parse a relative ("30m", "24h", "7d", "2w") or absolute date into an epoch ms
- *  cutoff. Units match monitor's --every: m=minutes, h=hours, d=days, w=weeks. */
+/** Parse a relative ("30s", "30m", "24h", "7d", "2w") or absolute date into an
+ *  epoch ms cutoff. Units match the shared s/m/h/d/w duration grammar
+ *  (monitor's --every / parseInterval): s=seconds, m=minutes, h=hours, d=days,
+ *  w=weeks. */
 export function parseSince(since: string): number | null {
-  const rel = since.match(/^(\d+)([mhdw])$/);
+  const rel = since.match(/^(\d+)([smhdw])$/);
   if (rel) {
     const n = Number(rel[1]);
     const unit = rel[2];
-    const ms = unit === "m" ? 60e3 : unit === "h" ? 3600e3 : unit === "d" ? 86400e3 : 7 * 86400e3;
+    const ms = unit === "s" ? 1e3 : unit === "m" ? 60e3 : unit === "h" ? 3600e3 : unit === "d" ? 86400e3 : 7 * 86400e3;
     // anchor on a fixed reference would break determinism; use process clock.
     return Date.parse(new Date().toISOString()) - n * ms;
   }

--- a/src/verbs/finding.ts
+++ b/src/verbs/finding.ts
@@ -1,5 +1,6 @@
 import { makeRecord, type MediaRef, type OvercastRecord } from "../record.js";
 import { resolveMediaRef, refPathExists } from "./media-ref.js";
+import { parseAtSpan } from "../media/ffmpeg.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
 function err(message: string): OvercastRecord {
@@ -57,27 +58,6 @@ export function makeFinding(input: {
 
 function textFromArgs(ctx: VerbContext): string {
   return [ctx.rest[0], ...ctx.rest.slice(1)].filter(Boolean).join(" ").trim();
-}
-
-function parseStamp(s: string): number | undefined {
-  const raw = s.trim();
-  if (!raw) return undefined;
-  if (/^\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
-  const parts = raw.split(":");
-  if (parts.length < 2 || parts.length > 3 || !parts.every((p) => /^\d+(?:\.\d+)?$/.test(p))) return undefined;
-  const nums = parts.map(Number);
-  return nums.length === 2 ? nums[0] * 60 + nums[1] : nums[0] * 3600 + nums[1] * 60 + nums[2];
-}
-
-function parseAt(s: string): number | [number, number] | undefined {
-  const span = s.trim().match(/^(.+)-(.+)$/);
-  if (span) {
-    const start = parseStamp(span[1]);
-    const end = parseStamp(span[2]);
-    if (start == null || end == null || end < start) return undefined;
-    return [start, end];
-  }
-  return parseStamp(s);
 }
 
 export function isRootFindingRecord(rec: OvercastRecord): boolean {
@@ -152,7 +132,7 @@ export const findingVerb: VerbSpec = {
       }
       if (ctx.opts.at != null) {
         if (!media?.ref) return [err("--at requires --ref to resolve to media")];
-        const at = parseAt(String(ctx.opts.at));
+        const at = parseAtSpan(String(ctx.opts.at));
         if (at == null) return [err(`invalid --at '${ctx.opts.at}' (expected seconds, hh:mm:ss, or start-end)`)];
         media = { ref: media.ref, at };
       }

--- a/src/verbs/note.ts
+++ b/src/verbs/note.ts
@@ -4,37 +4,11 @@
 
 import { makeRecord, type MediaRef, type OvercastRecord } from "../record.js";
 import { resolveMediaRef, refPathExists } from "./media-ref.js";
+import { parseAtSpan } from "../media/ffmpeg.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
 function err(message: string): OvercastRecord {
   return makeRecord({ verb: "note", format: "json", payload: { error: message }, error: message, state: "error" });
-}
-
-function parseStamp(s: string): number | undefined {
-  const raw = s.trim();
-  if (!raw) return undefined;
-  if (/^\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
-  const parts = raw.split(":");
-  if (parts.length < 2 || parts.length > 3) return undefined;
-  if (!parts.every((p) => /^\d+(?:\.\d+)?$/.test(p))) return undefined;
-  const nums = parts.map(Number);
-  if (nums.some((n) => !Number.isFinite(n))) return undefined;
-  return nums.length === 2
-    ? nums[0] * 60 + nums[1]
-    : nums[0] * 3600 + nums[1] * 60 + nums[2];
-}
-
-function parseAt(s: string): number | [number, number] | undefined {
-  const raw = s.trim();
-  if (!raw) return undefined;
-  const span = raw.match(/^(.+)-(.+)$/);
-  if (span) {
-    const start = parseStamp(span[1]);
-    const end = parseStamp(span[2]);
-    if (start == null || end == null || end < start) return undefined;
-    return [start, end];
-  }
-  return parseStamp(raw);
 }
 
 function splitTags(v: unknown): string[] | undefined {
@@ -119,7 +93,7 @@ export const noteVerb: VerbSpec = {
     if (ctx.opts.at != null) {
       if (!ctx.opts.ref) return [err("--at requires --ref so the timestamp has evidence to anchor")];
       if (!media?.ref) return [err("--at requires --ref to resolve to media (the referenced record has no media.ref)")];
-      const at = parseAt(String(ctx.opts.at));
+      const at = parseAtSpan(String(ctx.opts.at));
       if (at == null) return [err(`invalid --at '${ctx.opts.at}' (expected seconds, hh:mm:ss, or start-end)`)];
       media = { ref: media.ref, at };
     }

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -969,13 +969,14 @@ export const captureVerb: VerbSpec = {
 
 // ---- monitor (--once) ------------------------------------------------------
 
-/** Parse a cadence like "15m"/"6h"/"30s"/"1d" into milliseconds. */
+/** Parse a cadence like "15m"/"6h"/"30s"/"1d"/"2w" into milliseconds. Units
+ *  match the shared s/m/h/d/w duration grammar (parseSince). */
 export function parseInterval(s: string): number | undefined {
-  const m = s.match(/^(\d+)\s*([smhd])$/);
+  const m = s.match(/^(\d+)\s*([smhdw])$/);
   if (!m) return undefined;
   const n = Number(m[1]);
   const u = m[2];
-  return n * (u === "s" ? 1e3 : u === "m" ? 60e3 : u === "h" ? 3600e3 : 86400e3);
+  return n * (u === "s" ? 1e3 : u === "m" ? 60e3 : u === "h" ? 3600e3 : u === "d" ? 86400e3 : 7 * 86400e3);
 }
 
 const sleep = (ms: number, signal?: AbortSignal) =>

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -20,7 +20,7 @@ import {
   defaultOps,
   extractFrame,
   parseFrameRef,
-  parseTimecode,
+  parseAtSpan,
   modalityFromExt,
   spectrogram as ffSpectrogram,
   ENHANCE_OPS,
@@ -833,7 +833,8 @@ function buildPlayerHtml(
   spectrogramPath: string | undefined,
   isRemote = false,
 ): string {
-  const startAt = at ? parseTimecode(String(at).split("-")[0]) ?? 0 : 0;
+  const parsed = at ? parseAtSpan(String(at)) : undefined;
+  const startAt = parsed == null ? 0 : Array.isArray(parsed) ? parsed[0] : parsed;
   const tag = modality === "video" ? "video" : "audio";
   const markerPins = markers
     .map((m) => `<button class="pin" onclick="seek(${Number(m)})">⏱ ${Number(m)}s</button>`)

--- a/test/unit/ffmpeg.test.ts
+++ b/test/unit/ffmpeg.test.ts
@@ -12,6 +12,8 @@ import {
   defaultOps,
   modalityFromExt,
   parseFrameRef,
+  parseTimecode,
+  parseAtSpan,
 } from "../../src/media/ffmpeg.ts";
 
 let dir: string;
@@ -110,6 +112,25 @@ test("enhance throws (no silent no-op) when no op applies to the modality", asyn
   // a video op DOES apply to the image → ok, and reports it under ops
   const r = await enhance(png, ["grayscale"], join(dir, "e3"));
   assert.deepEqual(r.ops, ["grayscale"]);
+});
+
+test("parseTimecode accepts seconds + 2–3 segment timecodes, rejects garbage", () => {
+  assert.equal(parseTimecode("90"), 90);
+  assert.equal(parseTimecode("42.5"), 42.5);
+  assert.equal(parseTimecode("1:02"), 62);
+  assert.equal(parseTimecode("1:02:03"), 3723);
+  assert.equal(parseTimecode(""), undefined);
+  assert.equal(parseTimecode("1:2:3:4"), undefined);
+  assert.equal(parseTimecode(":30"), undefined);
+  assert.equal(parseTimecode("a:b"), undefined);
+  assert.equal(parseTimecode("-5"), undefined);
+});
+
+test("parseAtSpan parses points and spans, rejects end < start", () => {
+  assert.deepEqual(parseAtSpan("80-95"), [80, 95]);
+  assert.deepEqual(parseAtSpan("1:20-1:35"), [80, 95]);
+  assert.equal(parseAtSpan("95-80"), undefined);
+  assert.equal(parseAtSpan("90"), 90);
 });
 
 test("parseFrameRef parses frame://rec@sec and rejects others", () => {

--- a/test/unit/osint-verbs.test.ts
+++ b/test/unit/osint-verbs.test.ts
@@ -1543,13 +1543,24 @@ test("capture rejects an unresolved ref instead of shipping it to yt-dlp", async
 });
 
 import { parseInterval } from "../../src/verbs/osint.ts";
+import { parseSince } from "../../src/providers/memory/local.ts";
 
-test("parseInterval parses s/m/h/d cadences", () => {
+test("parseInterval parses s/m/h/d/w cadences", () => {
   assert.equal(parseInterval("30s"), 30_000);
   assert.equal(parseInterval("15m"), 900_000);
   assert.equal(parseInterval("6h"), 21_600_000);
   assert.equal(parseInterval("1d"), 86_400_000);
+  assert.equal(parseInterval("2w"), 1_209_600_000);
   assert.equal(parseInterval("nope"), undefined);
+});
+
+test("parseSince shares the s/m/h/d/w grammar with parseInterval", () => {
+  const now = Date.now();
+  const thirtyS = parseSince("30s");
+  assert.notEqual(thirtyS, null);
+  assert.ok(Math.abs((now - 30_000) - (thirtyS as number)) < 2_000);
+  assert.notEqual(parseSince("2w"), null);
+  assert.equal(parseSince("not-a-date"), null);
 });
 
 test("monitor --every loops with seen-set diff across passes (capped)", async () => {


### PR DESCRIPTION
## What & why

The `--at` flag was parsed **inconsistently** across verbs, and the duration grammars diverged despite docs claiming parity:

- `note --at 1:02-1:05` worked while `view --at 1:02-1:05` errored (no span support).
- `grid --at 1:2:3:4` silently accepted garbage (>3 segments folded permissively) while `note`/`finding` rejected it.
- Cadence/recency grammars split: `parseInterval` (osint `--every`) accepted `s/m/h/d` while `parseSince` (memory recency) accepted `m/h/d/w` — neither matched the documented set.

Divergent evidence-anchor parsing means the same `--at` string can round-trip to different offsets depending on the verb — a correctness/debt hazard for an evidence tool.

**Fix — one shared implementation:**
- `parseTimecode(s)` in `src/media/ffmpeg.ts` — tightened to accept plain seconds or a **2–3 segment** timecode (decimals allowed), rejecting empties, negatives, >3 segments, and non-numeric segments.
- New `parseAtSpan(s)` — point (`"90"`, `"1:30"`) **or** span (`"80-95"`, `"1:20-1:35"`), rejecting `end < start`.
- `note`/`finding`/`senses(view)` drop their private drifted copies and import the shared parsers.
- Duration grammar unified to **`s/m/h/d/w`** across `parseInterval` (osint) and `parseSince` (memory/local), with docs corrected.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **781 pass / 0 fail** (added a `parseTimecode`/`parseAtSpan` matrix + `parseInterval("2w")` / `parseSince` s/m/h/d/w cases)
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- Focused: `ffmpeg.test.ts` 13/13, `note.test.ts + finding.test.ts` 8/8, `osint-verbs.test.ts` 52/52 — all ✅
- Done-criteria greps — ✅ no matches for `function parseStamp|function parseAt(` in `src/verbs/`, none for `split("-")[0]` in `senses.ts`

## Notes for reviewers / downstream (plan 014)

Exports added to `src/media/ffmpeg.ts`:
```ts
export function parseTimecode(s: string): number | undefined
export function parseAtSpan(s: string): number | [number, number] | undefined
```
`parseTimecode("1:99")` still resolves to 159 (permissive minute overflow) — preserved deliberately. A distinct private `parseAt(value: unknown)` in `src/providers/memory/qmd.ts` has a different signature and is intentionally left alone. Plan 014 (shared verb helpers) builds on these exports.

## Deviations

None.

## Scope

In-scope: `src/media/ffmpeg.ts`, `src/verbs/note.ts`, `src/verbs/finding.ts`, `src/verbs/senses.ts`, `src/verbs/osint.ts` (parseInterval only — the `--every` loop is fenced out for plan 005), `src/providers/memory/local.ts`, `test/unit/ffmpeg.test.ts`, `test/unit/osint-verbs.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how evidence `--at` values and recency/monitor duration strings are parsed across verbs; behavior shifts (stricter timecodes, view span support, new `s`/`w` units) but is covered by expanded unit tests.
> 
> **Overview**
> **Evidence timestamps and cadence strings now share one parser**, so the same `--at` / timecode input should behave the same whether you anchor a **note**, **finding**, or **view** player seek.
> 
> In `src/media/ffmpeg.ts`, **`parseTimecode`** is tightened (2–3 segment timecodes with optional decimals; rejects empty, negative, >3 segments, and non-numeric parts). New **`parseAtSpan`** handles a single point or a **`start-end`** span and rejects **`end < start`**. **`note`** and **`finding`** drop their local `parseStamp` / `parseAt` helpers and call **`parseAtSpan`** for **`--at`**. **`view`** in `senses.ts` uses **`parseAtSpan`** for the HTML player start time instead of only taking the substring before the first `-`.
> 
> **Duration grammar is unified to `s/m/h/d/w`:** **`parseSince`** (local memory) adds **`s`**, and **`parseInterval`** (monitor **`--every`**) adds **`w`**, with comments tying the two together.
> 
> Unit coverage adds **`parseTimecode` / `parseAtSpan`** cases in `ffmpeg.test.ts` and **`parseInterval("2w")` / `parseSince`** alignment in `osint-verbs.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f2cb4a1c733e4ac98c6bd97728c7a0fc10b1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->