### PR TITLE
Memoize local-grep document extraction + tokenization by record id

### DIFF
--- a/src/providers/memory/local.ts
+++ b/src/providers/memory/local.ts
@@ -22,11 +22,9 @@ function tokenize(s: string): string[] {
     .filter((t) => t.length > 1);
 }
 
-/** TF-style keyword score of a query against a document's tokens. */
-function score(queryTokens: string[], docTokens: string[]): number {
+/** TF-style keyword score of a query against a document's precomputed token counts. */
+function score(queryTokens: string[], counts: Map<string, number>): number {
   if (queryTokens.length === 0) return 0;
-  const counts = new Map<string, number>();
-  for (const t of docTokens) counts.set(t, (counts.get(t) ?? 0) + 1);
   let s = 0;
   for (const qt of queryTokens) {
     const c = counts.get(qt) ?? 0;
@@ -46,6 +44,41 @@ function snippet(text: string, queryTokens: string[], width = 200): string {
   if (idx < 0) return text.slice(0, width).replace(/\s+/g, " ").trim();
   const start = Math.max(0, idx - width / 4);
   return text.slice(start, start + width).replace(/\s+/g, " ").trim();
+}
+
+interface FieldEntry {
+  path: string;
+  text: string; // the exact string previously built inline in query()
+  counts: Map<string, number>; // precomputed token counts for score()
+}
+interface DocEntry {
+  fields: FieldEntry[];
+}
+
+// Records are immutable after persist (append-only store; ids are unique per
+// write), so extraction+tokenization is memoizable by record id. Bounded so a
+// months-long TUI session over many cases can't grow without limit; eviction is
+// insertion-order (Map preserves it) — effectively FIFO, fine for this shape.
+const DOC_CACHE_MAX = 20_000;
+const docCache = new Map<string, DocEntry | null>();
+
+function docEntry(rec: OvercastRecord): DocEntry | null {
+  const hit = docCache.get(rec.id);
+  if (hit !== undefined) return hit;
+  const doc = indexableDocument(rec);
+  const entry: DocEntry | null = doc
+    ? {
+        fields: doc.fields.map((f) => {
+          const text = `${rec.verb} ${f.path}\n${f.text}\n${rec.media?.ref ?? ""}`;
+          const counts = new Map<string, number>();
+          for (const t of tokenize(text)) counts.set(t, (counts.get(t) ?? 0) + 1);
+          return { path: f.path, text, counts };
+        }),
+      }
+    : null;
+  docCache.set(rec.id, entry);
+  if (docCache.size > DOC_CACHE_MAX) docCache.delete(docCache.keys().next().value!);
+  return entry;
 }
 
 export class LocalMemoryProvider implements MemoryProvider {
@@ -89,16 +122,15 @@ export class LocalMemoryProvider implements MemoryProvider {
     }
     const scored: Passage[] = [];
     for (const rec of records) {
-      const doc = indexableDocument(rec);
-      if (!doc) continue;
-      for (const field of doc.fields) {
-        const text = `${rec.verb} ${field.path}\n${field.text}\n${rec.media?.ref ?? ""}`;
-        const s = score(qTokens, tokenize(text));
+      const entry = docEntry(rec);
+      if (!entry) continue;
+      for (const field of entry.fields) {
+        const s = score(qTokens, field.counts);
         if (s <= 0) continue;
         scored.push({
           recordId: rec.id,
           at: rec.media?.at,
-          text: snippet(text, qTokens),
+          text: snippet(field.text, qTokens),
           score: s,
           verb: rec.verb,
           field: field.path,

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -44,6 +44,42 @@ test("indexable field policy prefers verb-specific fields, including notes", () 
   assert.match(fields.map((f) => f.text).join("\n"), /white van/);
 });
 
+test("local memory memo: repeated identical queries return byte-identical passages (cache-hit path)", async () => {
+  await withCase((c) => {
+    const mem = new LocalMemoryProvider(c);
+    const first = mem.query("white van docks", { limit: 10 });
+    const second = mem.query("white van docks", { limit: 10 });
+    // determinism through the id-keyed document memo: same scores, snippets, order.
+    assert.ok(first.length > 0);
+    assert.deepEqual(second, first);
+    // a fresh provider instance (real call site constructs one per resolveMemory)
+    // must see the SAME result off the module-level memo.
+    const third = new LocalMemoryProvider(c).query("white van docks", { limit: 10 });
+    assert.deepEqual(third, first);
+  });
+});
+
+test("local memory memo: a newly written record is visible on the next query (no stale set)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-memo-fresh-"));
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "a quiet street corner" }, media: { ref: "s.mp4" } }));
+    const mem = new LocalMemoryProvider(c);
+    // prime the memo; the marker is absent so far.
+    assert.deepEqual(mem.query("HELICOPTER_MARKER", { limit: 10 }), []);
+    c.writeRecord(makeRecord({ verb: "watch", payload: { content: "HELICOPTER_MARKER overhead at dusk" }, media: { ref: "h.mp4" } }));
+    // record LIST comes from case_.records() (uncached here), so the new record
+    // is picked up and freshly memoized by its own id.
+    const hits = mem.query("HELICOPTER_MARKER", { limit: 10 });
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].verb, "watch");
+    assert.match(hits[0].text, /HELICOPTER_MARKER/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("case memory excludes operational/read/error records but indexes compact face summaries and crop evidence", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-memory-filter-"));
   try {


### PR DESCRIPTION
## What & why (performance)

Every `ask`, `brief`, and memory query re-ran, over **every record in the case**, `indexableDocument()` (a payload walk + JSON stringify) and `tokenize()` (lowercase + regex split) — including megabytes of `watch`/`listen` transcripts. The records are immutable after persist, so this is pure repeated work: on a large case, interactive reads slow to a crawl.

**Fix:** a bounded module-level `docCache` keyed by **record id** caches, per record, the extracted per-field `{ text, precomputed token counts }`. `score()` now takes the precomputed token-count Map instead of re-counting a token array each query, and `query()` pulls memoized entries via `docEntry(rec)` instead of re-walking/re-tokenizing.

**Why it's correct:**
- Record ids are **unique per write** (append-only JSONL store) → no key collisions.
- Payloads are **immutable after persist** → a cached entry never goes stale. Verified: the only `.payload =` assignment in `src/` mutates a freshly-created record *inside a provider before persist*, never a record read back from the store.
- The cached `text` string is **byte-identical** to the old inline build (`${verb} ${path}\n${field.text}\n${media.ref}`), so `snippet()` gets the same input → scores and snippets are unchanged.
- `null` (no indexable document) is memoized too, so misses don't re-walk.
- Bounded at `DOC_CACHE_MAX = 20_000` with insertion-order (FIFO) eviction, so a months-long TUI session across many cases can't grow without limit.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **790 pass / 0 fail** (+2 new tests; existing read/ask tests byte-identical green)
- `node --test --import tsx test/unit/read.test.ts` — ✅ 56/56 (54 existing unchanged + 2 new); scores/snippets/ordering unchanged
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- `grep -n 'docCache' src/providers/memory/local.ts` — ✅ bounded memo present (declaration, get, set, eviction)

New tests: cache-hit determinism (two identical queries + a fresh provider instance all deep-equal) and post-write freshness (a newly written record appears on the next query — proves id-keying never serves a stale set).

## Deviations

None.

## Scope

In-scope: `src/providers/memory/local.ts`, `test/unit/read.test.ts` (additive). `fields.ts` stays pure; qmd/scoring/snippet/dedup untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only caching in the local keyword provider; search semantics are preserved by identical field text and tests for determinism and post-write freshness.
> 
> **Overview**
> **Local memory queries** no longer re-run `indexableDocument()` and per-field tokenization on every record for each `ask`, `brief`, or search call. A **module-level, bounded cache** (`docCache`, max 20k entries, FIFO eviction) stores per-record field text and **precomputed token counts** keyed by record id; `query()` uses `docEntry(rec)` and `score()` reads those maps instead of rebuilding and re-counting each time.
> 
> **Scoring behavior is unchanged** in intent: the cached field string matches the previous inline `${verb} ${path}\n${field.text}\n${media.ref}` shape, so snippets and ranking should stay the same on cache hits.
> 
> **Tests** add coverage for identical repeated queries (including a fresh `LocalMemoryProvider` sharing the module cache) and for **new records** appearing on the next query after append-only writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1a0d75acf8d112831e294142fbac2f7a914368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->