### PR TITLE
Redact secrets from provider stderr before it persists into error fields

### DIFF
--- a/src/providers/memory/qmd.ts
+++ b/src/providers/memory/qmd.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import type { Case } from "../../case.js";
 import { memoryRecords, type OvercastRecord } from "../../record.js";
 import { execCapture } from "../exec.js";
+import { redactSecrets } from "../../env.js";
 import { tokenizeCommand } from "../sources/index.js";
 import { indexableDocument, type IndexableDocument } from "./fields.js";
 import { parseSince } from "./local.js";
@@ -276,7 +277,7 @@ export class QmdMemoryProvider implements MemoryProvider {
         stderr: (e as Error).message,
       }));
       if (res.code !== 0) {
-        const error = res.stderr || res.stdout || `qmd exited ${res.code}`;
+        const error = redactSecrets(res.stderr || res.stdout || `qmd exited ${res.code}`);
         this.writeManifest({ ...manifest, state: "error", error, updated: new Date().toISOString() });
         return { ...(await this.status()), state: "error", error };
       }
@@ -290,7 +291,7 @@ export class QmdMemoryProvider implements MemoryProvider {
         stderr: (e as Error).message,
       }));
       if (res.code !== 0) {
-        const error = res.stderr || res.stdout || `qmd embed exited ${res.code}`;
+        const error = redactSecrets(res.stderr || res.stdout || `qmd embed exited ${res.code}`);
         this.writeManifest({ ...manifest, state: "error", error, updated: new Date().toISOString() });
         return { ...(await this.status()), state: "error", error };
       }

--- a/src/providers/run.ts
+++ b/src/providers/run.ts
@@ -5,6 +5,7 @@
 // (providers/tinycloud/*) because they emit tinycloud envelopes, not records.
 
 import { makeRecord, type OvercastRecord } from "../record.js";
+import { redactSecrets } from "../env.js";
 import { execCapture, renderCommand, parseFirstJson } from "./exec.js";
 import type { ProviderDescriptor } from "../profile.js";
 
@@ -110,7 +111,7 @@ export async function runExecProvider(
       error:
         res.code === 0
           ? `provider produced no JSON record`
-          : `provider exited ${res.code}: ${res.stderr.trim().slice(0, 400)}`,
+          : `provider exited ${res.code}: ${redactSecrets(res.stderr.trim().slice(0, 400))}`,
       state: res.code === 13 ? "needs_credentials" : "error",
     });
   }

--- a/src/providers/sources/index.ts
+++ b/src/providers/sources/index.ts
@@ -13,6 +13,7 @@ import { dirname, extname, join } from "node:path";
 import { closeSync, existsSync, openSync, readFileSync, readSync, renameSync, statSync } from "node:fs";
 import { execCapture, parseFirstJson } from "../exec.js";
 import { makeRecord, type OvercastRecord } from "../../record.js";
