### PR TITLE
Consolidate duplicated verb helpers (err record, time read, HTML/regex escape)

### DIFF
--- a/src/providers/memory/local.ts
+++ b/src/providers/memory/local.ts
@@ -3,7 +3,7 @@
 // record's payload text. No external deps; per-case.
 
 import type { Case } from "../../case.js";
-import { memoryRecords, type OvercastRecord } from "../../record.js";
+import { memoryRecords, recordTimeMs, type OvercastRecord } from "../../record.js";
 import type { MemoryProvider, Passage, QueryOpts, Answer } from "./types.js";
 import { indexableDocument } from "./fields.js";
 
@@ -116,7 +116,7 @@ export class LocalMemoryProvider implements MemoryProvider {
         throw new Error(`invalid since value: ${opts.since}`);
       }
       records = records.filter((r) => {
-        const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+        const t = recordTimeMs(r);
         return Number.isNaN(t) || t >= cutoff;
       });
     }

--- a/src/record.ts
+++ b/src/record.ts
@@ -166,6 +166,13 @@ export function makeRecord(input: NewRecordInput): OvercastRecord {
   return rec;
 }
 
+/** Standard error record for a verb: state:"error" with the message doubled
+ *  into payload.error (display) and error (control). The one constructor —
+ *  verb files must not re-implement it. */
+export function errRecord(verb: string, message: string): OvercastRecord {
+  return makeRecord({ verb, format: "json", payload: { error: message }, error: message, state: "error" });
+}
+
 export interface ValidationResult {
   ok: boolean;
   errors: string[];
@@ -200,6 +207,12 @@ export function validateRecord(value: unknown): ValidationResult {
 /** Treat unknown/missing state as ready (consumer rule). */
 export function isReady(rec: Pick<OvercastRecord, "state">): boolean {
   return rec.state == null || rec.state === "ready";
+}
+
+/** Epoch ms of a record's meta.time, or NaN when absent/unparseable —
+ *  the single reading of the timestamp convention for sorts and --since. */
+export function recordTimeMs(rec: Pick<OvercastRecord, "meta">): number {
+  return rec.meta?.time ? Date.parse(String(rec.meta.time)) : NaN;
 }
 
 // --- JSONL persistence -------------------------------------------------------

--- a/src/report/wall.ts
+++ b/src/report/wall.ts
@@ -8,7 +8,8 @@
 import { existsSync } from "node:fs";
 import { basename } from "node:path";
 import { pathToFileURL } from "node:url";
-import { findingStatusMap, isReady, type OvercastRecord } from "../record.js";
+import { findingStatusMap, isReady, recordTimeMs, type OvercastRecord } from "../record.js";
+import { escapeRegex } from "../text.js";
 import { isRegisterableMediaRecord } from "../verbs/media-ref.js";
 import { isRootFindingRecord } from "../verbs/finding.js";
 import { sourceScanFreshness, latestTimed, triageCounts } from "../signals/pulse.js";
@@ -206,7 +207,7 @@ function buildTile(ref: string, group: OvercastRecord[], join: TileJoin): WallTi
   }
 
   const times = group
-    .map((r) => (r.meta?.time ? Date.parse(String(r.meta.time)) : NaN))
+    .map((r) => recordTimeMs(r))
     .filter((t) => !Number.isNaN(t));
   const lastMs = times.length ? Math.max(...times) : null;
 
@@ -427,7 +428,7 @@ function payloadOf(r: OvercastRecord): Record<string, unknown> {
 function sortByTime(records: OvercastRecord[]): OvercastRecord[] {
   return records
     .map((r, i) => {
-      const parsed = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+      const parsed = recordTimeMs(r);
       return { r, i, t: Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed };
     })
     .sort((a, b) => a.t - b.t || a.i - b.i)
@@ -440,7 +441,7 @@ function sortByTime(records: OvercastRecord[]): OvercastRecord[] {
 function newestFirst(records: OvercastRecord[]): OvercastRecord[] {
   return records
     .map((r, i) => {
-      const parsed = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+      const parsed = recordTimeMs(r);
       return { r, i, t: Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed };
     })
     .sort((a, b) => b.t - a.t || a.i - b.i)
@@ -454,11 +455,7 @@ function frameFileRe(ref: string): RegExp {
   const b = basename(ref.replace(/[?#].*$/, ""));
   const dot = b.lastIndexOf(".");
   const stem = dot > 0 ? b.slice(0, dot) : b;
-  return new RegExp(`^${escapeRegExp(stem)}_t\\d+\\.jpg$`, "i");
-}
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escapeRegex(stem)}_t\\d+\\.jpg$`, "i");
 }
 
 function displayName(ref: string): string {

--- a/src/signals/pulse.ts
+++ b/src/signals/pulse.ts
@@ -5,7 +5,7 @@
  * are the single source of truth for scan/monitor/brief recency — wall imports
  * them so its HUD can't drift from status.
  */
-import { findingStatusMap, isMemoryRecord, isReady, type OvercastRecord } from "../record.js";
+import { findingStatusMap, isMemoryRecord, isReady, recordTimeMs, type OvercastRecord } from "../record.js";
 import { isRootFindingRecord } from "../verbs/finding.js";
 import { buildThreads, threadsHeadline, type TargetThread } from "./threads.js";
 import type { TargetEntry } from "../state/target.js";
@@ -17,7 +17,7 @@ function payloadOf(r: OvercastRecord): Record<string, unknown> {
 }
 
 function timeMs(r: OvercastRecord): number {
-  const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+  const t = recordTimeMs(r);
   return Number.isNaN(t) ? NaN : t;
 }
 

--- a/src/signals/rollup.ts
+++ b/src/signals/rollup.ts
@@ -14,7 +14,7 @@
  * wins, so a whole sweep collapses to one "sweep" group. Records without it fall
  * through to the media-chain rules — so this works today without stamping runs.
  */
-import type { OvercastRecord } from "../record.js";
+import { recordTimeMs, type OvercastRecord } from "../record.js";
 
 export interface TimelineGroup {
   key: string;
@@ -33,7 +33,7 @@ function payloadOf(r: OvercastRecord): Record<string, unknown> {
 }
 
 function timeMs(r: OvercastRecord): number {
-  const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+  const t = recordTimeMs(r);
   return Number.isNaN(t) ? Number.POSITIVE_INFINITY : t;
 }
 

--- a/src/signals/threads.ts
+++ b/src/signals/threads.ts
@@ -17,7 +17,7 @@
  *   collecting           ← ≥1 evidence record linked
  *   cold                 ← nothing linked yet
  */
-import { findingStatusMap, isMemoryRecord, isReady, type OvercastRecord } from "../record.js";
+import { findingStatusMap, isMemoryRecord, isReady, recordTimeMs, type OvercastRecord } from "../record.js";
 import { isRootFindingRecord } from "../verbs/finding.js";
 import { targetMatchesEvidence, payloadText } from "./triggers.js";
 import { targetStatus, type TargetEntry } from "../state/target.js";
@@ -77,7 +77,7 @@ function payloadOf(r: OvercastRecord): Record<string, unknown> {
 }
 
 function timeOf(r: OvercastRecord): number {
-  const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+  const t = recordTimeMs(r);
   return Number.isNaN(t) ? 0 : t;
 }
 

--- a/src/signals/triggers.ts
+++ b/src/signals/triggers.ts
@@ -19,6 +19,7 @@
  * - "off": nothing fires.
  */
 import { findingStatusMap, isMemoryRecord, type OvercastRecord } from "../record.js";
+import { escapeRegex } from "../text.js";
 import { makeFinding } from "../verbs/finding.js";
 import { isTargetClosed, type TargetEntry } from "../state/target.js";
 import type { CaseSetup, SetupFindingsPolicy, SetupFindingsThresholds } from "../state/setup.js";
@@ -82,10 +83,6 @@ export function payloadText(rec: OvercastRecord): string {
   } catch {
     return "";
   }
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** Whole-phrase, case-insensitive, word-boundaried match of a target value

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,0 +1,6 @@
+// Small string/text utilities shared across the codebase.
+
+/** Escape a literal for embedding in a RegExp. */
+export function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/verbs/audio.ts
+++ b/src/verbs/audio.ts
@@ -7,7 +7,7 @@
 // transcode/noise/clipping; NOT robust to pitch/speed change (classic Wang).
 
 import { existsSync, mkdirSync } from "node:fs";
-import { makeRecord, isReady, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, isReady, type OvercastRecord } from "../record.js";
 import { addMember, findIndex, resolveIndexRef } from "../state/index.js";
 import { localIndexDir } from "../providers/local/vision.js";
 import { runLocalAudio } from "../providers/local/audio.js";
@@ -17,9 +17,7 @@ import { badNumber } from "./validate.js";
 import type { Case } from "../case.js";
 import type { VerbSpec } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "audio", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("audio", message);
 
 /** Resolve + validate a local audio-fp index the query/add targets. */
 function localAudioIndex(ctxCase: Case, value: unknown): { id?: string; error?: string } {

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -5,7 +5,7 @@
 import { spawn } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, recordTimeMs, type OvercastRecord } from "../record.js";
 import { openCase, recordFiles } from "../case.js";
 import { humanSize } from "../render.js";
 import { collectVisualRefs, isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiStatusReport, renderCsiTimelineReport } from "../report/html.js";
@@ -29,9 +29,7 @@ import { isAv } from "./media-ref.js";
 import { findProviderChoice } from "../providers/catalog.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "case", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("case", message);
 
 const DEFAULT_SIGNAL_BY_INDEX_TYPE: Record<string, string[]> = {
   "media-descriptions": ["watch", "index add"],
@@ -364,7 +362,7 @@ function truncateLine(text: string): string {
 function sortRecordsChronologically(records: OvercastRecord[]): OvercastRecord[] {
   return records
     .map((r, i) => {
-      const parsed = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+      const parsed = recordTimeMs(r);
       return { r, i, t: Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed };
     })
     .sort((a, b) => a.t - b.t || a.i - b.i)
@@ -1280,7 +1278,7 @@ export const caseVerb: VerbSpec = {
           return [err(`invalid --since: ${ctx.opts.since} (try 24h, 7d, or 2026-06-01)`)];
         }
         recs = recs.filter((r) => {
-          const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+          const t = recordTimeMs(r);
           return Number.isNaN(t) || t >= cutoff;
         });
       }

--- a/src/verbs/cluster.ts
+++ b/src/verbs/cluster.ts
@@ -21,7 +21,7 @@
 
 import { writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { runLocalCluster } from "../providers/local/vision.js";
 import { indexesByType, resolveIndexRef } from "../state/index.js";
 import { resolveVisualArg } from "./media-ref.js";
@@ -36,9 +36,7 @@ const VALID_ACTIONS = ["add", "ingest", "identify", "list", "show", "label", "re
 // placeholder media.ref so the record stays clean.
 const NON_MEDIA_OPS = new Set(["list", "show", "label", "recluster", "view"]);
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "cluster", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("cluster", message);
 
 const num = (v: unknown): number | undefined => {
   if (v == null) return undefined;

--- a/src/verbs/crop.ts
+++ b/src/verbs/crop.ts
@@ -6,7 +6,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { cropStill, modalityFromExt, probe, type CropBox } from "../media/ffmpeg.js";
 import { fetchMediaToCase } from "../media/fetch.js";
 import { badNumber } from "./validate.js";
@@ -32,9 +32,7 @@ interface Candidate {
   rawBox: unknown;
 }
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "crop", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("crop", message);
 
 /** Collision-free default crop name: same box/pad/square/source → same name
  *  (idempotent), different params → different name — a re-crop with new padding

--- a/src/verbs/face.ts
+++ b/src/verbs/face.ts
@@ -9,7 +9,7 @@
 //   face <video> --index <id>         → list     (stored detections for that video)
 
 import { existsSync } from "node:fs";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { runFace, type FaceOp, type FaceParams } from "../providers/tinycloud/face.js";
 import { tinycloudBaseFromRun, TC_SUBCOMMANDS, TINYCLOUD_TIMEOUT_MS } from "../providers/tinycloud/envelope.js";
 import { isCustomBinding, runBoundProvider } from "../providers/run.js";
@@ -25,9 +25,7 @@ import type { Case } from "../case.js";
 import type { ProviderDescriptor } from "../profile.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "face", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("face", message);
 
 const FACE_QUERY_IMAGE_RE = /\.(jpe?g|png)$/i;
 

--- a/src/verbs/finding.ts
+++ b/src/verbs/finding.ts
@@ -1,11 +1,9 @@
-import { makeRecord, type MediaRef, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type MediaRef, type OvercastRecord } from "../record.js";
 import { resolveMediaRef, refPathExists } from "./media-ref.js";
 import { parseAtSpan } from "../media/ffmpeg.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "finding", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("finding", message);
 
 export function latestFindingStatus(ctx: VerbContext, id: string): string {
   const updates = ctx.case.records().filter((r) => r.verb === "finding" && typeof r.payload === "object");

--- a/src/verbs/grid.ts
+++ b/src/verbs/grid.ts
@@ -9,16 +9,15 @@
 import { basename, join } from "node:path";
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { contactSheet, probe, parseTimecode, type GridCell } from "../media/ffmpeg.js";
+import { escapeHtml } from "../report/html.js";
 import { openHtmlPlayer } from "../media/view.js";
 import { resolveVideoArg } from "./media-ref.js";
 import { badNumber } from "./validate.js";
 import type { VerbSpec } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "grid", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("grid", message);
 
 const MAX_CELLS = 64;
 
@@ -214,14 +213,6 @@ interface GridHtmlOpts {
   title: string;
 }
 
-/** Escape for HTML text content. */
-function htmlText(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-/** Escape for a double-quoted HTML attribute. */
-function htmlAttr(s: string): string {
-  return htmlText(s).replace(/"/g, "&quot;");
-}
 /** Whole seconds → M:SS (labels); the exact seconds ride the seek + the record. */
 function mmss(sec: number): string {
   const s = Math.max(0, Math.round(sec));
@@ -255,14 +246,14 @@ function buildGridHtml(o: GridHtmlOpts): string {
       return (
         `<button class="cell" style="${style}" onclick="seek(${cell.at})" ` +
         `title="cell ${cell.n} · ${cell.at}s">` +
-        `<span class="badge">${cell.n}</span><span class="tc">${htmlText(mmss(cell.at))}</span></button>`
+        `<span class="badge">${cell.n}</span><span class="tc">${escapeHtml(mmss(cell.at))}</span></button>`
       );
     })
     .join("");
 
-  const videoUrl = htmlAttr(o.videoIsRemote ? o.video : pathToFileURL(o.video).href);
-  const montageUrl = htmlAttr(pathToFileURL(o.montage).href);
-  const nameEsc = htmlText(o.title);
+  const videoUrl = escapeHtml(o.videoIsRemote ? o.video : pathToFileURL(o.video).href);
+  const montageUrl = escapeHtml(pathToFileURL(o.montage).href);
+  const nameEsc = escapeHtml(o.title);
 
   return `<!doctype html><html><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/verbs/image.ts
+++ b/src/verbs/image.ts
@@ -3,7 +3,7 @@
 // `index`/`ask`/`face`.
 
 import { existsSync } from "node:fs";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { addMember, findIndex, resolveIndexRef } from "../state/index.js";
 import { localIndexDir, runLocalImage } from "../providers/local/vision.js";
 import { resolveImageArg, resolveVisualArg } from "./media-ref.js";
@@ -13,9 +13,7 @@ import { mkdirSync } from "node:fs";
 import type { Case } from "../case.js";
 import type { VerbSpec } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "image", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("image", message);
 
 function localImageIndex(ctxCase: Case, value: unknown): { id?: string; error?: string } {
   const raw = value != null ? String(value).trim() : "";

--- a/src/verbs/index.ts
+++ b/src/verbs/index.ts
@@ -13,7 +13,7 @@
 
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { makeRecord, isReady, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, isReady, type OvercastRecord } from "../record.js";
 import { runWatch } from "../providers/tinycloud/watch.js";
 import { isCustomBinding, runBoundProvider } from "../providers/run.js";
 import { providerBinding } from "../providers/bindings.js";
@@ -64,9 +64,7 @@ const VALID_ACTIONS = ["create", "attach", "add", "list", "show", "delete", "rem
 const LOCAL_VIDEO_RE = /\.(mp4|m4v|mov|webm|mkv|avi|mpe?g|m2ts|mts|ts|wmv|flv|3gp|3g2|ogv|mxf)$/i;
 const LOCAL_IMAGE_MEDIA_VERBS = new Set(["capture", "image", "face"]);
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "index", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("index", message);
 
 function isLocalIndex(entry: { backend?: string; type: string }): boolean {
   return entry.backend === "local";

--- a/src/verbs/note.ts
+++ b/src/verbs/note.ts
@@ -2,14 +2,12 @@
 // outputs), so they flow through local memory, ask, brief, and case records like
 // sensed/captured evidence. They can optionally anchor to a media ref or record.
 
-import { makeRecord, type MediaRef, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type MediaRef, type OvercastRecord } from "../record.js";
 import { resolveMediaRef, refPathExists } from "./media-ref.js";
 import { parseAtSpan } from "../media/ffmpeg.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "note", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("note", message);
 
 function splitTags(v: unknown): string[] | undefined {
   if (v == null) return undefined;

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -5,7 +5,7 @@
 import { join, basename, dirname } from "node:path";
 import { copyFileSync, existsSync, appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { sniffExt } from "../media/fetch.js";
 import {
   builtinDescriptor,
@@ -41,9 +41,7 @@ import { scanHitProvenance, stampProvenance } from "./provenance.js";
 import { redactSecrets } from "../env.js";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
-function err(verb: string, message: string): OvercastRecord {
-  return makeRecord({ verb, format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = errRecord;
 
 function scanFlagError(ctx: VerbContext, verb = "scan"): OvercastRecord | undefined {
   if (ctx.opts.limit != null) {

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -4,7 +4,7 @@
 
 import { existsSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { makeRecord, memoryRecords, type OvercastRecord } from "../record.js";
+import { makeRecord, memoryRecords, recordTimeMs, type OvercastRecord } from "../record.js";
 import { collectVisualRefs, isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiTimelineReport, type TimelineRecord, type TimelineSynthesis } from "../report/html.js";
 import { sparkline, fmtAge } from "../report/components.js";
 import { casePulse, type CasePulse } from "../signals/pulse.js";
@@ -438,7 +438,7 @@ function buildBrief(records: OvercastRecord[], caseName: string, opts: { pulse: 
   // their original insertion order (decorate-sort-undecorate for stability).
   const sorted = records
     .map((r, i) => {
-      const parsed = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+      const parsed = recordTimeMs(r);
       return { r, i, t: Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed };
     })
     .sort((a, b) => a.t - b.t || a.i - b.i)
@@ -632,7 +632,7 @@ export const briefVerb: VerbSpec = {
         // keep records at/after the cutoff (undated records are kept, since we
         // can't prove they're stale).
         records = records.filter((r) => {
-          const t = r.meta?.time ? Date.parse(String(r.meta.time)) : NaN;
+          const t = recordTimeMs(r);
           return Number.isNaN(t) || t >= cutoff;
         });
       }

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -28,7 +28,7 @@ import {
   type Modality,
 } from "../media/ffmpeg.js";
 import { openHtmlPlayer, osOpen } from "../media/view.js";
-import { renderEnhanceGallery, type EnhanceGalleryItem, type EnhanceGalleryReport } from "../report/html.js";
+import { escapeHtml, renderEnhanceGallery, type EnhanceGalleryItem, type EnhanceGalleryReport } from "../report/html.js";
 import { providerEnv } from "../providers/provider-env.js";
 import { provenanceFromCapture, stampProvenance } from "./provenance.js";
 import { fanOutEnhance, hasFanOut } from "./enhance-fanout.js";
@@ -843,9 +843,9 @@ function buildPlayerHtml(
   // remote http(s) URL is used as-is. Either way HTML-escape every interpolated
   // path so a filename with quotes/`<`/`&` can't break the attribute or inject
   // script into the generated page.
-  const fileUrl = htmlAttr(isRemote ? src : pathToFileURL(src).href);
-  const nameEsc = htmlText(basenameOf(src));
-  const srcEsc = htmlText(src);
+  const fileUrl = escapeHtml(isRemote ? src : pathToFileURL(src).href);
+  const nameEsc = escapeHtml(basenameOf(src));
+  const srcEsc = escapeHtml(src);
   return `<!doctype html><html><head><meta charset="utf-8">
 <title>overcast view — ${nameEsc}</title>
 <style>
@@ -859,7 +859,7 @@ function buildPlayerHtml(
 <h1>▶ OVERCAST VIEW — ${nameEsc}</h1>
 <${tag} id="m" src="${fileUrl}" controls></${tag}>
 <div class="pins">${markerPins || '<span class="note">no markers</span>'}</div>
-${spectrogramPath ? `<img src="${htmlAttr(pathToFileURL(spectrogramPath).href)}" alt="spectrogram" style="width:100%;max-width:1024px;border:1px solid #1f9d57;margin-top:12px"/>` : ""}
+${spectrogramPath ? `<img src="${escapeHtml(pathToFileURL(spectrogramPath).href)}" alt="spectrogram" style="width:100%;max-width:1024px;border:1px solid #1f9d57;margin-top:12px"/>` : ""}
 <p class="note">${srcEsc}</p>
 <script>
   const m=document.getElementById('m');
@@ -871,17 +871,4 @@ ${spectrogramPath ? `<img src="${htmlAttr(pathToFileURL(spectrogramPath).href)}"
 
 function basenameOf(p: string): string {
   return p.split("/").pop() ?? p;
-}
-
-/** Escape for HTML text content. */
-function htmlText(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-/** Escape for a double-quoted HTML attribute value. */
-function htmlAttr(s: string): string {
-  return htmlText(s).replace(/"/g, "&quot;");
 }

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -2,7 +2,7 @@
 // profiles), provider (init/list/describe a provider), doctor (readiness checks).
 // Bindings live in the profile so they travel with --profile.
 
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord } from "../record.js";
 import {
   loadProfile,
   saveProfile,
@@ -27,9 +27,7 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { VerbSpec, VerbContext } from "../registry/types.js";
 
-function err(verb: string, message: string): OvercastRecord {
-  return makeRecord({ verb, format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = errRecord;
 
 function quoteCommandArg(arg: string): string {
   return /^[A-Za-z0-9_./:=@+-]+$/.test(arg) ? arg : JSON.stringify(arg);

--- a/src/verbs/similar.ts
+++ b/src/verbs/similar.ts
@@ -5,7 +5,7 @@
 // open_clip); remote searchable video indexes stay under `index`/`ask`/`face`.
 
 import { existsSync, mkdirSync } from "node:fs";
-import { makeRecord, isReady, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, isReady, type OvercastRecord } from "../record.js";
 import { addMember, findIndex, resolveIndexRef } from "../state/index.js";
 import {
   localIndexDir,
@@ -24,9 +24,7 @@ import { runWatch } from "../providers/tinycloud/watch.js";
 import type { Case } from "../case.js";
 import type { VerbContext, VerbSpec } from "../registry/types.js";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "similar", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("similar", message);
 
 /** Resolve + validate a local semantic index (basic-clip = CLIP images/video, or
  *  basic-clap = CLAP audio) the query/add targets. Returns the resolved type so

--- a/src/verbs/skills.ts
+++ b/src/verbs/skills.ts
@@ -6,7 +6,7 @@ import { writeFileSync, mkdirSync, existsSync, cpSync, readFileSync } from "node
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
-import { makeRecord } from "../record.js";
+import { makeRecord, errRecord } from "../record.js";
 import { expandHome } from "../fs-path.js";
 import {
   generateVerbReference,
@@ -206,8 +206,7 @@ export const skillsVerb: VerbSpec = {
   providerKey: "skills",
   run: async (ctx) => {
     const action = ctx.input;
-    const fail = (msg: string) =>
-      [makeRecord({ verb: "skills", format: "json", payload: { error: msg }, error: msg, state: "error" })];
+    const fail = (msg: string) => [errRecord("skills", msg)];
 
     if (action === "generate") {
       // a source-repo command: it rewrites the committed skills/ from the

--- a/src/verbs/wall.ts
+++ b/src/verbs/wall.ts
@@ -7,7 +7,7 @@
 import { writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { makeRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { extractFrame } from "../media/ffmpeg.js";
 import { openHtmlPlayer } from "../media/view.js";
 import { normalizeHtmlTheme } from "../report/html.js";
@@ -20,9 +20,7 @@ import type { VerbSpec } from "../registry/types.js";
 // wall.html into whatever directory the command ran from.
 const WALL_DEFAULT_EXPORT = ".overcast/media/wall.html";
 
-function err(message: string): OvercastRecord {
-  return makeRecord({ verb: "wall", format: "json", payload: { error: message }, error: message, state: "error" });
-}
+const err = (message: string): OvercastRecord => errRecord("wall", message);
 
 export const wallVerb: VerbSpec = {
   name: "wall",


### PR DESCRIPTION
## What & why (tech debt)

Core helpers were re-implemented across 14+ verb/signal/report files with documented drift:
- the **error-record builder** existed 15 ways across two signatures (`err(message)` with a hardcoded verb, and `err(verb, message)`);
- **HTML escaping** existed three ways (`escapeHtml`, plus local `htmlText`/`htmlAttr` pairs);
- **regex escaping** was duplicated (`escapeRegex` / `escapeRegExp`);
- the **`meta.time → epoch-ms`** read was copy-pasted 11 times.

This consolidates the four LOW-risk, mechanically-verifiable helpers into shared homes, cutting god-module bloat and enforcing one code path per responsibility. It deliberately **excludes** the higher-risk, output-affecting refactors (payload summarization, status/brief unification, `verbs/index.ts` restructuring).

**Consolidation:**
- `errRecord(verb, message)` + `recordTimeMs(rec)` → `src/record.ts` — 15 and 11 call sites migrated.
- `escapeRegex(s)` → new `src/text.ts` — 2 call sites.
- HTML escaping unified on the existing `escapeHtml` (deleting the local `htmlText`/`htmlAttr` pair) — 8 call sites.

## Output-invisibility (the plan's contract)

**No test was edited or even referenced the private helpers** — the full unit + e2e suites pass **unchanged**. Two nuances, both benign:
- `htmlAttr` was byte-identical to `escapeHtml`, so those sites are unchanged.
- `htmlText` escaped a *subset* (`& < >`), so `htmlText → escapeHtml` only *adds* `"`→`&quot;`. In text nodes that renders identically; in an attribute context it's a latent fix (equal-or-more escaping, never less). Confirmed invisible by the existing characterization tests (incl. the wall "quotes/specials in a media path" test).
- One `osint.ts` err site with a **divergent** `payload.error` message (detailed) vs `error` (short) is intentionally left inline — `errRecord` doubles a single message, so migrating it would change output.

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **796 pass / 0 fail** (unchanged from before this PR)
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- Done-criteria greps — ✅ no `function err(`, no `function htmlText|htmlAttr|escapeRegex|escapeRegExp` (outside `text.ts`), no residual inline `meta.time ? Date.parse … : NaN`

## Deviations

Two minor, disclosed: migrated `skills.ts`'s `fail` helper (surfaced by the plan's own Step-1 verify grep, identical `errRecord` shape) and removed a now-dead `type OvercastRecord` import in `setup.ts`. Both byte-identical/no-op.

## Scope

In-scope: `src/record.ts`, new `src/text.ts`, and the call-site files (`src/report/wall.ts`, `src/signals/{pulse,rollup,threads,triggers}.ts`, `src/providers/memory/local.ts`, `src/verbs/*`). No verb behavior change; `src/verbs/index.ts` restructuring / payload summaries / sorts untouched. (Depends on plan 004; no overlap — 004 consolidated *parsers*, this consolidates *helpers*.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors with tests unchanged; HTML sites only add quote escaping (equal or stricter), and one osint err site was left unmigrated to preserve divergent messages.
> 
> **Overview**
> This PR **deduplicates four helpers** that were copy-pasted across verbs, signals, memory, and report code.
> 
> **`src/record.ts`** gains **`errRecord(verb, message)`** and **`recordTimeMs(rec)`**. Verbs that used local `err()` wrappers now call `errRecord` with a thin alias; memory **`--since`**, wall sorting, pulse/rollup/threads, **`case records`**, and **`brief`** scope filters all use **`recordTimeMs`** instead of inline `Date.parse` on `meta.time`.
> 
> A new **`src/text.ts`** exports **`escapeRegex`**, used by **`triggers.ts`** and **`report/wall.ts`** (replacing a local **`escapeRegExp`**). **`grid.ts`** and **`senses.ts`** drop private **`htmlText`/`htmlAttr`** and use **`escapeHtml`** from **`report/html.js`**.
> 
> One **`osint.ts`** error path with mismatched **`payload.error`** vs **`error`** text stays inline so output is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e861a4cc6f01882938397d2f03533c40bd428f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->