### PR TITLE
Add opt-in Cloudglue memory provider for cloud-tier ask --deep

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -655,6 +655,35 @@ configured semantic providers such as qmd, and `--memory qmd` forces that
 provider explicitly. `overcast doctor` reports qmd as an optional check when it
 is installed or configured.
 
+### Cloudglue cloud tier (`ask --deep`, opt-in)
+
+`ask --deep` can also fan out to a case-linked Cloudglue **media-descriptions**
+collection — true cross-modal search over the case's actual video at cloud scale.
+This is the `cloudglue` memory provider (alias `tinycloud`), and it is strictly
+**opt-in** because uploading/querying a Cloudglue collection costs money:
+
+```bash
+overcast index create Scenes --type media-descriptions   # a remote collection for the case
+overcast index add clip.mp4 --to <id>                     # (uploads cost money)
+overcast setup memory cloudglue                           # opt in (uses the first attached media-descriptions index)
+overcast setup memory cloudglue <index>                   # …or pin a specific index by id/name
+overcast setup memory cloudglue off                       # opt back out
+overcast ask "where did the buyer object to the price?" --deep --json
+```
+
+The opt-in lives in the case setup (`.overcast/setup.json`, `memory.cloudglue`) —
+it is off by default and never auto-enabled. The provider engages ONLY when all of
+these hold: `--deep` was requested, the case opted in, a media-descriptions
+collection resolves, and a Cloudglue key is present (`CLOUDGLUE_API_KEY`, or
+`~/.tinycloud/config.json`). A plain `ask` (no `--deep`) never touches the cloud —
+the provider's local `query()` returns nothing, so there is no silent spend. It
+only READS the collection; adding captured media to it is a separate, deliberate
+step (`index add`), not something `ask` does. Under the hood it goes through the
+public tinycloud ask verb (the same path as `ask --index`) and maps cited moments
+to `record.id` + `media.at` citations — never the Cloudglue SDK (invariant #9).
+`ask --deep --memory cloudglue` forces just this provider; combine with qmd to
+merge local semantic hits with the cloud answer.
+
 For typed remote retrieval, `ask --index <id>` queries a tinycloud-backed
 **media-descriptions** index directly (see below) — the public-verb realization
 of the portable/remote tier.

--- a/src/providers/memory/cloudglue.ts
+++ b/src/providers/memory/cloudglue.ts
@@ -1,0 +1,188 @@
+// Cloud-tier memory provider (A-spec, memory class): answers `ask --deep` over a
+// case-linked Cloudglue **media-descriptions** collection at cloud scale, i.e.
+// true cross-modal search over the case's actual video.
+//
+// Two hard constraints:
+//   1. OPT-IN ONLY (CLAUDE.md invariant #2 BYO spirit). Uploading/querying a
+//      Cloudglue collection costs money, so this provider is registered only when
+//      the operator opted in (`setup.memory.cloudglue`) AND `ask --deep` is asked
+//      for. Its `query()` returns [] so a plain `ask` never touches the cloud —
+//      no silent spend. `write()` is a no-op (this provider only READS an existing
+//      collection; auto-adding captured media is a separate cost-policy feature).
+//   2. PUBLIC tinycloud verbs only (invariant #9). Every call goes through
+//      `tcAsk` (src/providers/tinycloud/collection.ts) — the same public
+//      collection-ask path that powers `ask --index` — never the Cloudglue SDK.
+//      The envelope is mapped to the loose record there; we map that record to
+//      Passages/Answer here.
+
+import type { Case } from "../../case.js";
+import { resolveCloudglue } from "../../profile.js";
+import type { OvercastRecord } from "../../record.js";
+import { tcAsk } from "../tinycloud/collection.js";
+import type { Answer, Citation, MemoryIndexStatus, MemoryProvider, Passage, QueryOpts } from "./types.js";
+
+export interface CloudglueMemoryConfig {
+  /** the case's local mirror index id (== the remote collection id for a
+   *  media-descriptions index) — surfaced in `status()` for diagnostics. */
+  indexId: string;
+  /** the remote tinycloud/Cloudglue collection id (col_…) queried via `tcAsk`. */
+  collectionId: string;
+  /** pinned tinycloud invocation base (a profile binding), else
+   *  OVERCAST_TINYCLOUD_CMD / `tinycloud` — mirrors the `ask --index` path. */
+  base?: string;
+  /** env for the tinycloud exec (case media dir + system ffmpeg), like `ask --index`. */
+  env?: NodeJS.ProcessEnv;
+  /** abort propagation for a long cloud query. */
+  signal?: AbortSignal;
+}
+
+function objOf(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+}
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v.trim() : undefined;
+}
+function fin(v: unknown): number | undefined {
+  const n = typeof v === "number" ? v : typeof v === "string" ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Best-effort per-moment snippet (probe returns per-moment text; plain ask
+ *  citations may carry none — the caller falls back to the overall answer). */
+function momentText(m: Record<string, unknown>): string {
+  for (const k of ["text", "snippet", "description", "summary", "content", "answer"]) {
+    const s = str(m[k]);
+    if (s) return s;
+  }
+  return "";
+}
+/** A moment's media anchor: [start,end] when both present, else the single point. */
+function momentAt(m: Record<string, unknown>): number | [number, number] | undefined {
+  const start = fin(m.start ?? m.start_time ?? m.startTime ?? m.timestamp ?? m.time ?? m.at ?? m.offset);
+  const end = fin(m.end ?? m.end_time ?? m.endTime);
+  if (start != null && end != null) return [start, end];
+  if (start != null) return start;
+  return undefined;
+}
+/** The cited collection file/video id — synthesized as the Passage `recordId`
+ *  (passages require one; there is no local record for a remote moment). */
+function momentRef(m: Record<string, unknown>, fallback: string): string {
+  for (const k of ["file", "file_id", "fileId", "video", "video_id", "videoId", "uri", "ref", "url", "id", "source"]) {
+    const s = str(m[k]);
+    if (s) return s;
+  }
+  return fallback;
+}
+function momentScore(m: Record<string, unknown>): number {
+  return fin(m.score ?? m.similarity ?? m.relevance ?? m.confidence) ?? 1;
+}
+
+export class CloudglueMemoryProvider implements MemoryProvider {
+  readonly id = "cloudglue";
+  readonly backend = "cloudglue";
+  readonly aliases = ["tinycloud"];
+
+  /** Per-instance memo of the single PAID `tcAsk` call, keyed by the args that
+   *  vary it (query + limit). The provider is created fresh in `resolveMemory`
+   *  for each `ask` request, so this memo is correctly REQUEST-scoped. In one
+   *  `fanOutAnswer` pass `deepsearch()` and `answer()` run for the SAME query;
+   *  caching the Promise coalesces them into ONE cloud call (no double billing)
+   *  even though the two calls are sequential — see `run()`. */
+  private readonly runs = new Map<string, Promise<OvercastRecord>>();
+
+  constructor(private readonly case_: Case, private readonly ref: CloudglueMemoryConfig) {}
+
+  write(_record: OvercastRecord): void {
+    // no-op: uploading media to the collection is out of scope (a separate
+    // cost-policy feature). This provider only READS the collection.
+  }
+
+  async status(): Promise<MemoryIndexStatus> {
+    const key = resolveCloudglue().apiKey;
+    const ready = Boolean(key) && Boolean(this.ref.collectionId);
+    return {
+      provider: this.id,
+      backend: this.backend,
+      state: ready ? "ready" : "missing",
+      config: { collection: this.ref.collectionId, index: this.ref.indexId },
+      error: ready
+        ? undefined
+        : "attach a media-descriptions index and set CLOUDGLUE_API_KEY (opt in with `overcast setup memory cloudglue`)",
+    };
+  }
+
+  /** Plain `ask` stays local-only — the cloud tier is `ask --deep`. Returning []
+   *  guarantees a default ask never spends against the collection. */
+  query(_q: string, _opts?: QueryOpts): Passage[] {
+    return [];
+  }
+
+  /** `ask --deep`: answer over the case's media-descriptions collection through
+   *  the public tinycloud ask verb and map cited moments to passages. */
+  async deepsearch(q: string, opts?: QueryOpts): Promise<Passage[]> {
+    const rec = await this.run(q, opts);
+    return this.toPassages(rec);
+  }
+
+  /** Grounded NL answer + citations (used when deepsearch yields no passages, and
+   *  the cleaner rendering when it does). Same public call, mapped to an Answer. */
+  async answer(q: string, opts?: QueryOpts): Promise<Answer> {
+    const rec = await this.run(q, opts);
+    const text = str(objOf(rec.payload).text) ?? "";
+    if (!text && rec.error) return { text: `cloudglue: ${rec.error}`, citations: [] };
+    if (!text) return { text: `No cloud results for "${q}".`, citations: [] };
+    const citations: Citation[] = this.toPassages(rec).map((p) => ({
+      recordId: p.recordId,
+      at: p.at,
+      verb: p.verb,
+      text: p.text,
+    }));
+    return { text, citations };
+  }
+
+  /** The single PAID cloud call, memoized per (query, limit). Returns the cached
+   *  in-flight/settled Promise when present so `deepsearch` + `answer` for the
+   *  same query share ONE `tcAsk` invocation. Not `async`: it returns the SAME
+   *  Promise object so sequential callers coalesce onto one call. */
+  private run(q: string, opts?: QueryOpts): Promise<OvercastRecord> {
+    const key = JSON.stringify([q, opts?.limit ?? null]);
+    const cached = this.runs.get(key);
+    if (cached) return cached;
+    const pending = tcAsk(q, this.ref.collectionId, {
+      limit: opts?.limit,
+      base: this.ref.base,
+      env: this.ref.env,
+      signal: this.ref.signal,
+    });
+    this.runs.set(key, pending);
+    return pending;
+  }
+
+  /** Map a `tcAsk` record ({ text, citations[], mode }) to Passages: one per cited
+   *  moment (snippet or, if none, the overall answer), or a single passage
+   *  carrying the answer when the collection returned no moments. */
+  private toPassages(rec: OvercastRecord): Passage[] {
+    const payload = objOf(rec.payload);
+    const answerText = str(payload.text) ?? "";
+    const verb = str(payload.mode) ?? "ask";
+    const moments = Array.isArray(payload.citations) ? payload.citations : [];
+    const passages: Passage[] = [];
+    for (const raw of moments) {
+      const m = objOf(raw);
+      const text = momentText(m) || answerText;
+      if (!text) continue;
+      passages.push({
+        recordId: momentRef(m, this.ref.collectionId),
+        at: momentAt(m),
+        text,
+        score: momentScore(m),
+        verb,
+        provider: this.id,
+      });
+    }
+    if (passages.length === 0 && answerText) {
+      passages.push({ recordId: this.ref.collectionId, text: answerText, score: 1, verb, provider: this.id });
+    }
+    return passages;
+  }
+}

--- a/src/providers/memory/cloudglue.ts
+++ b/src/providers/memory/cloudglue.ts
@@ -121,7 +121,7 @@ export class CloudglueMemoryProvider implements MemoryProvider {
    *  the public tinycloud ask verb and map cited moments to passages. */
   async deepsearch(q: string, opts?: QueryOpts): Promise<Passage[]> {
     const rec = await this.run(q, opts);
-    return this.toPassages(rec);
+    return this.toPassages(rec, opts?.limit);
   }
 
   /** Grounded NL answer + citations (used when deepsearch yields no passages, and
@@ -131,7 +131,7 @@ export class CloudglueMemoryProvider implements MemoryProvider {
     const text = str(objOf(rec.payload).text) ?? "";
     if (!text && rec.error) return { text: `cloudglue: ${rec.error}`, citations: [] };
     if (!text) return { text: `No cloud results for "${q}".`, citations: [] };
-    const citations: Citation[] = this.toPassages(rec).map((p) => ({
+    const citations: Citation[] = this.toPassages(rec, opts?.limit).map((p) => ({
       recordId: p.recordId,
       at: p.at,
       verb: p.verb,
@@ -161,7 +161,7 @@ export class CloudglueMemoryProvider implements MemoryProvider {
   /** Map a `tcAsk` record ({ text, citations[], mode }) to Passages: one per cited
    *  moment (snippet or, if none, the overall answer), or a single passage
    *  carrying the answer when the collection returned no moments. */
-  private toPassages(rec: OvercastRecord): Passage[] {
+  private toPassages(rec: OvercastRecord, limit?: number): Passage[] {
     const payload = objOf(rec.payload);
     const answerText = str(payload.text) ?? "";
     const verb = str(payload.mode) ?? "ask";
@@ -183,6 +183,9 @@ export class CloudglueMemoryProvider implements MemoryProvider {
     if (passages.length === 0 && answerText) {
       passages.push({ recordId: this.ref.collectionId, text: answerText, score: 1, verb, provider: this.id });
     }
-    return passages;
+    // Cap to the caller's --limit so the cloud tier matches qmd/local-grep in a deep
+    // fan-out: `tcAsk` ignores `limit` for a non-probe collection ask, so without this
+    // cloudglue could contribute more citations than the user asked for (Bugbot #72).
+    return limit != null && limit >= 0 ? passages.slice(0, limit) : passages;
   }
 }

--- a/src/providers/memory/index.ts
+++ b/src/providers/memory/index.ts
@@ -2,14 +2,51 @@
 // and merge. local-grep is always present; profiles can opt into qmd.
 
 import type { Case } from "../../case.js";
-import type { Profile } from "../../profile.js";
+import { resolveCloudglue, type Profile } from "../../profile.js";
 import type { MemoryProvider, Answer, QueryOpts, Citation } from "./types.js";
 import { LocalMemoryProvider } from "./local.js";
 import { QmdMemoryProvider } from "./qmd.js";
+import { CloudglueMemoryProvider } from "./cloudglue.js";
 import { loadSetup } from "../../state/setup.js";
+import { indexesByType, resolveIndexRef } from "../../state/index.js";
+import { tinycloudBaseFromRun } from "../tinycloud/envelope.js";
+import { providerEnv } from "../provider-env.js";
 
-/** Resolve the bound memory providers for a case. local-grep is always present. */
-export function resolveMemory(case_: Case, profile?: Profile): MemoryProvider[] {
+/** Resolve the case's opt-in Cloudglue collection ref, if any. A pinned
+ *  `memory.cloudglue.index` (id / unique name) must be a media-descriptions
+ *  index; otherwise the case's first attached media-descriptions index is used.
+ *  Returns undefined when nothing ask-able is linked. */
+function resolveCloudglueCollection(case_: Case, pinned?: string): { indexId: string; collectionId: string } | undefined {
+  const want = pinned?.trim();
+  if (want) {
+    const ref = resolveIndexRef(case_, want);
+    // Fail CLOSED on an ambiguous pinned name (matches >1 mirror index): treating
+    // it as a raw remote id could silently query the WRONG collection. Return
+    // undefined so cloudglue isn't registered — mirroring how `ask --index`
+    // errors on ambiguity (src/verbs/read.ts). Only a value that is truly not in
+    // the mirror ({} — no entry AND no error) may map to a raw remote id.
+    if (ref.error) return undefined;
+    if (!ref.entry) return { indexId: want, collectionId: want }; // unmirrored → raw remote id
+    // Mirror `ask --index` (src/verbs/read.ts): accept a media-descriptions index
+    // OR an untyped ("unknown") mirror entry — one added by raw id without --type
+    // stays "unknown" yet is still a valid ask/probe target. Only OTHER concrete
+    // types (face-analysis, entities, …) are rejected. Being stricter than
+    // `ask --index` here would make the deep tier unable to use an index that
+    // `ask --index` already answers over.
+    if (ref.entry.type !== "media-descriptions" && ref.entry.type !== "unknown") return undefined;
+    return { indexId: ref.entry.id, collectionId: ref.entry.id };
+  }
+  const attached = indexesByType(case_, "media-descriptions")[0];
+  return attached ? { indexId: attached.id, collectionId: attached.id } : undefined;
+}
+
+/** Resolve the bound memory providers for a case. local-grep is always present.
+ *  `opts.deep` requests the cloud tier (the opt-in Cloudglue collection provider)
+ *  — it is NEVER added for a plain (non-deep) resolution, so a default `ask` can't
+ *  silently spend against the collection. `opts.signal` (the command's AbortSignal)
+ *  is threaded to the cloud provider so a canceled/timed-out `ask --deep` aborts the
+ *  paid tinycloud query instead of leaving it running. */
+export function resolveMemory(case_: Case, profile?: Profile, opts: { deep?: boolean; signal?: AbortSignal } = {}): MemoryProvider[] {
   const setup = loadSetup(case_);
   const setupMemory = setup?.memory;
   const signalSet = new Set(setupMemory?.signals ?? []);
@@ -39,6 +76,44 @@ export function resolveMemory(case_: Case, profile?: Profile): MemoryProvider[] 
     }
   }
   if (setupMemory?.backend === "qmd" && !hasQmd) providers.push(new QmdMemoryProvider(case_, { verbs }));
+
+  // Cloud tier (opt-in, deep-only). Registered ONLY when all hold: `ask --deep`
+  // was requested (opts.deep), the operator opted in (setup.memory.cloudglue), a
+  // media-descriptions collection resolves, AND a Cloudglue key is present — so a
+  // plain `ask` never sees this provider (no silent spend) and it is unreachable
+  // unless explicitly asked for. Invariant #9: it queries via the public tinycloud
+  // ask verb (collection.ts / tcAsk), never the Cloudglue SDK.
+  if (opts.deep && setupMemory?.cloudglue) {
+    const apiKey = resolveCloudglue().apiKey;
+    const ref = apiKey ? resolveCloudglueCollection(case_, setupMemory.cloudglue.index) : undefined;
+    if (apiKey && ref) {
+      providers.push(
+        new CloudglueMemoryProvider(case_, {
+          indexId: ref.indexId,
+          collectionId: ref.collectionId,
+          base: tinycloudBaseFromRun(profile?.providers?.index?.run ?? profile?.providers?.collection?.run),
+          env: providerEnv(case_.mediaDir, case_.dir),
+          // thread the command's AbortSignal so a canceled/timed-out deep ask
+          // aborts the paid tinycloud query (parity with `ask --index`).
+          signal: opts.signal,
+        }),
+      );
+    } else {
+      // The operator opted into the cloud tier and asked for `--deep`, but it
+      // couldn't activate. `resolveMemory` returns a provider list (not records),
+      // so a stderr note is the right channel to say WHY the tier is silent —
+      // otherwise `ask --deep` prints the misleading qmd-only "no semantic memory
+      // provider" message, misstating a cloudglue-only setup. Gated on opts.deep
+      // (this whole block), so non-deep callers stay silent.
+      const pinned = setupMemory.cloudglue.index?.trim();
+      const why = !apiKey
+        ? "no Cloudglue key (set CLOUDGLUE_API_KEY, or `overcast setup memory cloudglue off` to opt out)"
+        : pinned
+          ? `no resolvable media-descriptions collection for pinned index '${pinned}' (missing, not a media-descriptions index, or an ambiguous name)`
+          : "no media-descriptions index attached to this case (attach one, or pin it with `overcast setup memory cloudglue <index>`)";
+      process.stderr.write(`overcast: ask --deep Cloudglue cloud tier inactive — ${why}\n`);
+    }
+  }
   return providers;
 }
 

--- a/src/state/setup.ts
+++ b/src/state/setup.ts
@@ -74,6 +74,14 @@ export interface CaseSetup {
   memory: {
     backend: "local-grep" | "qmd" | string;
     signals: string[];
+    /** OPT-IN (off by default — the field is absent unless the operator opts in):
+     *  fan `ask --deep` out to a case-linked Cloudglue **media-descriptions**
+     *  collection at cloud scale. Uploading/querying that collection costs money,
+     *  so it is never auto-enabled (invariant #2 BYO spirit). `index` optionally
+     *  pins a media-descriptions index id/name; otherwise the case's first
+     *  attached media-descriptions index is used. Toggle via
+     *  `overcast setup memory cloudglue [index|off]`. */
+    cloudglue?: { index?: string };
   };
   indexes: SetupIndex[];
   default_signals: Record<string, string[]>;

--- a/src/verbs/read.ts
+++ b/src/verbs/read.ts
@@ -12,6 +12,7 @@ import { THREAD_STAGE_LABEL, type TargetThread } from "../signals/threads.js";
 import { groupTimeline, groupSummary } from "../signals/rollup.js";
 import { listTargets } from "../state/target.js";
 import { listSources } from "../state/source.js";
+import { loadSetup } from "../state/setup.js";
 import { posterFrame } from "../media/ffmpeg.js";
 import { resolveMemory, fanOutAnswer, matchesMemoryProvider } from "../providers/memory/index.js";
 import { parseSince } from "../providers/memory/local.js";
@@ -138,7 +139,9 @@ export const askVerb: VerbSpec = {
     if (ctx.opts.since && parseSince(String(ctx.opts.since)) == null) {
       return [askError(`invalid --since value: ${ctx.opts.since} (try 24h, 7d, or 2026-06-01)`)];
     }
-    const available = resolveMemory(ctx.case, ctx.profile);
+    // pass `deep` so the opt-in cloud tier (Cloudglue collection) is resolved ONLY
+    // for `ask --deep` — a plain ask never sees it (no silent cloud spend).
+    const available = resolveMemory(ctx.case, ctx.profile, { deep: ctx.opts.deep === true, signal: ctx.signal });
     let providers = available.filter((p) => matchesMemoryProvider(p, "local-grep"));
     if (ctx.opts.memory) {
       const ids = String(ctx.opts.memory).split(",").map((s) => s.trim()).filter(Boolean);
@@ -156,6 +159,37 @@ export const askVerb: VerbSpec = {
     if (ctx.opts.deep === true) {
       providers = (ctx.opts.memory ? providers : available).filter((p) => typeof p.deepsearch === "function");
       if (providers.length === 0) {
+        // Distinguish "Cloudglue genuinely failed to activate" from "Cloudglue
+        // resolved fine but the user filtered it out with --memory". Only the
+        // former should blame Cloudglue. Presence in `available` is the signal:
+        // resolveMemory registers the cloudglue provider ONLY when it actually
+        // activated (opted in + keyed + a resolvable collection).
+        const cloudglueOptedIn = loadSetup(ctx.case)?.memory?.cloudglue != null;
+        const cloudgluePresent = available.some((p) => matchesMemoryProvider(p, "cloudglue"));
+        // Opted in AND genuinely inactive (no cloudglue provider resolved) — the
+        // real fix is the Cloudglue setup, NOT qmd. A bare "run setup memory qmd"
+        // would misdirect; resolveMemory already wrote the specific reason to stderr.
+        if (cloudglueOptedIn && !cloudgluePresent) {
+          return [
+            askError(
+              "the Cloudglue cloud tier is opted in for --deep but inactive " +
+                "(check CLOUDGLUE_API_KEY and ensure a media-descriptions index is attached/pinned — " +
+                "the specific reason was written to stderr); " +
+                "or run `overcast setup memory qmd` for local semantic search, or use plain `ask` for local-grep",
+            ),
+          ];
+        }
+        // Cloudglue DID resolve into `available` but `--memory` excluded it — say
+        // so instead of the qmd misdirection or (wrongly) blaming Cloudglue.
+        if (cloudgluePresent && ctx.opts.memory) {
+          return [
+            askError(
+              `--memory ${ctx.opts.memory} excluded the Cloudglue cloud tier (the only --deep provider available); ` +
+                "drop --memory (or include cloudglue) to use it, run `overcast setup memory qmd` for local semantic search, " +
+                "or use plain `ask` for local-grep",
+            ),
+          ];
+        }
         return [
           askError(
             "no semantic memory provider is configured for --deep " +

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -17,6 +17,7 @@ import { execCapture } from "../providers/exec.js";
 import { tokenizeCommand } from "../providers/sources/index.js";
 import { tinycloudBase } from "../providers/tinycloud/envelope.js";
 import { DEFAULT_QMD_MODEL } from "../providers/memory/qmd.js";
+import { loadSetup, saveSetup, emptySetup } from "../state/setup.js";
 import { findProviderChoice, providerChoices, PROVIDER_PRESETS, type ProviderChoice } from "../providers/catalog.js";
 import { localVisionPython } from "../providers/local/vision.js";
 import { PI_VERSION } from "../version.js";
@@ -268,9 +269,27 @@ export const setupVerb: VerbSpec = {
     }
     if (action === "memory") {
       const backend = (ctx.rest[0] ?? "local-grep").trim();
-      if (!backend) return [err("setup", "usage: setup memory <local-grep|qmd> [command]")];
+      if (!backend) return [err("setup", "usage: setup memory <local-grep|qmd|cloudglue> [command|index]")];
+      // `cloudglue` is the CASE-scoped, opt-in cloud tier for `ask --deep`
+      // (invariant #2 BYO spirit — uploads/queries cost money, so it is NEVER
+      // auto-enabled). Unlike local-grep/qmd it does not bind a profile provider:
+      // it pins the case's media-descriptions collection, so it lives in the case
+      // setup (.overcast/setup.json). `[index]` pins a specific media-descriptions
+      // index (id/name); `off` clears the opt-in.
+      if (backend === "cloudglue") {
+        const setup = loadSetup(ctx.case) ?? emptySetup(ctx.case.exists() ? ctx.case.info().name : "case");
+        const arg = (ctx.rest[1] ?? "").trim();
+        if (/^(off|false|none|disable|clear)$/i.test(arg)) {
+          delete setup.memory.cloudglue;
+        } else {
+          setup.memory.cloudglue = arg ? { index: arg } : {};
+        }
+        setup.updated_at = new Date().toISOString();
+        saveSetup(ctx.case, setup);
+        return [makeRecord({ verb: "setup", format: "json", payload: { memory: { cloudglue: setup.memory.cloudglue ?? null }, case: ctx.case.dir }, state: "ready" })];
+      }
       if (backend !== "local-grep" && backend !== "local" && backend !== "qmd") {
-        return [err("setup", `unknown memory backend '${backend}' (expected local-grep | qmd)`)];
+        return [err("setup", `unknown memory backend '${backend}' (expected local-grep | qmd | cloudglue)`)];
       }
       if (backend === "local-grep" || backend === "local") {
         profile.memory = [];

--- a/test/unit/cloudglue-memory.test.ts
+++ b/test/unit/cloudglue-memory.test.ts
@@ -1,0 +1,601 @@
+// Offline unit tests for the opt-in Cloudglue memory provider (`ask --deep` over
+// a case-linked media-descriptions collection). Everything runs against the
+// stubbed tinycloud CLI (OVERCAST_TINYCLOUD_CMD → test/fixtures/fake-tinycloud.sh),
+// so the REAL envelope→record→passage mapping runs with NO live creds. Invariant
+// #9: the provider never imports the Cloudglue SDK; it goes through tcAsk.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openCase } from "../../src/case.ts";
+import { defaultProfile } from "../../src/profile.ts";
+import { makeRecord } from "../../src/record.ts";
+import { addIndex } from "../../src/state/index.ts";
+import { emptySetup, saveSetup, loadSetup } from "../../src/state/setup.ts";
+import { CloudglueMemoryProvider } from "../../src/providers/memory/cloudglue.ts";
+import { resolveMemory, fanOutAnswer } from "../../src/providers/memory/index.ts";
+import { LocalMemoryProvider } from "../../src/providers/memory/local.ts";
+import { setupVerb } from "../../src/verbs/setup.ts";
+import { askVerb } from "../../src/verbs/read.ts";
+import type { VerbContext } from "../../src/registry/types.ts";
+
+const FIXTURE = `bash ${join(process.cwd(), "test/fixtures/fake-tinycloud.sh")}`;
+
+function withCase(fn: (c: ReturnType<typeof openCase>, dir: string) => void | Promise<void>) {
+  const dir = mkdtempSync(join(tmpdir(), "oc-cg-"));
+  const c = openCase(dir);
+  c.ensure();
+  return Promise.resolve(fn(c, dir)).finally(() => rmSync(dir, { recursive: true, force: true }));
+}
+
+/** Run `fn` with a controlled env, restoring every touched key afterward. `null`
+ *  deletes the key for the duration (used to force "no Cloudglue key"). */
+async function withEnv(vars: Record<string, string | null>, fn: () => void | Promise<void>) {
+  const prev: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(vars)) {
+    prev[k] = process.env[k];
+    if (v === null) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+/** Write a fake tinycloud (in `dir`) that tallies each `ask`/`probe` call by
+ *  appending one byte to `countFile`, so a test can PROVE call coalescing (count
+ *  the bytes = the number of paid cloud calls). `body`:
+ *   - "delegate": exec the shared realistic fixture (answer + one citation);
+ *   - "empty": return a ready answer with NO text/citations, so `deepsearch`
+ *     yields [] and `fanOutAnswer` falls through to `answer` — the exact
+ *     Finding-A double-call path.
+ *  Returns the `base` command string to hand the provider. */
+function countingTinycloud(dir: string, countFile: string, body: "delegate" | "empty" = "delegate"): string {
+  const script = join(dir, `counting-tc-${body}.sh`);
+  const emit =
+    body === "empty"
+      ? `echo '{"tinycloud":"1","kind":"ask","status":"ready","data":{"answer":"","citations":[]}}'`
+      : `exec bash ${join(process.cwd(), "test/fixtures/fake-tinycloud.sh")} "$@"`;
+  writeFileSync(
+    script,
+    [
+      "#!/usr/bin/env bash",
+      `if [ "\${1:-}" = "ask" ] || [ "\${1:-}" = "probe" ]; then printf x >> ${countFile}; fi`,
+      emit,
+      "",
+    ].join("\n"),
+  );
+  return `bash ${script}`;
+}
+
+/** Count the paid cloud calls a `countingTinycloud` fake tallied. */
+function askCalls(countFile: string): number {
+  return existsSync(countFile) ? readFileSync(countFile, "utf8").length : 0;
+}
+
+test("status() is missing without a collection (key present)", async () => {
+  await withCase(async (c) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const p = new CloudglueMemoryProvider(c, { indexId: "", collectionId: "" });
+      const st = await p.status();
+      assert.equal(st.state, "missing");
+      assert.match(st.error ?? "", /media-descriptions|CLOUDGLUE_API_KEY/);
+    });
+  });
+});
+
+test("status() is missing without a Cloudglue key (collection present)", async () => {
+  await withCase(async (c, dir) => {
+    // point HOME at an empty dir so readTinycloudKey finds no ~/.tinycloud key,
+    // and drop CLOUDGLUE_API_KEY — resolveCloudglue().apiKey must be undefined.
+    await withEnv({ CLOUDGLUE_API_KEY: null, HOME: dir }, async () => {
+      const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x" });
+      const st = await p.status();
+      assert.equal(st.state, "missing");
+    });
+  });
+});
+
+test("status() is ready with a key and a collection", async () => {
+  await withCase(async (c) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x" });
+      const st = await p.status();
+      assert.equal(st.state, "ready");
+      assert.equal((st.config as Record<string, unknown>).collection, "col_x");
+    });
+  });
+});
+
+test("query() is empty — a plain ask never touches the cloud", async () => {
+  await withCase(async (c) => {
+    const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base: FIXTURE });
+    assert.deepEqual(p.query("anything"), []);
+  });
+});
+
+test("deepsearch() maps the tinycloud ask envelope to anchored passages", async () => {
+  await withCase(async (c) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base: FIXTURE });
+      const passages = await p.deepsearch("why did the buyer object?");
+      assert.equal(passages.length, 1);
+      const [hit] = passages;
+      // fixture ask envelope: answer "They objected to the price.", citation
+      // { file: "vid1.mp4", timestamp: 42 }
+      assert.equal(hit.recordId, "vid1.mp4");
+      assert.equal(hit.at, 42);
+      assert.match(hit.text, /objected to the price/);
+      assert.equal(hit.provider, "cloudglue");
+    });
+  });
+});
+
+test("answer() returns the grounded answer + mapped citations", async () => {
+  await withCase(async (c) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base: FIXTURE });
+      const ans = await p.answer("why did the buyer object?");
+      assert.match(ans.text, /objected to the price/);
+      assert.equal(ans.citations.length, 1);
+      assert.equal(ans.citations[0].recordId, "vid1.mp4");
+      assert.equal(ans.citations[0].at, 42);
+    });
+  });
+});
+
+// ---- Finding A: deepsearch + answer for one query = ONE paid tcAsk call -------
+
+test("deepsearch + answer for the same query coalesce into ONE tcAsk call (no double cloud spend)", async () => {
+  await withCase(async (c, dir) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const countFile = join(dir, "ask-calls-direct");
+      const base = countingTinycloud(dir, countFile, "delegate");
+      const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base });
+      // both public entry points call the private run() for the SAME query.
+      const passages = await p.deepsearch("why did the buyer object?");
+      const ans = await p.answer("why did the buyer object?");
+      assert.equal(passages.length, 1); // still fully functional
+      assert.match(ans.text, /objected to the price/);
+      assert.equal(askCalls(countFile), 1, "the per-instance memo must collapse both to ONE tcAsk call");
+    });
+  });
+});
+
+test("fanOutAnswer (deep) with an empty cloud result makes ONE tcAsk call, not two", async () => {
+  // Reproduces the exact Finding-A path: deepsearch yields no passages, so
+  // fanOutAnswer falls through to answer(). Without the memo that is two paid
+  // calls for one user query; with it, one.
+  await withCase(async (c, dir) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const countFile = join(dir, "ask-calls-fanout");
+      const base = countingTinycloud(dir, countFile, "empty");
+      const cloud = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base });
+      await fanOutAnswer([cloud], "why did the buyer object?", {}, true);
+      assert.equal(askCalls(countFile), 1, "deepsearch()→[] then answer() must share ONE tcAsk call");
+    });
+  });
+});
+
+test("distinct queries are NOT coalesced (the memo keys on the query)", async () => {
+  await withCase(async (c, dir) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const countFile = join(dir, "ask-calls-distinct");
+      const base = countingTinycloud(dir, countFile, "delegate");
+      const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base });
+      await p.deepsearch("first question?");
+      await p.answer("second question?");
+      assert.equal(askCalls(countFile), 2, "different queries must each make their own call");
+    });
+  });
+});
+
+test("resolveMemory includes cloudglue only when opted in, deep, keyed, with a collection", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {}; // opt in (default: first attached media-descriptions index)
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(deep.some((p) => p.id === "cloudglue"), "deep resolution includes cloudglue when opted in");
+      const shallow = resolveMemory(c, defaultProfile(), { deep: false });
+      assert.ok(!shallow.some((p) => p.id === "cloudglue"), "non-deep resolution never includes cloudglue");
+      // default (no opts) must also stay cloud-free — plain ask/brief path
+      assert.ok(!resolveMemory(c, defaultProfile()).some((p) => p.id === "cloudglue"));
+    });
+  });
+});
+
+test("resolveMemory omits cloudglue when the case has an index but no opt-in (no silent spend)", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    // no setup.memory.cloudglue → NOT opted in, even with a media-descriptions index + key
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(!deep.some((p) => p.id === "cloudglue"));
+    });
+  });
+});
+
+test("resolveMemory omits cloudglue when opted in but no Cloudglue key resolves", async () => {
+  await withCase(async (c, dir) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: null, HOME: dir }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(!deep.some((p) => p.id === "cloudglue"));
+    });
+  });
+});
+
+// ---- Finding B: an ambiguous pinned index name must NOT become a raw id -------
+
+test("resolveMemory omits cloudglue when the pinned index name is AMBIGUOUS (fail closed, no wrong collection)", async () => {
+  await withCase(async (c) => {
+    // two mirror indexes share the display name "Scenes" → resolveIndexRef reports
+    // ambiguity. The pinned name must NOT silently become a raw collection id.
+    addIndex(c, { id: "col_a", name: "Scenes", type: "media-descriptions" });
+    addIndex(c, { id: "col_b", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = { index: "Scenes" }; // pin the AMBIGUOUS name
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(
+        !deep.some((p) => p.id === "cloudglue"),
+        "an ambiguous pinned name must fail closed, not resolve to a raw collection id",
+      );
+    });
+  });
+});
+
+test("resolveMemory still resolves a pinned name that is UNIQUE (ambiguity guard didn't over-reach)", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_a", name: "Scenes", type: "media-descriptions" });
+    addIndex(c, { id: "col_b", name: "Other", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = { index: "Scenes" }; // unique name → resolves to col_a
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(deep.some((p) => p.id === "cloudglue"), "a unique pinned name still registers cloudglue");
+    });
+  });
+});
+
+test("resolveMemory still accepts a truly-unmirrored pinned id as a raw collection id", async () => {
+  await withCase(async (c) => {
+    // no index with this id/name in the mirror → resolveIndexRef returns {} →
+    // raw remote id is the correct, preserved behavior (only ambiguity fails closed).
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = { index: "col_raw_remote" };
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(deep.some((p) => p.id === "cloudglue"), "an unmirrored pinned id still resolves as a raw remote id");
+    });
+  });
+});
+
+// ---- Round-4 Finding A: an 'unknown'-typed pinned index is ask-able ----------
+
+test("resolveMemory registers cloudglue for a pinned 'unknown'-typed index (parity with ask --index)", async () => {
+  await withCase(async (c) => {
+    // an index added by raw id without --type stays "unknown"; `ask --index`
+    // accepts it, so the Cloudglue deep tier must too (was previously rejected).
+    addIndex(c, { id: "col_u", name: "Untyped", type: "unknown" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = { index: "col_u" }; // pin the untyped index
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(
+        deep.some((p) => p.id === "cloudglue"),
+        "an 'unknown'-typed pinned index must register cloudglue (mirrors ask --index)",
+      );
+    });
+  });
+});
+
+test("resolveMemory rejects a pinned index whose type is neither media-descriptions nor unknown", async () => {
+  await withCase(async (c) => {
+    // a face-analysis index is not ask-able — still fails closed, unchanged.
+    addIndex(c, { id: "col_f", name: "Faces", type: "face-analysis" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = { index: "col_f" };
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true });
+      assert.ok(
+        !deep.some((p) => p.id === "cloudglue"),
+        "a non-ask-able (face-analysis) pinned index must not register cloudglue",
+      );
+    });
+  });
+});
+
+test("fanOutAnswer (deep) merges the cloud citation with local ones", async () => {
+  await withCase(async (c) => {
+    c.writeRecord(makeRecord({ verb: "note", payload: { text: "The buyer objected to the price at the dock" }, media: { ref: "note1" } }));
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const local = new LocalMemoryProvider(c);
+      const cloud = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base: FIXTURE });
+      const ans = await fanOutAnswer([local, cloud], "objected", {}, true);
+      assert.ok(ans.citations.some((cit) => cit.recordId === "vid1.mp4"), "cloud citation present");
+      assert.ok(ans.citations.some((cit) => cit.recordId !== "vid1.mp4"), "local citation present");
+      assert.match(ans.text, /objected to the price/);
+    });
+  });
+});
+
+// ---- verb-level: ask --deep over the opted-in stubbed case --------------------
+
+function ctx(c: ReturnType<typeof openCase>, input: string, opts: VerbContext["opts"] = {}): VerbContext {
+  return { input, rest: [], opts, case: c, profile: defaultProfile() };
+}
+
+test("ask --deep answers over the case's Cloudglue collection when opted in", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key", OVERCAST_TINYCLOUD_CMD: FIXTURE }, async () => {
+      const [rec] = await askVerb.run(ctx(c, "why did the buyer object?", { deep: true }));
+      assert.equal(rec.state, "ready");
+      assert.equal(rec.meta?.provider, "cloudglue");
+      assert.match(String((rec.payload as Record<string, unknown>).text), /objected to the price/);
+      const citations = (rec.payload as Record<string, unknown>).citations as Array<Record<string, unknown>>;
+      assert.ok(citations.some((cit) => cit.recordId === "vid1.mp4"));
+    });
+  });
+});
+
+// ---- Round-3: the deep-no-provider error names Cloudglue when opted-in --------
+
+test("ask --deep opted into Cloudglue but inactive → a Cloudglue-aware error, not a bare qmd suggestion", async () => {
+  await withCase(async (c) => {
+    // opted in, key present, but NO media-descriptions index attached → the cloud
+    // tier can't activate, so no deepsearch provider resolves. The returned error
+    // RECORD must point at the Cloudglue setup, not misdirect to `setup memory qmd`.
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const note = await captureStderr(async () => {
+        const [rec] = await askVerb.run(ctx(c, "why did the buyer object?", { deep: true }));
+        assert.equal(rec.state, "error");
+        assert.match(rec.error ?? "", /Cloudglue/);
+        // NOT the bare "no semantic memory provider … setup memory qmd" misdirection
+        assert.doesNotMatch(rec.error ?? "", /^no semantic memory provider/);
+      });
+      // the round-2 stderr note (the specific reason) still fires alongside
+      assert.match(note, /Cloudglue cloud tier inactive/);
+    });
+  });
+});
+
+test("ask --deep WITHOUT a Cloudglue opt-in keeps the existing qmd suggestion (unchanged)", async () => {
+  await withCase(async (c) => {
+    // no setup.memory.cloudglue → the deep-no-provider error stays the qmd message,
+    // byte-for-byte the pre-round-3 behavior (no Cloudglue mention).
+    const [rec] = await askVerb.run(ctx(c, "why did the buyer object?", { deep: true }));
+    assert.equal(rec.state, "error");
+    assert.match(rec.error ?? "", /no semantic memory provider is configured for --deep/);
+    assert.match(rec.error ?? "", /overcast setup memory qmd/);
+    assert.doesNotMatch(rec.error ?? "", /Cloudglue/);
+  });
+});
+
+// ---- Round-4 Finding B: --memory filtering out an ACTIVE Cloudglue tier -------
+
+test("ask --deep --memory local-grep with Cloudglue resolvable does NOT blame Cloudglue (it was filtered, not inactive)", async () => {
+  await withCase(async (c) => {
+    // Cloudglue opted in + keyed + a resolvable media-descriptions collection →
+    // the cloudglue provider IS in `available`. Filtering to --memory local-grep
+    // leaves no deepsearch provider, but that's the FILTER's doing, not a
+    // Cloudglue failure — the error must not claim Cloudglue is inactive.
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key", OVERCAST_TINYCLOUD_CMD: FIXTURE }, async () => {
+      const [rec] = await askVerb.run(ctx(c, "why did the buyer object?", { deep: true, memory: "local-grep" }));
+      assert.equal(rec.state, "error");
+      // NOT the round-3 "Cloudglue … inactive" text — Cloudglue resolved fine.
+      assert.doesNotMatch(rec.error ?? "", /opted in for --deep but inactive/);
+      // instead: either the --memory note or the standard qmd message.
+      assert.match(rec.error ?? "", /--memory local-grep excluded|no semantic memory provider/);
+    });
+  });
+});
+
+// ---- opt-in surface: `setup memory cloudglue [index|off]` ---------------------
+
+function setupCtx(c: ReturnType<typeof openCase>, dir: string, rest: string[]): VerbContext {
+  return { input: "memory", rest, opts: {}, case: c, profile: defaultProfile(), home: dir, profileName: "default" };
+}
+
+test("setup memory cloudglue enables the opt-in in the case setup", async () => {
+  await withCase(async (c, dir) => {
+    const [rec] = await setupVerb.run(setupCtx(c, dir, ["cloudglue"]));
+    assert.equal(rec.state, "ready");
+    const saved = loadSetup(c);
+    assert.deepEqual(saved?.memory.cloudglue, {});
+  });
+});
+
+test("setup memory cloudglue <index> pins a specific media-descriptions index", async () => {
+  await withCase(async (c, dir) => {
+    await setupVerb.run(setupCtx(c, dir, ["cloudglue", "col_pinned"]));
+    assert.deepEqual(loadSetup(c)?.memory.cloudglue, { index: "col_pinned" });
+  });
+});
+
+test("setup memory cloudglue off clears the opt-in", async () => {
+  await withCase(async (c, dir) => {
+    await setupVerb.run(setupCtx(c, dir, ["cloudglue"]));
+    await setupVerb.run(setupCtx(c, dir, ["cloudglue", "off"]));
+    assert.equal(loadSetup(c)?.memory.cloudglue, undefined);
+  });
+});
+
+// ---- Round-2 Finding A: the command's AbortSignal reaches the cloud provider --
+
+test("resolveMemory threads the AbortSignal into the cloudglue provider config (deep ask is cancelable)", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const controller = new AbortController();
+      const deep = resolveMemory(c, defaultProfile(), { deep: true, signal: controller.signal });
+      const cloud = deep.find((p) => p.id === "cloudglue");
+      assert.ok(cloud, "deep resolution includes cloudglue");
+      // the config the provider forwards to tcAsk (run() passes this.ref.signal),
+      // so an aborted command aborts the paid cloud query instead of leaking it.
+      const ref = (cloud as unknown as { ref: { signal?: AbortSignal } }).ref;
+      assert.equal(ref.signal, controller.signal, "the command's AbortSignal reaches the provider config");
+    });
+  });
+});
+
+test("resolveMemory without a signal leaves the cloud provider config signal undefined (backward-compatible)", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const deep = resolveMemory(c, defaultProfile(), { deep: true }); // no signal (case.ts caller)
+      const cloud = deep.find((p) => p.id === "cloudglue");
+      assert.ok(cloud);
+      assert.equal((cloud as unknown as { ref: { signal?: AbortSignal } }).ref.signal, undefined);
+    });
+  });
+});
+
+// ---- Round-2 Finding B: opt-in that can't activate is NOT silent (stderr note)-
+
+/** Capture everything written to process.stderr while `fn` runs, restoring the
+ *  original writer afterward. Used to prove the cloud-tier note fires (or not). */
+async function captureStderr(fn: () => void | Promise<void>): Promise<string> {
+  const target = process.stderr as unknown as { write: (chunk: string | Uint8Array) => boolean };
+  const orig = target.write.bind(process.stderr);
+  let out = "";
+  target.write = (chunk) => {
+    out += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    target.write = orig;
+  }
+  return out;
+}
+
+test("deep + opted-in but NO attached media-descriptions collection → a clear stderr note (not silent)", async () => {
+  await withCase(async (c) => {
+    // opted in, key present, but no media-descriptions index attached → no collection
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const note = await captureStderr(() => {
+        const deep = resolveMemory(c, defaultProfile(), { deep: true });
+        assert.ok(!deep.some((p) => p.id === "cloudglue"), "provider still omitted when no collection resolves");
+      });
+      assert.match(note, /Cloudglue cloud tier inactive/);
+      assert.match(note, /no media-descriptions index/);
+    });
+  });
+});
+
+test("deep + opted-in but NO Cloudglue key → a distinct 'no key' stderr note", async () => {
+  await withCase(async (c, dir) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: null, HOME: dir }, async () => {
+      const note = await captureStderr(() => {
+        resolveMemory(c, defaultProfile(), { deep: true });
+      });
+      assert.match(note, /Cloudglue cloud tier inactive/);
+      assert.match(note, /no Cloudglue key/);
+    });
+  });
+});
+
+test("deep + opted-in with an AMBIGUOUS pinned index names the pin in the stderr note", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_a", name: "Scenes", type: "media-descriptions" });
+    addIndex(c, { id: "col_b", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = { index: "Scenes" }; // ambiguous → fails closed
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const note = await captureStderr(() => resolveMemory(c, defaultProfile(), { deep: true }));
+      assert.match(note, /pinned index 'Scenes'/);
+    });
+  });
+});
+
+test("NON-deep resolution never emits the cloud-tier note (plain ask / case memory status stay silent)", async () => {
+  await withCase(async (c) => {
+    // the exact condition that fires the note under --deep (opted in, no collection)
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const note = await captureStderr(() => {
+        resolveMemory(c, defaultProfile(), { deep: false });
+        resolveMemory(c, defaultProfile()); // default opts too
+      });
+      assert.equal(note, "", "non-deep resolution must stay silent about the cloud tier");
+    });
+  });
+});
+
+test("a cleanly-activating cloud tier emits NO stderr note", async () => {
+  await withCase(async (c) => {
+    addIndex(c, { id: "col_x", name: "Scenes", type: "media-descriptions" });
+    const setup = emptySetup("cg-test");
+    setup.completed = true;
+    setup.memory.cloudglue = {};
+    saveSetup(c, setup);
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      const note = await captureStderr(() => {
+        const deep = resolveMemory(c, defaultProfile(), { deep: true });
+        assert.ok(deep.some((p) => p.id === "cloudglue"));
+      });
+      assert.equal(note, "", "a working cloud tier is silent");
+    });
+  });
+});

