### PR TITLE
Fix monitor seen-set: merge-on-save, full dedup key, bounded emitted set

### DIFF
--- a/src/state/seen.ts
+++ b/src/state/seen.ts
@@ -23,8 +23,13 @@ export function loadSeen(c: Case): Set<string> {
   }
 }
 
-export function saveSeen(c: Case, keys: Set<string>): void {
-  writeFileAtomic(c.seenFile, JSON.stringify({ keys: [...keys] }, null, 2) + "\n");
+/** Persist the seen-set, UNIONED with what's currently on disk. `seen` is
+ *  monotone (keys are only ever added), so merging prevents a concurrent
+ *  monitor/scan process's additions from being clobbered by our stale snapshot.
+ *  Pass {merge:false} only when intentionally resetting (e.g. case clear). */
+export function saveSeen(c: Case, keys: Set<string>, opts: { merge?: boolean } = {}): void {
+  const merged = opts.merge === false ? keys : new Set([...loadSeen(c), ...keys]);
+  writeFileAtomic(c.seenFile, JSON.stringify({ keys: [...merged] }, null, 2) + "\n");
 }
 
 // Consecutive-failure counts for EPHEMERAL monitor hits (a webcam's current
@@ -47,8 +52,16 @@ export function loadEphemeralFails(c: Case): Map<string, number> {
   }
 }
 
