### PR TITLE
Hoist trigger-eval store snapshot + status map out of per-record loop

### DIFF
--- a/src/signals/triggers.ts
+++ b/src/signals/triggers.ts
@@ -308,7 +308,18 @@ export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
   // match is intrinsically interesting), it just isn't attributed to a dead line.
   const targets = opts.targets.filter((t) => !isTargetClosed(t));
   const out: OvercastRecord[] = [];
-  const seen = () => [...opts.existing, ...(opts.pending ?? []), ...out];
+  // Hoisted once per evaluation (NOT per candidate): the store copy and the
+  // finding-status map are O(N); rebuilding them per matching record made a
+  // scan --pull pass O(F × N). Freshly pushed findings are appended to `all`
+  // and applied to `statusMap` so dedup still sees same-pass findings.
+  const all: OvercastRecord[] = [...opts.existing, ...(opts.pending ?? [])];
+  const statusMap = findingStatusMap(all);
+  const pushFinding = (rec: OvercastRecord) => {
+    out.push(rec);
+    all.push(rec);
+    const p = rec.payload as Record<string, unknown>;
+    if (typeof p?.status === "string") statusMap.set(rec.id, p.status);
+  };
 
   for (const rec of opts.fresh) {
     // only true evidence records are trigger SOURCES — never operational/meta
@@ -327,10 +338,8 @@ export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
     for (const target of TEXT_TARGET_VERBS.has(rec.verb) ? targets : []) {
       if (target.kind === "image") continue;
       if (!targetMatchesEvidence(target.value, haystack)) continue;
-      const all = seen();
-      const statusMap = findingStatusMap(all);
       if (hasEquivalentFinding(all, statusMap, { kind: "text-target", target: target.value, sourceRecord: rec, dismissedBlocks: mode === "suggest" })) continue;
-      out.push(
+      pushFinding(
         makeFinding({
           text: `Automated match for target '${target.value}' in ${rec.verb} record ${rec.id}`,
           target: target.value,
@@ -352,11 +361,9 @@ export function evaluateTriggers(opts: EvaluateTriggerOpts): OvercastRecord[] {
       obj(rec.payload)?.reference as string | undefined,
       sig.matched,
     ]);
-    const all = seen();
-    const statusMap = findingStatusMap(all);
     if (hasEquivalentFinding(all, statusMap, { kind: sig.kind, target: target?.value ?? "", sourceRecord: rec, dismissedBlocks: true })) continue;
     const high = highBandFor(sig.kind, thresholds);
-    out.push(
+    pushFinding(
       makeFinding({
         text: suggestionText(rec, sig, target),
         target: target?.value ?? "",

--- a/test/unit/triggers.test.ts
+++ b/test/unit/triggers.test.ts
@@ -168,6 +168,16 @@ test("evaluateTriggers: two senses on the same clip fold to one text lead (share
   assert.equal(evaluateTriggers({ fresh: [listen], existing: first, targets: [nameTarget], policy: SUGGEST }).length, 0);
 });
 
+test("evaluateTriggers: two SAME-PASS senses on one clip fold to a single lead (incremental dedup)", () => {
+  // both records arrive in ONE evaluation batch (a single `fresh` array): the
+  // second candidate must see the first's freshly PUSHED finding via the hoisted
+  // all/statusMap — the invariant the O(F×N)→O(N) hoist depends on. Shared media.ref.
+  const watch = makeRecord({ verb: "watch", format: "json", payload: { content: "acme handle appears" }, media: { ref: "c.mp4" } });
+  const listen = makeRecord({ verb: "listen", format: "json", payload: { transcript: "someone says acme handle" }, media: { ref: "c.mp4" } });
+  const out = evaluateTriggers({ fresh: [watch, listen], existing: [], targets: [nameTarget], policy: SUGGEST });
+  assert.equal(out.length, 1);
+});
+
 test("evaluateTriggers: CLOSED lines accumulate no new suggestions (text + score)", () => {
   const closedName: TargetEntry = { ...nameTarget, status: "dead-end" };
   const closedImg: TargetEntry = { ...imageTarget, status: "answered" };


### PR DESCRIPTION
## What & why (performance)

`evaluateTriggers` runs after every verb persist. For each matching fresh record it rebuilt the **entire** store snapshot (`seen()` — an O(N) spread copy of `existing + pending + out`) and the `findingStatusMap` (another O(N) walk). On a `scan --pull` or `monitor` pass persisting **F** records into a case of **N** records, that's **O(F × N)** array copies + map rebuilds — the kind of thing that turns an interactive command into a stall as a case grows.

**Fix (pure hoist + incremental update — behavior-identical):**
- Build the store snapshot `all = [...existing, ...pending]` and `statusMap = findingStatusMap(all)` **once** at the top of `evaluateTriggers`.
- A `pushFinding(rec)` helper appends to `out` **and** `all`, and sets `statusMap.set(rec.id, status)` when the finding carries a status — so same-pass dedup still sees findings pushed earlier in the same evaluation.
- Both `makeFinding(...)` call sites (text-target and suggested-signal) now go through `pushFinding`.

**Correctness:** `findingStatusMap` keys a record by `payload.finding_id ?? rec.id` (`record.ts`). Findings emitted here come only from `makeFinding` — root findings (status present, no `finding_id`) — so the incremental `statusMap.set(rec.id, status)` reproduces exactly what a full rebuild would compute, and `all` stays content/order-identical to the old `seen()`. The hot path is now **O(N)**.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **788 pass / 0 fail**
- `node --test --import tsx test/unit/triggers.test.ts` — ✅ 23/23 (**all 17 pre-existing trigger tests pass unchanged** — behavior preserved)
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- Done-criteria greps — ✅ no `const seen = ()` in `triggers.ts`; `findingStatusMap` invoked exactly once inside `evaluateTriggers`

Added one additive regression test — two same-pass senses over one clip fold to a single lead — which pins the incremental-visibility invariant the optimization relies on (the pre-existing "two senses" test only covered the cross-pass case).

## Deviations

None.

## Scope

In-scope: `src/signals/triggers.ts` (function body), `test/unit/triggers.test.ts` (additive).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with behavior preserved; risk is limited to dedup edge cases, covered by existing and new trigger unit tests.
> 
> **Overview**
> **`evaluateTriggers`** no longer rebuilds the full store snapshot and **`findingStatusMap`** on every matching fresh record. It builds **`all`** and **`statusMap`** once per evaluation and routes new findings through **`pushFinding`**, which keeps **`all`** / **`statusMap`** in sync so same-pass dedup still works.
> 
> This cuts trigger evaluation from **O(F × N)** to **O(N)** on bulk persist passes (e.g. **`scan --pull`**) without changing trigger or dedup semantics.
> 
> Adds a unit test: **watch + listen** on the same clip in one **`fresh`** batch must fold to a single text lead (incremental dedup invariant).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5cdde34380172bb4d290c4b752efa3504e179da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->