### PR TITLE
Harden /chair: unhandled-rejection guard + un-truncated pairing QR widget

### DIFF
--- a/src/chair/bridge.ts
+++ b/src/chair/bridge.ts
@@ -235,7 +235,15 @@ export class ChairBridge {
           this.agent.abort();
           return this.json(res, 200, { ok: true });
         }
-        if (path === "/api/prompt") return void this.handlePrompt(req, res);
+        if (path === "/api/prompt") {
+          return void this.handlePrompt(req, res).catch(() => {
+            try {
+              this.json(res, 500, { error: "internal error" });
+            } catch {
+              /* headers already sent — nothing to salvage */
+            }
+          });
+        }
       }
       return this.json(res, 404, { error: "not found" });
     }
@@ -317,7 +325,11 @@ export class ChairBridge {
     } catch (e) {
       return this.json(res, 500, { error: (e as Error).message || "send failed" });
     }
-    this.agent.onRemotePrompt?.({ mode: delivered, chars: text.length });
+    try {
+      this.agent.onRemotePrompt?.({ mode: delivered, chars: text.length });
+    } catch {
+      /* a UI-notify failure must not fail the (already delivered) prompt */
+    }
     // 202: sendUserMessage is fire-and-forget; the console observes the outcome
     // (or an error notice) on the event stream, so this only means "queued".
     this.json(res, 202, { delivered } satisfies ChairPromptResult);

--- a/src/extension/chair.ts
+++ b/src/extension/chair.ts
@@ -11,6 +11,7 @@
 import { randomBytes } from "node:crypto";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import { Container, Text } from "@earendil-works/pi-tui";
 import { openCase } from "../case.js";
 import { loadProfile } from "../profile.js";
 import { OVERCAST_VERSION } from "../version.js";
@@ -454,7 +455,16 @@ export function registerChair(pi: ExtensionAPI): ChairHandle {
       "",
       `  ${bridge.url}   ·   /chair qr to hide`,
     ];
-    ctx.ui.setWidget(QR_WIDGET_KEY, lines);
+    // Render via a component FACTORY, not a string[]: pi caps array widgets at
+    // MAX_WIDGET_LINES (10) and appends "... (widget truncated)", which chops a
+    // scannable QR (~13–21 rows) mid-code and drops the pairing URL. The factory
+    // path is exempt from that cap, so the whole QR + pair line stay pinned.
+    // Mirrors pi's own array rendering (Text(line, 1, 0)) so appearance is identical.
+    ctx.ui.setWidget(QR_WIDGET_KEY, () => {
+      const box = new Container();
+      for (const line of lines) box.addChild(new Text(line, 1, 0));
+      return box;
+    });
     qrVisible = true;
   }
 

--- a/test/unit/chair-bridge.test.ts
+++ b/test/unit/chair-bridge.test.ts
@@ -369,3 +369,77 @@ test("chair bridge: stop closes the port and start rejects a busy port", async (
   assert.equal(bridge.running, false);
   await assert.rejects(fetch(url), /fetch failed/);
 });