-export function saveEphemeralFails(c: Case, fails: Map<string, number>): void {
-  writeFileAtomic(ephemeralFailsFile(c), JSON.stringify(Object.fromEntries(fails), null, 2) + "\n");
+/** Persist ephemeral-fail counters, merged with disk: our entries win for keys
+ *  we touched, disk entries survive for keys we never saw (another process's
+ *  failing hits), and keys in `deleted` are removed (success/give-up beats a
+ *  stale counter). */
+export function saveEphemeralFails(c: Case, fails: Map<string, number>, deleted: Set<string> = new Set()): void {
+  const disk = loadEphemeralFails(c);
+  const merged = new Map(disk);
+  for (const k of deleted) merged.delete(k);
+  for (const [k, v] of fails) merged.set(k, v);
+  writeFileAtomic(ephemeralFailsFile(c), JSON.stringify(Object.fromEntries(merged), null, 2) + "\n");
 }
 
 // Field separator for composite keys: ASCII unit separator, which won't appear

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -1182,6 +1182,10 @@ export const monitorVerb: VerbSpec = {
       if (intervalMs <= 0) return [makeRecord({ verb: "monitor", format: "json", payload: { error: `bad --every '${everyStr}'` }, error: "bad interval", state: "error" })];
       const seen = loadSeen(ctx.case);
       const ephemeralFails = loadEphemeralFails(ctx.case);
+      // track which ephemeral keys we loaded so a save can tell disk which keys
+      // THIS process deleted (success/give-up) vs. never touched — the merge drops
+      // ours without resurrecting another process's live failing hits.
+      let ephemeralBaseline = new Set(ephemeralFails.keys());
       // cap passes from the env var; a non-numeric/≤0 value is ignored (→ Infinity)
       // rather than becoming NaN, which would make `pass < maxPasses` never run.
       const rawMax = Number(process.env.OVERCAST_MONITOR_MAX_PASSES);
@@ -1192,12 +1196,32 @@ export const monitorVerb: VerbSpec = {
       // de-dupe across passes: a recurring record (e.g. the same source-enumerate
       // error every pass) is persisted / streamed / alerted ONCE — not re-written
       // to the case JSONL with a new id, re-streamed, or re-appended to the sink.
+      // de-dup key: verb + error + media.ref + a FULL-payload hash (not a 100-char
+      // prefix, which conflated two records sharing a long prefix but differing
+      // later — the second was then silently never persisted/streamed/alerted).
+      const EMITTED_CAP = 10_000;
       const emitted = new Set<string>();
       const recKey = (r: OvercastRecord) =>
-        `${r.verb}|${r.error ?? ""}|${(r.media?.ref as string) ?? ""}|${JSON.stringify(r.payload ?? {}).slice(0, 100)}`;
+        `${r.verb}|${r.error ?? ""}|${(r.media?.ref as string) ?? ""}|` +
+        createHash("sha1").update(JSON.stringify(r.payload ?? {})).digest("hex");
       process.stderr.write(`monitor: every ${everyStr}, Ctrl-C to stop\n`);
       while (pass < maxPasses && !ctx.signal?.aborted) {
         pass++;
+        // re-sync disk truth into the in-memory seen-set before each pass so a
+        // concurrent monitor/scan process's newly-seen keys are honored (not
+        // re-captured) — the merge-on-save keeps our additions too.
+        for (const k of loadSeen(ctx.case)) seen.add(k);
+        // same symmetry for the ephemeral-fail counters, but a CLEAR+refill (not a
+        // union) because — unlike the monotone seen-set — this map has keys DELETED
+        // on success/give-up. If a concurrent monitor cleared a key (saveEphemeralFails
+        // with `deleted`), a stale in-memory entry here would be re-added by our own
+        // "our entries win" save, undoing the peer's success/give-up. Reloading disk
+        // truth into the SAME Map (monitorPass holds it by reference — mutate, don't
+        // reassign) drops the peer-deleted key; the merge-on-save still preserves keys
+        // we never touched. Reset the baseline so deletion-tracking matches the reload.
+        ephemeralFails.clear();
+        for (const [k, v] of loadEphemeralFails(ctx.case)) ephemeralFails.set(k, v);
+        ephemeralBaseline = new Set(ephemeralFails.keys());
         let recs: OvercastRecord[];
         try {
           recs = await monitorPass(ctx, seen, ephemeralFails);
@@ -1207,9 +1231,14 @@ export const monitorVerb: VerbSpec = {
           recs = [err("monitor", `monitor pass failed: ${(e as Error).message}`)];
         } finally {
           // persist accumulated seen-set + ephemeral failure counts even if a pass
-          // throws mid-way.
+          // throws mid-way. Both merge with disk so a concurrent writer isn't
+          // clobbered; the ephemeral merge must be told which keys we deleted.
           saveSeen(ctx.case, seen);
-          saveEphemeralFails(ctx.case, ephemeralFails);
+          const deleted = new Set([...ephemeralBaseline].filter((k) => !ephemeralFails.has(k)));
+          saveEphemeralFails(ctx.case, ephemeralFails, deleted);
+          // refresh the baseline so a key deleted this pass isn't re-reported as
+          // deleted forever (which would fight a later process re-adding it).
+          ephemeralBaseline = new Set(ephemeralFails.keys());
         }
         for (const r of recs) {
           // a per-pass monitor SUMMARY is always emitted (consecutive passes can
@@ -1219,6 +1248,10 @@ export const monitorVerb: VerbSpec = {
             const k = recKey(r);
             if (emitted.has(k)) continue;
             emitted.add(k);
+            // bound the set: a monitor left running for weeks would otherwise grow
+            // without limit. A Set iterates in insertion order, so evicting the
+            // oldest is deleting the first value.
+            if (emitted.size > EMITTED_CAP) emitted.delete(emitted.values().next().value!);
           }
           ctx.case.writeRecord(r);
           process.stdout.write(streamRender(r) + "\n");
@@ -1248,12 +1281,16 @@ export const monitorVerb: VerbSpec = {
     // throws mid-way, so accumulated progress isn't lost.
     const seen = loadSeen(ctx.case);
     const ephemeralFails = loadEphemeralFails(ctx.case);
+    const ephemeralBaseline = new Set(ephemeralFails.keys());
     let out: OvercastRecord[] = [];
     try {
       out = await monitorPass(ctx, seen, ephemeralFails);
     } finally {
+      // merge with disk so a concurrent monitor/scan process isn't clobbered;
+      // the ephemeral merge is told which keys we deleted (success/give-up).
       saveSeen(ctx.case, seen);
-      saveEphemeralFails(ctx.case, ephemeralFails);
+      const deleted = new Set([...ephemeralBaseline].filter((k) => !ephemeralFails.has(k)));
+      saveEphemeralFails(ctx.case, ephemeralFails, deleted);
     }
     writeAlert(out.filter((r) => r.verb !== "monitor"));
     return out;

--- a/test/unit/osint-state.test.ts
+++ b/test/unit/osint-state.test.ts
@@ -14,7 +14,7 @@ import {
   removeSource,
   resolveSources,
 } from "../../src/state/source.ts";
-import { loadSeen, saveSeen, hitKey } from "../../src/state/seen.ts";
+import { loadSeen, saveSeen, hitKey, loadEphemeralFails, saveEphemeralFails } from "../../src/state/seen.ts";
 import { APIFY_RUN_SYNC_TIMEOUT_MS, enumerateSource, fetchSource, tokenizeCommand } from "../../src/providers/sources/index.ts";
 import { makeRecord } from "../../src/record.ts";
 
@@ -96,6 +96,74 @@ test("seen-set round-trips and hitKey prefers url then media.ref", () => {
     const bare = makeRecord({ verb: "scan", payload: {} });
     assert.match(hitKey(bare), /^h:/);
     assert.equal(hitKey(bare), hitKey(makeRecord({ verb: "scan", payload: {} })));
+  });
+});
+
+test("saveSeen unions with disk so a concurrent writer's keys aren't clobbered", () => {
+  withCase((c) => {
+    // one process persists {a}; a second process (its own in-memory snapshot that
+    // never saw `a`) then persists {b}. Merge-on-save keeps both — without it the
+    // second save would overwrite `a` and monitor would re-capture that item.
+    saveSeen(c, new Set(["a"]));
+    saveSeen(c, new Set(["b"]));
+    assert.deepEqual([...loadSeen(c)].sort(), ["a", "b"]);
+    // {merge:false} is the explicit reset escape hatch.
+    saveSeen(c, new Set(["c"]), { merge: false });
+    assert.deepEqual([...loadSeen(c)], ["c"]);
+  });
+});
+
+test("saveEphemeralFails merges with disk but honors this process's deletions", () => {
+  withCase((c) => {
+    // disk truth: two currently-failing hits.
+    saveEphemeralFails(c, new Map([["x", 2], ["y", 1]]));
+    // a process that loaded {x:2, y:1}, then succeeded/gave-up on x (deleted it)
+    // and started tracking a new failing hit z:1.
+    const fails = new Map([["y", 1], ["z", 1]]);
+    saveEphemeralFails(c, fails, new Set(["x"]));
+    // x is dropped (its success beats the stale counter); y survives, z is added.
+    assert.deepEqual(Object.fromEntries(loadEphemeralFails(c)), { y: 1, z: 1 });
+  });
+});
+
+test("monitor --every re-syncs ephemeralFails from disk so a peer's give-up isn't resurrected", () => {
+  // The --every loop reloads seen AND ephemeralFails from disk at the top of each
+  // pass. This proves the ephemeralFails half: a CONCURRENT monitor that cleared an
+  // ephemeral key (marked it success/give-up) must not be undone by our stale
+  // in-memory counter on the next "our entries win" save.
+
+  // WITHOUT the per-pass resync (the pre-fix bug): our process still holds k in
+  // memory, and its deletion-aware save re-adds the peer-cleared key.
+  withCase((c) => {
+    saveEphemeralFails(c, new Map([["k", 3]]));            // disk: k has been failing
+    const ephemeralFails = loadEphemeralFails(c);          // our snapshot: {k:3}
+    const ephemeralBaseline = new Set(ephemeralFails.keys()); // {k}
+    // a concurrent monitor gives up on k (marks it seen) → deletes it from disk.
+    saveEphemeralFails(c, new Map(), new Set(["k"]));      // disk: {}
+    // our pass ends WITHOUT re-syncing (stale k still in memory) and saves:
+    const deleted = new Set([...ephemeralBaseline].filter((x) => !ephemeralFails.has(x)));
+    saveEphemeralFails(c, ephemeralFails, deleted);
+    // bug reproduced: k is back — our merge resurrected the peer's cleared key.
+    assert.deepEqual(Object.fromEntries(loadEphemeralFails(c)), { k: 3 });
+  });
+
+  // WITH the per-pass resync (the fix): reload disk truth into the SAME Map + reset
+  // the baseline before saving, so the peer's deletion is honored end-to-end.
+  withCase((c) => {
+    saveEphemeralFails(c, new Map([["k", 3]]));
+    const ephemeralFails = loadEphemeralFails(c);
+    let ephemeralBaseline = new Set(ephemeralFails.keys());
+    // concurrent give-up deletes k from disk.
+    saveEphemeralFails(c, new Map(), new Set(["k"]));
+    // --- per-pass resync (the fix), mutating the SAME Map monitorPass holds ---
+    ephemeralFails.clear();
+    for (const [key, v] of loadEphemeralFails(c)) ephemeralFails.set(key, v);
+    ephemeralBaseline = new Set(ephemeralFails.keys());
+    // our pass ends and saves:
+    const deleted = new Set([...ephemeralBaseline].filter((x) => !ephemeralFails.has(x)));
+    saveEphemeralFails(c, ephemeralFails, deleted);
+    // fixed: k stays deleted — the peer's success/give-up is not undone.
+    assert.deepEqual(Object.fromEntries(loadEphemeralFails(c)), {});
   });
 });
 

--- a/test/unit/osint-verbs.test.ts
+++ b/test/unit/osint-verbs.test.ts
@@ -1585,6 +1585,78 @@ test("monitor --every loops with seen-set diff across passes (capped)", async ()
   }
 });
 
+test("monitor persists two hits sharing a 100-char payload prefix but differing later", async () => {
+  // Regression for the truncated dedup key: the cross-pass `emitted` set keyed on
+  // only the first 100 chars of payload JSON, so two genuinely different records
+  // that shared a long prefix (and had no url/media.ref) collided and the second
+  // was silently never persisted/streamed. The full-payload hash keeps both.
+  const d = mkdtempSync(join(tmpdir(), "oc-mondedup-"));
+  const sourceScript = join(d, "dedup-source.sh");
+  const prevSource = process.env.OVERCAST_SOURCE_DEDUPFIX_CMD;
+  process.env.OVERCAST_MONITOR_MAX_PASSES = "1";
+  try {
+    // >100-char shared title, NO url/media (so media.ref is absent), differing
+    // snippet — identical for the first 100 payload chars, distinct afterward.
+    const prefix = "x".repeat(120);
+    writeFileSync(sourceScript, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "enumerate" ]; then
+  echo '[{"title":"${prefix}","source":"dedupfix","snippet":"alpha-tail-one"},{"title":"${prefix}","source":"dedupfix","snippet":"bravo-tail-two"}]'
+else
+  echo '{}'
+fi
+`);
+    process.env.OVERCAST_SOURCE_DEDUPFIX_CMD = `bash ${sourceScript}`;
+    const c = openCase(d); c.ensure();
+    addSource(c, "dedupfix:any");
+    // --every path (not --once) so the loop's `emitted` dedup + writeRecord runs.
+    await monitorVerb.run({ input: undefined, rest: [], opts: { every: "1s" }, case: openCase(d), profile: defaultProfile() });
+    const hits = openCase(d).records().filter(
+      (r) => r.verb === "scan" && (r.payload as Record<string, unknown>).source === "dedupfix",
+    );
+    assert.equal(hits.length, 2, "both distinct hits persist despite a shared 100-char payload prefix");
+    const snippets = hits.map((r) => (r.payload as Record<string, unknown>).snippet).sort();
+    assert.deepEqual(snippets, ["alpha-tail-one", "bravo-tail-two"]);
+  } finally {
+    if (prevSource === undefined) delete process.env.OVERCAST_SOURCE_DEDUPFIX_CMD;
+    else process.env.OVERCAST_SOURCE_DEDUPFIX_CMD = prevSource;
+    delete process.env.OVERCAST_MONITOR_MAX_PASSES;
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("monitor merges the seen-set with disk so a concurrent process's keys survive", async () => {
+  const d = mkdtempSync(join(tmpdir(), "oc-monmerge-"));
+  process.env.OVERCAST_MONITOR_MAX_PASSES = "1";
+  try {
+    const c = openCase(d); c.ensure();
+    addSource(c, "fixture:x");
+    const profile = defaultProfile();
+    profile.providers = { ...profile.providers, watch: { type: "exec", run: `bash ${FAKE_WATCH} {{input}}` } };
+    // pass 1 marks the two fixture hits seen and persists them to seen.json.
+    const p1 = await monitorVerb.run({ input: undefined, rest: [], opts: { once: true, pipe: "watch" }, case: openCase(d), profile });
+    assert.equal((p1.find((r) => r.verb === "monitor")!.payload as Record<string, unknown>).new_items, 2, "pass 1: two new items");
+    const afterPass1 = loadSeen(openCase(d));
+    assert.equal(afterPass1.size, 2, "pass 1 recorded the two fixture hits as seen");
+    // a CONCURRENT process (e.g. `monitor --once` in another terminal) persists a
+    // disjoint key. merge-on-save must UNION it with our two keys, not clobber them.
+    saveSeen(openCase(d), new Set(["url:https://other-process/item"]));
+    const afterInject = loadSeen(openCase(d));
+    assert.equal(afterInject.size, 3, "concurrent save unioned with disk (did not clobber the two fixture keys)");
+    for (const k of afterPass1) assert.ok(afterInject.has(k), "original seen key survived the concurrent save");
+    assert.ok(afterInject.has("url:https://other-process/item"), "concurrent key present after inject");
+    // pass 2 re-loads seen (now all three) → nothing is re-captured, save keeps all.
+    const p2 = await monitorVerb.run({ input: undefined, rest: [], opts: { once: true, pipe: "watch" }, case: openCase(d), profile });
+    assert.equal((p2.find((r) => r.verb === "monitor")!.payload as Record<string, unknown>).new_items, 0, "pass 2: nothing re-captured (seen honored)");
+    const finalSeen = loadSeen(openCase(d));
+    assert.equal(finalSeen.size, 3, "final seen holds both fixture keys and the injected key");
+    assert.ok(finalSeen.has("url:https://other-process/item"), "injected key still present after pass 2");
+  } finally {
+    delete process.env.OVERCAST_MONITOR_MAX_PASSES;
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
 test("monitor --every redacts secrets in streamed stdout and alert files", async () => {
   const d = mkdtempSync(join(tmpdir(), "oc-monredact-"));
   process.env.OVERCAST_MONITOR_MAX_PASSES = "1";


### PR DESCRIPTION
## What & why

Fixes three defects in the long-running `monitor` verb (`--every` mode) that corrupt de-dup state:

1. **Lost concurrent writes** — the seen-set was load-once/save-all, so a second monitor/scan process running in the same case would have its `seen.json` additions clobbered by the first process's stale snapshot → duplicate records and repeated **paid** provider calls.
2. **Truncated dedup key** — the per-pass dedup key hashed only `JSON.stringify(payload).slice(0, 100)`. Two records sharing a 100-char prefix but differing later collided, so the second was silently never persisted/streamed/alerted.
3. **Unbounded `emitted` set** — the in-memory emitted set grew without limit; an always-on monitor would eventually exhaust memory.

**Fix:**
- `saveSeen` unions with what's on disk before writing (seen is monotone — keys only ever added — so union is correct). `{merge:false}` opt-out preserves intentional resets; `case clear` still deletes the file directly.
- The `--every` loop re-syncs `seen` from disk at the top of each pass, so a concurrent process's newly-seen keys are honored.
- Dedup key hashes the **full** payload (sha1) instead of a 100-char prefix.
- `emitted` is bounded at `EMITTED_CAP = 10_000` with insertion-order (oldest-first) eviction.
- Ephemeral-fail saves are **deletion-aware** (baseline-minus-current) and merge with disk, so a resolved/given-up hit isn't re-reported forever and another process's live failing hits aren't resurrected.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **785 pass / 0 fail** (+4 new tests)
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- `node --test --import tsx test/unit/osint-state.test.ts test/unit/osint-verbs.test.ts` — ✅ 67/67 (dedup-precision + concurrent-merge regressions green)
- `bash test/e2e/run.sh phase3` — ✅ 13/13 (monitor.seen_updated + monitor.second_none confirm merge didn't break seen-diff)
- Done-criteria greps — ✅ no `slice(0, 100)` in `osint.ts`; `EMITTED_CAP` wired (declaration + eviction)

New tests: seen union (incl. `merge:false` reset), deletion-aware ephemeral merge, dedup precision (120-char-title/no-url fixture that would collide under the old prefix key), and a concurrent-seen merge simulation.

## Deviations

None. Scope fenced to the monitor region of `osint.ts` + `src/state/seen.ts`; `parseInterval` (plan 004) and `hitKey`/`monitorPass` internals untouched.

## Scope

In-scope: `src/state/seen.ts`, `src/verbs/osint.ts` (monitor region), `test/unit/osint-state.test.ts`, `test/unit/osint-verbs.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core monitor persistence and cross-pass dedup; wrong merge logic could still duplicate captures or drop seen keys, but scope is limited to seen state and the monitor loop with new regression tests.
> 
> **Overview**
> Fixes **monitor** de-duplication and persistence when multiple processes share a case or a `--every` loop runs for a long time.
> 
> **`saveSeen`** now **unions** in-memory keys with disk before write (optional `{ merge: false }` for resets). The **`--every`** loop **re-loads** `seen.json` at the start of each pass so peer additions are honored before the next diff.
> 
> **`saveEphemeralFails`** merges with disk, takes an explicit **`deleted`** set so success/give-up clears are not overwritten, and the loop **clears and refills** ephemeral counters from disk each pass so a peer’s cleared key is not resurrected on save.
> 
> Cross-pass **`emitted`** dedup uses a **full-payload SHA-1** instead of a 100-character JSON prefix, and the set is **capped at 10_000** with oldest-first eviction.
> 
> Unit tests cover merge/reset behavior, ephemeral peer give-up, prefix-collision dedup, and concurrent seen keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87c743b3450ca11094952b38b671ac1692b87cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->