+import { redactSecrets } from "../../env.js";
 import { shippedPath } from "../../pkg.js";
 
 /** Path to a shipped source-provider script — resolves the package root (dev) or
@@ -218,7 +219,7 @@ export async function enumerateSource(
         verb: "scan",
         format: "json",
         payload: { source: desc.type },
-        error: `source ${desc.type} enumerate failed (exit ${res.code}): ${res.stderr.trim().slice(0, 300)}`,
+        error: `source ${desc.type} enumerate failed (exit ${res.code}): ${redactSecrets(res.stderr.trim().slice(0, 300))}`,
         state: res.code === 13 ? "needs_credentials" : "error",
       }),
     ];
@@ -315,7 +316,7 @@ export async function fetchSource(
       verb: "capture",
       format: "json",
       payload: { url: opts.url, source: desc.type },
-      error: `source ${desc.type} fetch failed (exit ${res.code}): ${res.stderr.trim().slice(0, 300)}`,
+      error: `source ${desc.type} fetch failed (exit ${res.code}): ${redactSecrets(res.stderr.trim().slice(0, 300))}`,
       state: res.code === 13 ? "needs_credentials" : "error",
     });
   }

--- a/src/providers/tinycloud/envelope.ts
+++ b/src/providers/tinycloud/envelope.ts
@@ -13,6 +13,7 @@
 //   needs_download(3) error(1)   — (exit codes in parens).
 
 import { execCapture, parseFirstJson } from "../exec.js";
+import { redactSecrets } from "../../env.js";
 import { tokenizeCommand } from "../sources/index.js";
 import type { RecordState } from "../../record.js";
 
@@ -229,7 +230,7 @@ export async function runTinycloud(
           ? "tinycloud produced no JSON output"
           : credGap
             ? "tinycloud needs credentials (set CLOUDGLUE_API_KEY or run `tinycloud setup cloudglue`)"
-            : `tinycloud exited ${res.code}: ${res.stderr.trim().slice(0, 400)}`,
+            : `tinycloud exited ${res.code}: ${redactSecrets(res.stderr.trim().slice(0, 400))}`,
     };
   }
 
@@ -251,7 +252,7 @@ export async function runTinycloud(
     error =
       envError ||
       (res.code !== 0
-        ? `tinycloud exited ${res.code}: ${res.stderr.trim().slice(0, 400)}`
+        ? `tinycloud exited ${res.code}: ${redactSecrets(res.stderr.trim().slice(0, 400))}`
         : "tinycloud reported a failure");
   } else if (state === "needs_credentials") {
     error =

--- a/src/providers/tinycloud/listen.ts
+++ b/src/providers/tinycloud/listen.ts
@@ -3,6 +3,7 @@
 // the exec boundary. Swap to a local whisper via http/in-proc for offline use.
 
 import { makeRecord, type OvercastRecord } from "../../record.js";
+import { redactSecrets } from "../../env.js";
 import { execCapture, renderCommand, parseFirstJson } from "../exec.js";
 
 const DEFAULT_RUN = "tinycloud watch {{input}} --speech-only --json";
@@ -164,7 +165,7 @@ export async function runListen(
           ? "tinycloud listen produced no JSON output"
           : res.code === 13
             ? "tinycloud listen needs credentials (exit 13 — set CLOUDGLUE_API_KEY)"
-            : `tinycloud listen exited ${res.code}: ${res.stderr.trim().slice(0, 500)}`,
+            : `tinycloud listen exited ${res.code}: ${redactSecrets(res.stderr.trim().slice(0, 500))}`,
       // exit 13 = missing creds, matching runExecProvider + the source providers
       state: res.code === 13 ? "needs_credentials" : "error",
     });
@@ -221,7 +222,7 @@ export async function runListen(
         envError ||
         (res.code === 13
           ? "tinycloud listen needs credentials (exit 13 — set CLOUDGLUE_API_KEY)"
-          : `tinycloud listen failed (exit ${res.code}): ${res.stderr.trim().slice(0, 500)}`),
+          : `tinycloud listen failed (exit ${res.code}): ${redactSecrets(res.stderr.trim().slice(0, 500))}`),
       state: res.code === 13 ? "needs_credentials" : "error",
     });
   }

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { makeRecord, type OvercastRecord } from "../../record.js";
+import { redactSecrets } from "../../env.js";
 import {
   execCapture,
   renderCommand,
@@ -203,7 +204,7 @@ export async function runWatch(
           ? "tinycloud watch produced no JSON output"
           : res.code === 13
             ? "tinycloud watch needs credentials (exit 13 — set CLOUDGLUE_API_KEY)"
-            : `tinycloud watch exited ${res.code}: ${res.stderr.trim().slice(0, 500)}`,
+            : `tinycloud watch exited ${res.code}: ${redactSecrets(res.stderr.trim().slice(0, 500))}`,
       // exit 13 = missing creds, matching runExecProvider + the source providers
       state: res.code === 13 ? "needs_credentials" : "error",
     });
@@ -235,7 +236,7 @@ export async function runWatch(
       meta: { provider: "tinycloud", model: "cloudglue" },
       error:
         envError ||
-        `tinycloud watch failed (exit ${res.code}): ${res.stderr.trim().slice(0, 500)}`,
+        `tinycloud watch failed (exit ${res.code}): ${redactSecrets(res.stderr.trim().slice(0, 500))}`,
       // exit 13 is the cred-gap convention even when JSON parsed — classify it as
       // needs_credentials (not a hard error), matching the no-JSON path + runExecProvider.
       state: res.code === 13 ? "needs_credentials" : "error",

--- a/test/unit/provider-contract.test.ts
+++ b/test/unit/provider-contract.test.ts
@@ -6,8 +6,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { runExecProvider } from "../../src/providers/run.ts";
+import { enumerateSource } from "../../src/providers/sources/index.ts";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const P = (rel: string) => join(ROOT, "examples/providers", rel);
@@ -76,5 +80,35 @@ test("no provider crashes the interpreter on a value-less trailing flag (set -u 
     if (r.out.trim() && !missingDeps(r.err)) {
       assert.doesNotThrow(() => JSON.parse(r.out.trim()), `${p.file}: stdout on a bad flag must be valid JSON (got: ${r.out.slice(0, 120)})`);
     }
+  }
+});
+
+// Security (plan 011): provider stderr flows into the persisted record `error`
+// field, and the at-rest store (.overcast/records/*.jsonl) is written verbatim.
+// A provider that echoes a credentialed URL / token to stderr must NOT land it on
+// disk — the exec boundary redacts the stderr slice before it reaches the record.
+test("provider stderr carrying a secret is redacted before it reaches the persisted error field", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-stderr-redact-"));
+  try {
+    // A fixture provider that leaks an Apify-shaped token to stderr, then fails
+    // with no JSON on stdout (→ an error record via runExecProvider/enumerateSource).
+    const SECRET = "apify_api_0123456789abcdefghij"; // matches SECRET_VALUE_RE in src/env.ts
+    const script = join(dir, "leak.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\necho "auth error: token=${SECRET} rejected" 1>&2\nexit 1\n`);
+
+    // runExecProvider — generic exec sense provider (src/providers/run.ts)
+    const rec = await runExecProvider("see", `bash ${script}`, "evidence.jpg");
+    assert.equal(rec.state, "error", "non-zero exit with no JSON record → error state");
+    assert.match(rec.error ?? "", /^provider exited 1:/, "error prefix unchanged (characterization)");
+    assert.ok(rec.error?.includes("[REDACTED]"), `error must be redacted (got: ${rec.error})`);
+    assert.ok(!rec.error?.includes(SECRET), `raw secret must not persist (got: ${rec.error})`);
+
+    // enumerateSource — source provider (src/providers/sources/index.ts)
+    const [scanRec] = await enumerateSource({ type: "test", base: ["bash", script] }, {});
+    assert.equal(scanRec.state, "error");
+    assert.ok(scanRec.error?.includes("[REDACTED]"), `enumerate error must be redacted (got: ${scanRec.error})`);
+    assert.ok(!scanRec.error?.includes(SECRET), `enumerate must not persist raw secret (got: ${scanRec.error})`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## What & why (security)

Provider **stderr** flowed verbatim into persisted record `error` fields in `.overcast/records/*.jsonl`. A provider that echoes a credentialed URL or token to stderr (a common failure mode) would land that secret **on disk** — in case directories that users share, sync, or archive as evidence. Redacting at the exec boundary closes the highest-likelihood leak path without touching evidence payloads (where over-redaction would risk corrupting legitimate content).

**Fix:** apply the existing `redactSecrets()` (`src/env.ts`, unchanged) to the bounded stderr slice at **every** `res.stderr → record.error` site the Step-1 inventory grep surfaced:
- `src/providers/run.ts` (generic exec provider)
- `src/providers/sources/index.ts` (enumerate + fetch)
- `src/providers/tinycloud/envelope.ts` (both outcome-error branches)
- `src/providers/tinycloud/listen.ts`, `watch.ts` (record errors)
- `src/providers/memory/qmd.ts` (rebuild/embed errors — redacting at source also cleans the copy `case.ts` mirrors into `payload.memory_index`, with no payload-redaction logic added)

Slice-before-redact order is preserved. `env.ts` patterns are **not** widened (separate concern). Non-record stderr uses (the `exec.ts` capture util, the two `stderr:` transport fields on `TinycloudOutcome` — verified no caller reads them, and the monitor status line) are left alone.

## ⚠️ Follow-up flagged (out of scope)

Two genuine `stderr → PAYLOAD` sites exist in `src/verbs/setup.ts:382/399` (the `provider` verb's `describe`/`init` ops write stdout+stderr verbatim into a payload field). Payload redaction was explicitly **fenced out** of this plan (over-redaction risk), so these are **left untouched and flagged** per the plan's STOP directive — they need a separate decision. These are operational `provider` records (excluded from ask/brief memory) but still written at-rest.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **793 pass / 0 fail** (+1 regression test: a stderr containing a secret → persisted error is redacted)
- `node --test --import tsx test/unit/provider-contract.test.ts` — ✅ 3/3
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- Done-criteria grep — ✅ `rg 'res\.stderr' src/providers/ | rg -v redactSecrets` shows only the two verified non-record transport assignments; no record-bound `res.stderr` remains unredacted
- STOP check — ✅ within `src/providers/`, no payload field carries raw stderr

## Deviations

Redacted `listen.ts`/`watch.ts`/`qmd.ts` beyond the plan's explicitly-named `envelope.ts` candidate — all are `res.stderr → record.error` sites the Step-1 grep surfaced, within the plan's "any additional site" allowance and required by the done-criteria grep.

## Scope

In-scope: `src/providers/run.ts`, `src/providers/sources/index.ts`, `src/providers/tinycloud/{envelope,listen,watch}.ts`, `src/providers/memory/qmd.ts`, `test/unit/provider-contract.test.ts`. `persist.ts`/`Case.writeRecord`/`env.ts` untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted string redaction at error-message boundaries only; no changes to auth, persistence, or secret-detection patterns. Residual risk: stderr copied into payloads elsewhere (e.g. setup verb) remains out of scope.
> 
> **Overview**
> **Provider stderr is now scrubbed before it becomes a persisted record `error`.** Every exec boundary that copied a bounded `stderr` slice into `record.error` (or qmd manifest errors) now runs it through the existing `redactSecrets()` helper from `env.ts`, so tokens echoed on failure do not land in `.overcast/records/*.jsonl`.
> 
> Coverage includes the generic exec runner, source enumerate/fetch, tinycloud envelope/listen/watch, and qmd index/embed failures. Slice-then-redact order is unchanged; evidence payloads are untouched.
> 
> A unit test asserts that a fixture provider leaking an Apify-shaped token to stderr yields `[REDACTED]` in errors from both `runExecProvider` and `enumerateSource`, with the raw secret absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4f58d77f67ab7ffed765f2f2cd6c992baaf693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->