+
+test("chair bridge: a throwing onRemotePrompt hook can't crash the process (202, no unhandled rejection)", async () => {
+  // The extension's hook calls ctx.ui.notify(...) on the live pi TUI, which can
+  // throw. It runs AFTER sendUserMessage, so delivery already succeeded — the
+  // throw must be swallowed (still a 202) and must never escape as an unhandled
+  // rejection (which would terminate the live desk process on Node >=15).
+  const { agent, calls } = fakeAgent({
+    onRemotePrompt: () => {
+      throw new Error("ui notify blew up");
+    },
+  });
+  const bridge = makeBridge(agent);
+  const { url, pairingUrl } = await bridge.start();
+  const token = pairingUrl.split("#t=")[1];
+  const auth = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+
+  // Registering a listener both DETECTS the rejection and prevents a crash, so
+  // the assertion is that it never captured anything.
+  const rejections: unknown[] = [];
+  const onRejection = (reason: unknown) => rejections.push(reason);
+  process.on("unhandledRejection", onRejection);
+  try {
+    const res = await fetch(`${url}api/prompt`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ text: "look into the van" }),
+    });
+    assert.equal(res.status, 202);
+    assert.deepEqual(await res.json(), { delivered: "turn" });
+    // the message WAS delivered before the hook blew up
+    assert.deepEqual(calls.sent[0], { text: "look into the van", opts: undefined });
+    // give any escaped rejection a tick to surface as an unhandledRejection
+    await new Promise((r) => setTimeout(r, 50));
+    assert.deepEqual(rejections, [], "a throwing UI hook must not produce an unhandled rejection");
+  } finally {
+    process.removeListener("unhandledRejection", onRejection);
+    await bridge.stop();
+  }
+});
+
+test("chair bridge: a pre-delivery throw (isIdle) becomes a 500, not a hang/crash", async () => {
+  // isIdle() is reached at the routing step (auto mode), BEFORE sendUserMessage
+  // and outside the send try/catch. If it throws, handlePrompt's discarded
+  // promise rejects — the route-seam .catch must answer the phone with a 500
+  // instead of leaking an unhandled rejection or hanging the request.
+  const { agent, calls } = fakeAgent({
+    isIdle: () => {
+      throw new Error("isIdle blew up");
+    },
+  });
+  const bridge = makeBridge(agent);
+  const { url, pairingUrl } = await bridge.start();
+  const token = pairingUrl.split("#t=")[1];
+  const auth = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+
+  const rejections: unknown[] = [];
+  const onRejection = (reason: unknown) => rejections.push(reason);
+  process.on("unhandledRejection", onRejection);
+  try {
+    const res = await fetch(`${url}api/prompt`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ text: "look into the van" }),
+    });
+    assert.equal(res.status, 500);
+    // nothing was ever delivered (the throw happened before sendUserMessage)
+    assert.equal(calls.sent.length, 0);
+    await new Promise((r) => setTimeout(r, 50));
+    assert.deepEqual(rejections, [], "the route-seam catch must handle the reject, not leak it");
+  } finally {
+    process.removeListener("unhandledRejection", onRejection);
+    await bridge.stop();
+  }
+});

