### PR TITLE
Move Apify token from URL query to Authorization: Bearer header

### DIFF
--- a/examples/providers/sources/facesearch.sh
+++ b/examples/providers/sources/facesearch.sh
@@ -57,7 +57,8 @@ case "$op" in
     # local image → upload to the account's `overcast-lens` key-value store (shared
     # with the lens source) under a content-hash key; the actor fetches it by URL.
     if [ -f "$query" ]; then
-      if ! store="$(curl -fsS -m 30 -X POST "https://api.apify.com/v2/key-value-stores?token=$APIFY_TOKEN&name=overcast-lens")"; then
+      if ! store="$(curl -fsS -m 30 -X POST -H "Authorization: Bearer $APIFY_TOKEN" \
+        "https://api.apify.com/v2/key-value-stores?name=overcast-lens")"; then
         echo "facesearch: could not open the overcast-lens key-value store on Apify" >&2; exit 1
       fi
       sid="$(printf '%s' "$store" | jq -r '.data.id // empty')"
@@ -68,7 +69,8 @@ case "$op" in
         *) echo "facesearch: unsupported image type '.$ext' (jpg|jpeg|png|webp)" >&2; exit 1 ;;
       esac
       key="face_$(h8 <"$query").$ext"
-      if ! curl -fsS -m 60 -X PUT "https://api.apify.com/v2/key-value-stores/$sid/records/$key?token=$APIFY_TOKEN" \
+      if ! curl -fsS -m 60 -X PUT -H "Authorization: Bearer $APIFY_TOKEN" \
+        "https://api.apify.com/v2/key-value-stores/$sid/records/$key" \
         -H "content-type: $ct" --data-binary @"$query" >/dev/null; then
         echo "facesearch: image upload to Apify failed for $query" >&2; exit 1
       fi
@@ -78,7 +80,8 @@ case "$op" in
     input="$(jq -nc --arg u "$query" --argjson n "$limit" --argjson demo "$demo" \
       '{imageUrl:$u, maxResults:$n, demo:$demo}')"
     if ! run="$(curl -fsS -m 280 -X POST \
-      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items?token=$APIFY_TOKEN" \
+      -H "Authorization: Bearer $APIFY_TOKEN" \
+      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items" \
       -H 'content-type: application/json' -d "$input")"; then
       echo "facesearch enumerate request failed for '$query'" >&2; exit 1
     fi

--- a/examples/providers/sources/instagram.sh
+++ b/examples/providers/sources/instagram.sh
@@ -61,7 +61,8 @@ case "$op" in
       '{directUrls:[$u], resultsType:"posts", resultsLimit:$n, addParentData:false}
        + (if $newer != "" then {onlyPostsNewerThan:$newer} else {} end)')"
     if ! run=$(curl -fsS -m 280 -X POST \
-      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items?token=$APIFY_TOKEN" \
+      -H "Authorization: Bearer $APIFY_TOKEN" \
+      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items" \
       -H 'content-type: application/json' -d "$input"); then
       echo "instagram enumerate request failed for '$query'" >&2; exit 1
     fi

--- a/examples/providers/sources/lens.sh
+++ b/examples/providers/sources/lens.sh
@@ -63,7 +63,8 @@ case "$op" in
       # local image → upload to the account's `overcast-lens` key-value store
       # (get-or-create) under a content-hash key, so repeat scans of the same
       # image reuse one record. The actor fetches it by the public record URL.
-      if ! store="$(curl -fsS -m 30 -X POST "https://api.apify.com/v2/key-value-stores?token=$APIFY_TOKEN&name=overcast-lens")"; then
+      if ! store="$(curl -fsS -m 30 -X POST -H "Authorization: Bearer $APIFY_TOKEN" \
+        "https://api.apify.com/v2/key-value-stores?name=overcast-lens")"; then
         echo "lens: could not open the overcast-lens key-value store on Apify" >&2; exit 1
       fi
       sid="$(printf '%s' "$store" | jq -r '.data.id // empty')"
@@ -77,7 +78,8 @@ case "$op" in
         *) echo "lens: unsupported image type '.$ext' (jpg|jpeg|png|webp|gif)" >&2; exit 1 ;;
       esac
       key="img_$(h8 <"$query").$ext"
-      if ! curl -fsS -m 60 -X PUT "https://api.apify.com/v2/key-value-stores/$sid/records/$key?token=$APIFY_TOKEN" \
+      if ! curl -fsS -m 60 -X PUT -H "Authorization: Bearer $APIFY_TOKEN" \
+        "https://api.apify.com/v2/key-value-stores/$sid/records/$key" \
         -H "content-type: $ct" --data-binary @"$query" >/dev/null; then
         echo "lens: image upload to Apify failed for $query" >&2; exit 1
       fi
@@ -87,7 +89,8 @@ case "$op" in
     input="$(jq -nc --arg u "$query" '{searchTypes:["exact-match","visual-match"],imageUrls:[{url:$u}]}')"
     # -f fails the request on HTTP errors so Apify error JSON isn't parsed as hits
     if ! run="$(curl -fsS -m 240 -X POST \
-      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items?token=$APIFY_TOKEN" \
+      -H "Authorization: Bearer $APIFY_TOKEN" \
+      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items" \
       -H 'content-type: application/json' -d "$input")"; then
       echo "lens enumerate request failed for '$query'" >&2; exit 1
     fi