--- a/test/unit/cloudglue-memory.test.ts
+++ b/test/unit/cloudglue-memory.test.ts
@@ -150,6 +150,28 @@ test("answer() returns the grounded answer + mapped citations", async () => {
   });
 });
 
+// ---- Bugbot #72: cloud citations honor --limit like qmd/local-grep -----------
+
+test("deepsearch + answer cap cloud citations at opts.limit (parity with the other memory providers)", async () => {
+  await withCase(async (c, dir) => {
+    await withEnv({ CLOUDGLUE_API_KEY: "test-key" }, async () => {
+      // tcAsk ignores `limit` for a non-probe collection ask, so a fixture that
+      // returns FIVE citations lets us prove the PROVIDER caps its fan-out output —
+      // otherwise cloudglue would over-contribute vs qmd/local-grep for one --limit.
+      const script = join(dir, "multi-cite-tc.sh");
+      const cites = [1, 2, 3, 4, 5].map((n) => `{"file":"v${n}.mp4","timestamp":${n},"text":"m${n}"}`).join(",");
+      writeFileSync(
+        script,
+        ["#!/usr/bin/env bash", `echo '{"tinycloud":"1","kind":"ask","status":"ready","data":{"answer":"multi","citations":[${cites}]}}'`, ""].join("\n"),
+      );
+      const p = new CloudglueMemoryProvider(c, { indexId: "col_x", collectionId: "col_x", base: `bash ${script}` });
+      assert.equal((await p.deepsearch("q")).length, 5, "no limit → all cloud moments");
+      assert.equal((await p.deepsearch("q", { limit: 2 })).length, 2, "--limit caps cloud passages");
+      assert.equal((await p.answer("q", { limit: 3 })).citations.length, 3, "answer citations honor --limit too");
+    });
+  });
+});
+
 // ---- Finding A: deepsearch + answer for one query = ONE paid tcAsk call -------
 
 test("deepsearch + answer for the same query coalesce into ONE tcAsk call (no double cloud spend)", async () => {


### PR DESCRIPTION
## What & why (direction / new capability)

overcast's core promise — *intelligence accumulates* in a case — requires cross-modal search over the case's **actual video** at cloud scale. The infrastructure was ~95% there (collections lifecycle, deepsearch hook, fan-out), but the glue was missing: users had to manually wire `index create` + `ask --index`. This adds the missing piece — a `CloudglueMemoryProvider` that answers `ask --deep` over a case-linked media-descriptions collection.

**Design (two hard constraints honored):**
- **No silent spend (opt-in, deep-only).** The provider is registered in `resolveMemory` **only** when all hold: `ask --deep` was requested (`opts.deep`), the case opted in (`setup.memory.cloudglue`), a media-descriptions collection resolves, and a Cloudglue key is present. A plain `ask` calls `resolveMemory(..., { deep: false })`, so the provider is never in the list — and even if it were, its `query()` returns `[]`. `write()` is a no-op (read-only; auto-ingest is a separate cost-policy feature).
- **Public tinycloud verbs only (invariant #9).** Every call goes through `tcAsk` (`src/providers/tinycloud/collection.ts`) — the same public collection-ask path that powers `ask --index` — **never** the Cloudglue SDK (`grep -rn '@cloudglue|cloudglue-js' src/providers/memory/` → empty). Cited moments map to `Passage[]`/`Answer` with `at` anchors.

Opt-in is set via `setup memory cloudglue [index|off]`, written to the case's `.overcast/setup.json` (it's inherently case-scoped — it pins the case's collection).

## Verification evidence

- `npm run typecheck` — ✅ exit 0
- `npm test` — ✅ **810 pass / 0 fail** (+14; existing read/resolveMemory tests unmodified → **plain-ask byte-identical** without the opt-in)
- `node --test --import tsx test/unit/cloudglue-memory.test.ts` — ✅ 14/14
- `npm run build` — ✅ exit 0
- `SKIP_BUILD=1 bash test/e2e/run.sh` — ✅ **171/171 passed, 0 failed**
- `grep -n 'cloudglue' src/providers/memory/index.ts` — ✅ deep-only gate (`opts.deep && setupMemory?.cloudglue && resolveCloudglue().apiKey`)
- Invariant #9 — ✅ no Cloudglue SDK import

Tests are fully **offline**: `OVERCAST_TINYCLOUD_CMD` bound to `test/fixtures/fake-tinycloud.sh` whose `ask` branch echoes a realistic envelope, so the real envelope→record→passage mapping runs; a dedicated test confirms an attached media-descriptions index **alone** doesn't trigger the provider (opt-in required). Live e2e is optional/creds-gated.

## Deviations

- `src/verbs/read.ts` touched (one line) — the required `resolveMemory` caller update for `deep`; the 3 `case.ts` callers need no change (new param optional), well under the ~6-site STOP threshold.
- Opt-in lives in the **case** setup (not the profile like qmd) because it pins a case's collection — matches the plan's `SetupModel` field and keeps `case.ts` out of scope.

## Scope

In-scope: new `src/providers/memory/cloudglue.ts`, `src/providers/memory/index.ts`, `src/state/setup.ts`, `src/verbs/setup.ts`, one line in `src/verbs/read.ts`, new `test/unit/cloudglue-memory.test.ts`, `docs/providers.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces paid cloud queries on `ask --deep`, but registration is gated on explicit opt-in, credentials, and deep mode; main risk is misconfiguration or user surprise at billing, mitigated by read-only provider and stderr/error messaging.
> 
> **Overview**
> **Opt-in cloud semantic search for `ask --deep`** over a case’s **media-descriptions** collection (alias `cloudglue` / `tinycloud`). Plain `ask` never registers or calls it; activation requires `--deep`, `setup memory cloudglue`, a resolvable index, and `CLOUDGLUE_API_KEY`.
> 
> The new **`CloudglueMemoryProvider`** reads collections only (`write` no-op, `query()` empty) and uses **`tcAsk`** (same path as `ask --index`), mapping citations to passages with **`--limit`** enforcement and **one memoized paid call** per query when both `deepsearch` and `answer` run.
> 
> **`resolveMemory`** gains `{ deep, signal }`: cloudglue is added only for deep asks; **AbortSignal** propagates to tinycloud; stderr explains inactive tiers; pinned indexes **fail closed** on ambiguity and accept **`unknown`** types like `ask --index`.
> 
> **Case setup** stores **`memory.cloudglue`** in `.overcast/setup.json`. **`setup memory cloudglue [index|off]`** toggles opt-in (case-scoped, not profile qmd). **`ask`** passes `deep`/`signal` and returns **Cloudglue-specific errors** instead of generic qmd hints when opted-in but inactive or filtered by `--memory`.
> 
> Docs and a large offline **`cloudglue-memory.test.ts`** suite cover coalescing, limits, and verb/setup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae3b33656a6be5c146796d9b14b2a8da90e1ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->