--- a/test/unit/chair-extension.test.ts
+++ b/test/unit/chair-extension.test.ts
@@ -41,7 +41,7 @@ function fakePi(opts: { throwOnSend?: boolean } = {}) {
 }
 
 function fakeCtx(dir: string, overrides: Record<string, unknown> = {}) {
-  const widgets = new Map<string, string[] | undefined>();
+  const widgets = new Map<string, unknown[] | undefined>();
   const notices: string[] = [];
   const ctx = {
     mode: "tui",
@@ -58,8 +58,18 @@ function fakeCtx(dir: string, overrides: Record<string, unknown> = {}) {
       notify: (text: string) => {
         notices.push(text);
       },
-      setWidget: (key: string, lines: string[] | undefined) => {
-        widgets.set(key, lines);
+      // Mirror pi's InteractiveMode: a string[] is kept as-is; a component
+      // FACTORY (used for content that must exceed pi's 10-line array cap — e.g.
+      // the pairing QR) is rendered and we keep its `children` array, so the
+      // line-count assertions below still measure the number of rendered lines.
+      // undefined clears the widget.
+      setWidget: (key: string, content: unknown) => {
+        widgets.set(
+          key,
+          typeof content === "function"
+            ? (content as (t: unknown, th: unknown) => { children: unknown[] })(undefined, undefined).children
+            : (content as unknown[] | undefined),
+        );
       },
     },
     ...overrides,


### PR DESCRIPTION
## What & why

Two `/chair` robustness fixes.

### 1. Unhandled-rejection guard (plan 007 — the original fix)

The `/chair` bridge is an HTTP server running **inside the live agent process**. `POST /api/prompt` discarded the promise returned by `handlePrompt`, and `handlePrompt`'s tail called `this.agent.onRemotePrompt?.()` **outside any try/catch**. That hook routes into pi's `ctx.ui.notify()` (wrapped in try/catch elsewhere — evidence it *can* throw). If it threw, the discarded promise rejected **unhandled**, which on Node ≥15 **terminates the process** — crashing the whole live investigation session and hanging the phone's request.

**Fix — close both escape paths for the discarded promise:**
- **Route seam** — `handlePrompt(req,res)` now has a terminal `.catch()` that answers the phone `500` (inner try/catch swallows a "headers already sent" throw). Handles a throw *before* delivery (e.g. a throwing `isIdle()`).
- **Post-delivery hook** — `this.agent.onRemotePrompt?.()` is wrapped in try/catch, so a UI-notify failure *after* delivery can't reject the promise; the request still returns `202`.

### 2. Pairing-QR widget no longer truncated (follow-on fix)

The TUI pairing widget rendered `... (widget truncated)` mid-QR (see below), leaving the QR **unscannable** and dropping the pairing URL line under it. Cause: pi's `InteractiveMode` caps **string-array** widgets at `MAX_WIDGET_LINES = 10` and appends the truncation notice — but a scannable QR is ~13–21 rows plus the header/URL lines.

**Fix:** `showQr()` now passes `setWidget` a **component factory** (`() => Container` of `Text` lines) instead of a `string[]`. pi's factory path is **exempt** from the array line-cap, so the full QR + pairing line render as a pinned widget. It mirrors pi's own array rendering (`new Text(line, 1, 0)`), so appearance is identical — just no longer chopped. `MAX_WIDGET_LINES` is pi's (pinned `0.80.3`), so we can't raise it — the factory overload is the supported escape hatch.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ (unit suite green)
- `npm run build` — ✅
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ 171/171 (chair widget is TUI-only; e2e unaffected)
- `node --test --import tsx test/unit/chair-bridge.test.ts` — ✅ 12/12, incl. the two guard regressions:
  - throwing `onRemotePrompt` → **202**, and a `process.on("unhandledRejection")` listener captures **nothing** (proves no rejection escapes to kill the process)
  - pre-delivery `isIdle` throw → **500**
- **Live:** the QR now renders in full in the TUI (`/chair`), untruncated and scannable.

## Deviations / scope note

Plan 007 scoped `src/chair/bridge.ts`. The QR-widget truncation was a separate, user-reported TUI bug on the same feature, folded into this PR (touches `src/extension/chair.ts`) as a companion `/chair` fix rather than a standalone PR.

## Scope

In-scope: `src/chair/bridge.ts`, `test/unit/chair-bridge.test.ts` (guard), `src/extension/chair.ts` (QR widget).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling on the remote prompt HTTP path inside the live agent process; behavior is defensive (500/202 instead of crash) with targeted unit coverage.
> 
> **Overview**
> Hardens **`POST /api/prompt`** on the in-process chair HTTP bridge so failures cannot take down the live desk session, and fixes the TUI pairing QR so it renders in full.
> 
> **Bridge:** The prompt route now attaches a **`.catch()`** on `handlePrompt` so a rejected async handler returns **500** instead of an unhandled rejection (which can exit Node ≥15). **`onRemotePrompt`** is wrapped in **try/catch** so a throwing desk UI notify after a successful **`sendUserMessage`** still returns **202**.
> 
> **Extension:** **`showQr()`** registers the widget via a **component factory** (`Container` + `Text` lines) instead of a **`string[]`**, avoiding pi’s **10-line array widget cap** that was truncating the QR and pairing URL.
> 
> **Tests:** Two bridge regressions (throwing hook → 202, throwing **`isIdle`** → 500); extension test fake **`setWidget`** invokes factories so line-count checks still pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28125cccb948e97339b07645d5db2eb87a1fd4a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->