--- a/examples/providers/sources/telegram.sh
+++ b/examples/providers/sources/telegram.sh
@@ -73,7 +73,8 @@ case "$op" in
       '{channels:$c, maxPosts:$n, includeText:true}
        + (if $d != "" then {daysRange:($d|tonumber)} else {} end)')"
     if ! run=$(curl -fsS -m 280 -X POST \
-      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items?token=$APIFY_TOKEN" \
+      -H "Authorization: Bearer $APIFY_TOKEN" \
+      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items" \
       -H 'content-type: application/json' -d "$input"); then
       echo "telegram enumerate request failed for '$channel'" >&2; exit 1
     fi

--- a/examples/providers/sources/tiktok.sh
+++ b/examples/providers/sources/tiktok.sh
@@ -50,7 +50,8 @@ case "$op" in
     # hits; -m stays under the harness's Apify run-sync budget (the endpoint
     # holds up to 300s) so a slow run fails here with a clear message.
     if ! run=$(curl -fsS -m 280 -X POST \
-      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items?token=$APIFY_TOKEN" \
+      -H "Authorization: Bearer $APIFY_TOKEN" \
+      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items" \
       -H 'content-type: application/json' -d "$input"); then
       echo "tiktok enumerate request failed for '$query'" >&2; exit 1
     fi

--- a/examples/providers/sources/x.sh
+++ b/examples/providers/sources/x.sh
@@ -93,7 +93,8 @@ case "$op" in
          else {} end)')"
     # -f fails the request on HTTP errors so Apify error JSON isn't parsed as hits
     if ! run=$(curl -fsS -X POST \
-      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items?token=$APIFY_TOKEN" \
+      -H "Authorization: Bearer $APIFY_TOKEN" \
+      "https://api.apify.com/v2/acts/$ACTOR/run-sync-get-dataset-items" \
       -H 'content-type: application/json' -d "$input"); then
       echo "x enumerate request failed for '$query'" >&2; exit 1
     fi


### PR DESCRIPTION
## What & why (security)

Six Apify source scripts passed the account token in the **URL query string** (`?token=$APIFY_TOKEN`). URL-embedded secrets leak two ways:
- **Process inspection** — `ps` / `/proc/<pid>/cmdline` is world-readable to any local user, so the full URL (token included) is visible to everyone on the box.
- **Access logs** — proxy and server logs routinely record full request URLs, capturing the token.

These scrapers run on **every** `scan`/`monitor` pass, so on shared or CI hosts the token was exposed repeatedly. Apify supports `Authorization: Bearer` header auth on all `api.apify.com/v2` endpoints.

**Fix:** all **10** call sites moved from `?token=$APIFY_TOKEN` to `-H "Authorization: Bearer $APIFY_TOKEN"`:
- `x.sh` (1), `tiktok.sh` (1), `telegram.sh` (1), `instagram.sh` (1), `facesearch.sh` (3: store-create, record PUT, run-sync), `lens.sh` (3).

Non-auth behavior is preserved exactly — the `name=overcast-lens` query param stays in the URL, `-m` timeouts, `--data-binary` bodies, and `content-type` headers are untouched. No argument-parsing or jq-mapping logic changed. `web.sh` already used header auth and is out of scope.

## ⚠️ Token rotation required

`APIFY_TOKEN` was historically exposed via argv/URL query (readable via `ps`/`/proc` and captured in access logs). **Operators must rotate `APIFY_TOKEN` after this lands** — this change stops future leakage but does not un-expose the previously-leaked value.

## Verification evidence

- `shellcheck -S warning examples/providers/sources/*.sh` — ✅ **no output, exit 0** (the CI-gated check)
- `grep -F 'token=$APIFY_TOKEN' examples/providers/sources/` — ✅ **0 remaining**
- `grep -F 'Authorization: Bearer $APIFY_TOKEN'` — ✅ **10 total** (x:1, tiktok:1, telegram:1, instagram:1, facesearch:3, lens:3)
- `npm run typecheck` — ✅ exit 0 (no TS changed)
- `npm test` — ✅ **785 pass / 0 fail**
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed** (fixture-bound source e2e cases all green)

## Deviations

None. Could not make live Apify calls to confirm header acceptance at runtime; implemented per Apify's documented Bearer-auth shape (works on all `v2` endpoints). No `$APIFY_TOKEN` URL sites exist beyond the 10 cited.

## Scope

In-scope: `examples/providers/sources/{x,tiktok,telegram,instagram,facesearch,lens}.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auth transport change only; same endpoints and request semantics. Low runtime risk, but previously exposed tokens should be rotated.
> 
> **Overview**
> Stops passing **`APIFY_TOKEN` in Apify request URLs** across six example source scripts (`x`, `tiktok`, `telegram`, `instagram`, `facesearch`, `lens`). All **10** `curl` call sites now use `-H "Authorization: Bearer $APIFY_TOKEN"` instead of `?token=…` on key-value store create/PUT and actor `run-sync-get-dataset-items` POSTs.
> 
> **Why:** query-string tokens show up in process listings and HTTP access logs on shared/CI hosts that run scans repeatedly. Non-auth behavior is unchanged (timeouts, JSON bodies, `name=overcast-lens` query param, etc.).
> 
> **Ops note:** rotate **`APIFY_TOKEN`** after deploy; this only prevents future leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12953821b1f0822b198bf71e72b6ffe92c9b87f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->