### PR TITLE
Verify grid cells: null a dropped frame instead of shifting the timestamp map

### DIFF
--- a/src/media/ffmpeg.ts
+++ b/src/media/ffmpeg.ts
@@ -333,6 +333,7 @@ export async function contactSheet(
   const out = opts.outPath ?? join(outDir, `${safeName(base)}_grid_${n}_${sig}.png`);
   ensureDir(dirname(out)); // a caller-supplied nested --out needs its parent created first
   const work = mkdtempSync(join(tmpdir(), "oc-grid-"));
+  const missing = new Set<number>(); // sample indices whose frame never materialized
   try {
     const scalePad =
       `scale=${cellWidth}:${cellHeight}:force_original_aspect_ratio=decrease,` +
@@ -355,17 +356,28 @@ export async function contactSheet(
         ["-y", "-ss", String(seconds[i]), "-i", input, "-frames:v", "1", "-q:v", "3", "-vf", vf, cell],
         { maxBuffer: 16 * 1024 * 1024, timeout: FFMPEG_MEDIA_TIMEOUT_MS },
       );
+      // ffmpeg can exit 0 with NO frame written when a seek lands at/past the last
+      // decodable frame (near-EOF on some containers). A gap would truncate the
+      // image2 sequence in the tile pass below and SHIFT every later cell off its
+      // mapped timestamp — substitute the filler and null the mapping (invariant:
+      // reject/blank rather than lie) instead of silently mislabeling cells.
+      if (!existsSync(cell)) missing.add(i);
     }
     // pad the last row so `tile` receives an exact cols×rows sequence — the
     // partial-tile-at-EOF behavior varies across ffmpeg versions; a full grid is
-    // deterministic. Fillers reuse the tile background color.
-    if (n < slots) {
+    // deterministic. Fillers reuse the tile background color. Also backfill any
+    // sampled cell whose frame never materialized (`missing`) so the image2
+    // sequence stays gapless and no later cell shifts into a dropped slot.
+    if (n < slots || missing.size) {
       const filler = join(work, "filler.jpg");
       await execFileP(
         FFMPEG_PATH,
         ["-y", "-f", "lavfi", "-i", `color=c=0x101418:s=${cellWidth}x${cellHeight}`, "-frames:v", "1", filler],
         { maxBuffer: 8 * 1024 * 1024, timeout: FFMPEG_MEDIA_TIMEOUT_MS },
       );
+      for (const i of missing) {
+        copyFileSync(filler, join(work, `cell_${String(i + 1).padStart(3, "0")}.jpg`));
+      }
       for (let i = n; i < slots; i++) {
         copyFileSync(filler, join(work, `cell_${String(i + 1).padStart(3, "0")}.jpg`));
       }
@@ -383,11 +395,12 @@ export async function contactSheet(
   }
 
   // map EVERY tile position (cols×rows), not just the sampled ones — the trailing
-  // blank fillers get at:null, so a cell number read off the montage always
-  // resolves (to a timestamp, or to null = blank) instead of falling off the map.
+  // blank fillers AND any dropped (missing) sample get at:null, so a cell number
+  // read off the montage always resolves (to a timestamp, or to null = blank)
+  // instead of pointing at a shifted/wrong source moment.
   const cells: GridCell[] = Array.from({ length: slots }, (_, i) => ({
     n: i + 1,
-    at: i < n ? seconds[i] : null,
+    at: i < n && !missing.has(i) ? seconds[i] : null,
   }));
   return { output: out, cells, cols, rows, cellWidth, cellHeight, labeled };
 }

--- a/test/unit/ffmpeg.test.ts
+++ b/test/unit/ffmpeg.test.ts
@@ -1,7 +1,7 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -131,6 +131,50 @@ test("parseAtSpan parses points and spans, rejects end < start", () => {
   assert.deepEqual(parseAtSpan("1:20-1:35"), [80, 95]);
   assert.equal(parseAtSpan("95-80"), undefined);
   assert.equal(parseAtSpan("90"), 90);
+});
+
+test("contactSheet nulls a cell whose frame ffmpeg drops (exit 0, no output) — no later-cell shift", async () => {
+  // Some ffmpeg builds/containers exit 0 with NO frame written when a seek lands
+  // at/past the last decodable frame. That gap truncates the image2 sequence in
+  // the tile pass and shifts every LATER cell off its mapped timestamp while the
+  // returned map still claims the original one — the grid then silently lies.
+  // This machine's ffmpeg errors (non-zero) on such a seek, so we reproduce the
+  // exit-0-no-output case deterministically with a wrapper that answers one
+  // sentinel seek with exit 0 + no file and delegates everything else to the real
+  // ffmpeg (FFMPEG_PATH is captured here before the override).
+  const realFfmpeg = FFMPEG_PATH;
+  const POISON = 123.456; // a seek this 1s clip has no frame for; the stub drops it
+  const stub = join(dir, "ffmpeg-drop-stub.sh");
+  writeFileSync(
+    stub,
+    `#!/bin/sh\nfor a in "$@"; do\n  if [ "$a" = "${POISON}" ]; then exit 0; fi\ndone\nexec "${realFfmpeg}" "$@"\n`,
+    { mode: 0o755 },
+  );
+
+  const prev = process.env.OVERCAST_FFMPEG;
+  process.env.OVERCAST_FFMPEG = stub;
+  try {
+    // fresh module instance so FFMPEG_PATH resolves to the stub (it's read at load)
+    const { contactSheet } = await import("../../src/media/ffmpeg.ts?dropstub");
+    const seconds = [0, 0.2, POISON, 0.6];
+    const r = await contactSheet(clip, seconds, join(dir, "drop-sheet"));
+
+    // resolves + still produces a montage (no throw, no half-built grid)
+    assert.ok(existsSync(r.output), "montage still produced despite a dropped frame");
+    // the dropped cell maps to null — never a shifted/wrong source timestamp
+    assert.equal(r.cells[2].at, null, "the cell whose frame was dropped maps to null");
+    // every OTHER cell keeps its EXACT original timestamp (no shift into the gap)
+    assert.equal(r.cells[0].at, 0);
+    assert.equal(r.cells[1].at, 0.2);
+    assert.equal(r.cells[3].at, 0.6);
+    // invariant: any cell that claims a timestamp maps to its OWN sample, in place
+    for (const c of r.cells) {
+      if (c.at != null) assert.equal(c.at, seconds[c.n - 1], `cell ${c.n} maps to its own sample`);
+    }
+  } finally {
+    if (prev === undefined) delete process.env.OVERCAST_FFMPEG;
+    else process.env.OVERCAST_FFMPEG = prev;
+  }
 });
 
 test("parseFrameRef parses frame://rec@sec and rejects others", () => {


### PR DESCRIPTION
## What & why (bug)

`grid` renders one ffmpeg frame per sampled second, tiles them into an `image2` (`cell_%03d.jpg`) sequence, and emits a payload with a **trusted cell-number → timestamp map** — the whole point of the "grid trick" for temporal search.

But `contactSheet` never verified ffmpeg actually **produced** each frame. ffmpeg can exit `0` with **no frame written** when a seek lands at or past the last decodable frame (near-EOF on some containers). A resulting gap in the sequence gets truncated by the tile pass, which **shifts every later cell off its mapped timestamp** — while the payload still claims the original mapping. The grid's core contract silently lies, and a VLM (or a human) reading "cell 7 = 0:42" is pointed at the wrong moment.

**Fix (in `contactSheet` only):**
- After each per-cell render, `if (!existsSync(cell)) missing.add(i)` records any sample whose frame ffmpeg didn't write.
- Filler-tile generation now triggers on `n < slots || missing.size`; each missing cell gets the filler copied into its `cell_NNN.jpg` slot, keeping the `image2` sequence **gapless** so no later cell can shift into a dropped slot.
- The cell map becomes `at: i < n && !missing.has(i) ? seconds[i] : null` — a dropped cell is **blanked and mapped to `null`** (the existing null-`at` convention), never a shifted/wrong timestamp.

This upholds the "reject/blank rather than lie" posture: a cell number read off the montage always resolves to a correct timestamp or to `null` (blank).

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **796 pass / 0 fail** (+1 regression test)
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- Done-criteria: `missing` gap-fill logic present; the regression test is load-bearing (disabling the `existsSync` check makes it fail)

**Regression test note:** the local ffmpeg 8.1.2 is *strict* — a real `t > duration` seek returns a **non-zero** exit (so `contactSheet` throws, not silently drops). To faithfully reproduce the exit-0-no-output condition the fix targets, the test uses the plan's blessed escape hatch: an `OVERCAST_FFMPEG` wrapper that answers one sentinel seek with `exit 0` + no file and delegates all else to real ffmpeg. It asserts the dropped cell → `at: null` and the other cells keep their exact timestamps (no shift). This is more faithful and version-independent than relying on a specific ffmpeg's near-EOF behavior.

## Deviations

None in code. Test uses the deterministic-wrapper reproduction (the plan's own alternative) rather than a natural `t > duration` seek, because the local strict ffmpeg can't produce the exit-0-no-output path directly — so the STOP condition ("cannot reproduce a missing frame") did **not** apply.

## Scope

In-scope: `src/media/ffmpeg.ts` (`contactSheet` only), `test/unit/ffmpeg.test.ts` (additive). Per-cell spawn structure, `grid.ts` flag validation, and tile/labeling/hashing logic untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to contact sheet assembly and mapping in ffmpeg.ts plus an additive regression test; grid consumers get more accurate null-at semantics with no API break.
> 
> **Overview**
> **`contactSheet`** now treats ffmpeg **exit 0 with no output file** as a failed sample: it tracks those indices in a **`missing`** set, copies a **filler** into the corresponding `cell_NNN.jpg` so the **`image2`** sequence stays gapless for **`tile`**, and sets **`cells[i].at`** to **`null`** for dropped samples instead of claiming the original timestamp.
> 
> This keeps the **grid** verb’s cell-number → time map honest (blank/`null` rather than a wrong moment when a near-EOF seek produces no frame). A unit test uses an **`OVERCAST_FFMPEG`** wrapper that simulates one poison seek with exit 0 and no file, asserting the dropped cell is **`null`** and other cells keep their exact times.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943b4792867f01e64f2d147ad95ae959c27d6bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->