### PR TITLE
Add enhance --ops ela and --ops panorama (image forensics + panorama stitch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,13 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   search — `add`/`match`/`search` image→image, text→image against `basic-clip`
   indexes, or audio→audio, text→audio against `basic-clap` indexes; videos
   frame-sampled + pooled, audio windowed into 10s moments), `enhance` (system
-  ffmpeg ops, a bound restore model, or the split ops `--ops separate` = per-speaker
-  tracks + optional `--summarize`, and `--ops segment --prompt` = text-prompted
-  masks/cutouts — bound `local-models` or `fal`, fanned out one record per artifact),
+  ffmpeg ops, a bound restore model, or the provider-only fan-out ops
+  `--ops separate` = per-speaker tracks + optional `--summarize`, `--ops segment
+  --prompt` = text-prompted masks/cutouts (bound `local-models` or `fal`),
+  `--ops ela` = ELA/noise/luminance forensic overlays from an image (heuristic
+  edit-detection leads; `examples/providers/enhance/ela.py`), and `--ops panorama`
+  = stitch a panning video into one wide still for skyline/landmark geolocation
+  (`examples/providers/enhance/panorama.py`) — each fanned out one record per artifact),
   `reconstruct` (SPECULATIVE scene reconstruction from a still or `--at` video
   frame via a bound generative provider — fal toolbox: `--rotate/--elevate/--zoom`
   camera reposition + `--ops sweep` 360° stops → contact sheet + turntable mp4

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -417,6 +417,37 @@ overcast view <parent-id>                                        # gallery / emb
 - **Cost note.** The Qwen multi-angle LoRA bills ~$0.035/megapixel per synthesized
   view — an 8-stop sweep of a ~1 MP frame is ~$0.28.
 
+## Enhance analysis ops — `ela` (forensics) + `panorama` (stitch)
+
+Two more provider-only `enhance` ops derive analysis artifacts from ONE input and
+fan out the same way (parent + children, gallery-able via `overcast view <parent>`).
+Both ship as shell-free example providers — no fal/local-models preset, just bind
+the script:
+
+```bash
+# image forensics: ELA + noise residual + luminance-gradient overlays (pillow + numpy)
+overcast setup provider enhance "exec:python3 examples/providers/enhance/ela.py"
+overcast enhance suspect.jpg --ops ela          # -> parent + 3 overlay children
+#   ...or stitch a panning video into one wide still (opencv-python + numpy)
+overcast setup provider enhance "exec:python3 examples/providers/enhance/panorama.py"
+overcast enhance pan_shot.mp4 --ops panorama    # -> parent + 1 stitched-still child
+overcast view <parent-id>                       # gallery of the overlays / the wide still
+```
+
+- **ela** (`examples/providers/enhance/ela.py`, pillow + numpy) — from an image it
+  writes three heuristic maps: **ELA** (re-save at JPEG q90, amplify the per-pixel
+  abs difference so recompressed/pasted regions light up), **noise residual** (input
+  minus a blurred copy, normalized), and a **luminance gradient** (Sobel edge
+  magnitude). These are *leads, not proof* — compression, resizing, and texture also
+  trigger them (`payload.caveat` says so). Image-only; run it on a `frame://` still of
+  a video.
+- **panorama** (`examples/providers/enhance/panorama.py`, opencv-python + numpy) —
+  samples ~18 frames uniformly across a video (dropping black + near-duplicate
+  frames) and runs `cv2.Stitcher` in PANORAMA mode into one wide still, exposing a
+  skyline/landmark strip for geolocation that no single frame shows. A failed stitch
+  (too little overlap / too much motion) returns a clean error record, not a crash.
+  The stitched still is a first-class `media.enhanced` child → `see`/`crop`/reverse-search it.
+
 ## Object detection (`see` — open-vocabulary, local)
 
 A zero-shot **object detector** that takes a list of target objects (`--detect`)

--- a/examples/providers/enhance/ela.py
+++ b/examples/providers/enhance/ela.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# overcast `enhance --ops ela` (LOCAL): image-forensics overlays.
+# From ONE input image it derives THREE heuristic maps that make edits visible:
+#   1) ELA (Error Level Analysis) — re-save as JPEG q90, amplify the per-pixel
+#      abs difference vs the original; pasted/edited regions recompress at a
+#      different error level and light up.
+#   2) noise residual — input minus a blurred copy, normalized; a spliced patch
+#      often carries a different sensor-noise floor than its surroundings.
+#   3) luminance gradient — Sobel edge magnitude of the luma channel; exposes
+#      cloned/feathered seams and inconsistent edge sharpness.
+# Emits ONE record whose payload.outputs[] is fanned out into a record per
+# overlay by the enhance verb (parent + 3 children, each a viewable image).
+#
+# Bind, then run:
+#   overcast setup provider enhance "exec:python3 examples/providers/enhance/ela.py"
+#   overcast enhance suspect.jpg --ops ela
+#   overcast view <parent-id>            # gallery of the three overlays
+#
+# Needs:  pillow, numpy   (pip install pillow numpy — or the uv venv:
+#         scripts/visual-db-uv.sh already installs numpy; add pillow, e.g. via
+#         `scripts/visual-db-uv.sh --segment`, or `uv pip install pillow`).
+# Env:    OVERCAST_MEDIA_DIR (output dir; falls back to the input's directory),
+#         OVERCAST_ELA_QUALITY (JPEG re-save quality, default 90),
+#         OVERCAST_ELA_BLUR (noise-residual blur radius, default 2.0)
+#
+# Exec contract:  describe | init | [run] --input <img> [--ops ela]
+import io
+import json
+import os
+import sys
+
+IMG_EXTS = (".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff")
+QUALITY = 90
+BLUR = 2.0
+try:
+    QUALITY = int(os.environ.get("OVERCAST_ELA_QUALITY", "90"))
+except (ValueError, TypeError):
+    QUALITY = 90
+try:
+    BLUR = float(os.environ.get("OVERCAST_ELA_BLUR", "2.0"))
+except (ValueError, TypeError):
+    BLUR = 2.0
+
+CAVEAT = ("ELA/noise/luminance maps are HEURISTIC forensic aids — bright seams/edges "
+          "can indicate edits but compression, resizing, and texture also trigger them. "
+          "A lead, not proof.")
+
+
+def emit(rec):
+    sys.stdout.write(json.dumps(rec) + "\n")
+
+
+def fail(msg, state="error"):
+    emit({"verb": "enhance", "format": "json", "payload": {"op": "ela"},
+          "error": msg, "state": state})
+    sys.exit(0)
+
+
+def describe():
+    emit({"verb": "enhance", "kind": "media.enhanced", "ops": ["ela"],
+          "accepts": ["image"], "needs": ["pillow", "numpy"]})
+    sys.exit(0)
+
+
+def init():
+    try:
+        import PIL  # noqa: F401
+        import numpy  # noqa: F401
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write("ela needs: pillow + numpy (pip install pillow numpy, or a uv venv) — %s\n" % e)
+        sys.exit(13)
+    sys.exit(0)
+
+
+def parse_args(argv):
+    inp = ""
+
+    def val(j):
+        return argv[j + 1] if j + 1 < len(argv) else ""
+
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--input":
+            inp = val(i); i += 2
+        elif a in ("--ops", "--prompt", "--speakers"):
+            i += 2  # accepted; consume the value (--ops is the dispatch key)
+        elif a == "--masks-only":
+            i += 1
+        elif a == "run":
+            i += 1
+        elif not a.startswith("-"):
+            inp = a; i += 1
+        else:
+            i += 1
+    return inp
+
+
+def _outdir(inp):
+    base = os.environ.get("OVERCAST_MEDIA_DIR") or os.path.dirname(os.path.abspath(inp)) or "."
+    d = os.path.join(base, "ela")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def run():
+    inp = parse_args(sys.argv[1:])
+    if not inp or not os.path.exists(inp):
+        fail("input not found: %r" % inp)
+    if not inp.lower().endswith(IMG_EXTS):
+        fail("ela is image-only (%s); run it on a frame:// still of a video first" % os.path.basename(inp))
+
+    try:
+        import numpy as np
+        from PIL import Image, ImageFilter
+    except Exception as e:  # noqa: BLE001
+        fail("ela deps missing: %s (pip install pillow numpy)" % e)
+
+    try:
+        orig = Image.open(inp).convert("RGB")
+    except Exception as e:  # noqa: BLE001
+        fail("could not read image %r: %s" % (inp, e))
+
+    rgb = np.asarray(orig, dtype=np.float64)
+
+    def normalize_u8(arr):
+        """Min/max stretch to 0-255 (uint8)."""
+        arr = arr.astype(np.float64)
+        lo, hi = float(arr.min()), float(arr.max())
+        if hi - lo < 1e-9:
+            return np.zeros(arr.shape, dtype=np.uint8)
+        return np.clip((arr - lo) / (hi - lo) * 255.0, 0, 255).astype(np.uint8)
+
+    outdir = _outdir(inp)
+    base = os.path.splitext(os.path.basename(inp))[0]
+
+    # 1) ELA — re-save as JPEG q90 in memory, diff vs the original, scale so the
+    #    MAX per-pixel difference maps to 255 (edited regions recompress hotter).
+    buf = io.BytesIO()
+    orig.save(buf, format="JPEG", quality=QUALITY)
+    buf.seek(0)
+    resaved = np.asarray(Image.open(buf).convert("RGB"), dtype=np.float64)
+    diff = np.abs(rgb - resaved)
+    mx = float(diff.max())
+    scale = (255.0 / mx) if mx > 0 else 1.0
+    ela = np.clip(diff * scale, 0, 255).astype(np.uint8)
+    ela_path = os.path.join(outdir, base + "_ela.png")
+    Image.fromarray(ela, mode="RGB").save(ela_path)
+
+    # 2) noise residual — input minus a blurred copy, min/max normalized. A
+    #    spliced patch often carries a different high-frequency noise floor.
+    blurred = np.asarray(orig.filter(ImageFilter.GaussianBlur(radius=BLUR)), dtype=np.float64)
+    residual = normalize_u8(rgb - blurred)
+    noise_path = os.path.join(outdir, base + "_noise.png")
+    Image.fromarray(residual, mode="RGB").save(noise_path)
+
+    # 3) luminance gradient — Sobel edge magnitude of the luma channel (pure
+    #    numpy, edge-padded), normalized. Exposes cloned/feathered seams.
+    lum = np.asarray(orig.convert("L"), dtype=np.float64)
+    lp = np.pad(lum, 1, mode="edge")
+    gx = ((lp[:-2, 2:] + 2 * lp[1:-1, 2:] + lp[2:, 2:])
+          - (lp[:-2, :-2] + 2 * lp[1:-1, :-2] + lp[2:, :-2]))
+    gy = ((lp[2:, :-2] + 2 * lp[2:, 1:-1] + lp[2:, 2:])
+          - (lp[:-2, :-2] + 2 * lp[:-2, 1:-1] + lp[:-2, 2:]))
+    mag = normalize_u8(np.sqrt(gx * gx + gy * gy))
+    lum_path = os.path.join(outdir, base + "_luminance.png")
+    Image.fromarray(mag, mode="L").save(lum_path)
+
+    emit({
+        "verb": "enhance", "format": "json",
+        "payload": {
+            "op": "ela", "ops": ["ela"], "input": inp,
+            "quality": QUALITY, "blur": BLUR,
+            "outputs": [
+                {"kind": "ela", "ref": ela_path, "label": "ELA q%d" % QUALITY},
+                {"kind": "noise", "ref": noise_path, "label": "noise residual"},
+                {"kind": "luminance", "ref": lum_path, "label": "luminance gradient"},
+            ],
+            "caveat": CAVEAT,
+        },
+        "media": {"ref": inp},
+        "meta": {"provider": "local:ela"},
+        "state": "ready",
+    })
+
+
+def main():
+    argv = sys.argv[1:]
+    op = argv[0] if argv else "run"
+    if op == "describe":
+        return describe()
+    if op == "init":
+        return init()
+    run()
+
+
+main()

--- a/examples/providers/enhance/ela.py
+++ b/examples/providers/enhance/ela.py
@@ -74,6 +74,7 @@ def init():
 
 def parse_args(argv):
     inp = ""
+    ops = ""
 
     def val(j):
         return argv[j + 1] if j + 1 < len(argv) else ""
@@ -83,8 +84,10 @@ def parse_args(argv):
         a = argv[i]
         if a == "--input":
             inp = val(i); i += 2
-        elif a in ("--ops", "--prompt", "--speakers"):
-            i += 2  # accepted; consume the value (--ops is the dispatch key)
+        elif a == "--ops":
+            ops = val(i); i += 2  # the dispatch key — must be 'ela' for this provider
+        elif a in ("--prompt", "--speakers"):
+            i += 2  # accepted; consume the value
         elif a == "--masks-only":
             i += 1
         elif a == "run":
@@ -93,7 +96,7 @@ def parse_args(argv):
             inp = a; i += 1
         else:
             i += 1
-    return inp
+    return inp, ops
 
 
 def _outdir(inp):
@@ -104,7 +107,12 @@ def _outdir(inp):
 
 
 def run():
-    inp = parse_args(sys.argv[1:])
+    inp, ops = parse_args(sys.argv[1:])
+    # this provider handles ONLY --ops ela; a different provider-only op routed here
+    # (because it is the bound enhance provider) must fail loudly, not silently
+    # return an ELA result for, say, a requested panorama.
+    if ops and ops.strip().lower() != "ela":
+        fail("this provider only handles --ops ela (got %r) — bind the provider that implements %r" % (ops, ops))
     if not inp or not os.path.exists(inp):
         fail("input not found: %r" % inp)
     if not inp.lower().endswith(IMG_EXTS):

--- a/examples/providers/enhance/panorama.py
+++ b/examples/providers/enhance/panorama.py
@@ -132,14 +132,30 @@ def sample_frames(cv2, np, inp):
             if ok:
                 consider(frame)
     else:
-        # unknown/streaming length: read sequentially, keeping non-dup frames into a
-        # bounded buffer (still spanning the clip), then thin below.
-        cap_buf = TARGET_FRAMES * 3
-        while len(frames) < cap_buf:
+        # unreliable metadata (frame_count 0/1): COUNT frames with a cheap grab pass
+        # (no decode), then reopen and keep uniformly-spaced indices across the FULL
+        # clip by COUNTING (not seeking — unreliable metadata often means seeking is
+        # unreliable too). This spans the whole pan instead of just its opening slice.
+        count = 0
+        while cap.grab():
+            count += 1
+        cap.release()
+        cap = cv2.VideoCapture(inp)
+        if count > 1:
+            n = min(count, TARGET_FRAMES * 3)
+            want = {int(round(k * (count - 1) / (n - 1))) for k in range(n)}
+            idx = 0
+            while True:
+                ok, frame = cap.read()
+                if not ok:
+                    break
+                if idx in want:
+                    consider(frame)
+                idx += 1
+        else:
             ok, frame = cap.read()
-            if not ok:
-                break
-            consider(frame)
+            if ok:
+                consider(frame)
     cap.release()
 
     # thin an oversampled set down to TARGET_FRAMES, evenly across its span, so the

--- a/examples/providers/enhance/panorama.py
+++ b/examples/providers/enhance/panorama.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# overcast `enhance --ops panorama` (LOCAL): stitch a PANNING video into one wide
+# still. Samples frames uniformly across the clip (skipping black + near-duplicate
+# frames), then runs OpenCV's Stitcher in PANORAMA mode. The stitched image is a
+# first-class media.enhanced child you can then `see`/`crop`/reverse-image-search —
+# it exposes a skyline/landmark strip for geolocation that no single frame shows.
+# Emits ONE record whose payload.outputs[] is fanned out by the enhance verb.
+#
+# Bind, then run:
+#   overcast setup provider enhance "exec:python3 examples/providers/enhance/panorama.py"
+#   overcast enhance pan_shot.mp4 --ops panorama
+#   overcast view <parent-id>            # the stitched wide still
+#
+# Needs:  opencv-python, numpy   (pip install opencv-python numpy — or the uv
+#         venv: `scripts/visual-db-uv.sh` installs opencv-python + numpy by default).
+# Env:    OVERCAST_MEDIA_DIR (output dir; falls back to the input's directory),
+#         OVERCAST_PANORAMA_FRAMES (target sample count, default 18, clamped 6-40)
+#
+# Exec contract:  describe | init | [run] --input <video> [--ops panorama]
+import json
+import os
+import sys
+
+VID_EXTS = (".mp4", ".mov", ".webm", ".mkv", ".avi", ".m4v", ".mpg", ".mpeg", ".ts")
+TARGET_FRAMES = 18
+try:
+    TARGET_FRAMES = int(os.environ.get("OVERCAST_PANORAMA_FRAMES", "18"))
+except (ValueError, TypeError):
+    TARGET_FRAMES = 18
+TARGET_FRAMES = max(6, min(40, TARGET_FRAMES))
+
+BLACK_MEAN = 6.0    # frames dimmer than this (0-255) are dropped as black
+DUP_MEAN_ABS = 3.0  # frames within this mean-abs-diff of the last kept are dropped
+
+CAVEAT = ("Stitched from sampled frames; parallax/moving subjects can distort geometry — "
+          "use it to expose skyline/landmarks for geolocation, not for measurement.")
+
+
+def emit(rec):
+    sys.stdout.write(json.dumps(rec) + "\n")
+
+
+def fail(msg, state="error"):
+    emit({"verb": "enhance", "format": "json", "payload": {"op": "panorama"},
+          "error": msg, "state": state})
+    sys.exit(0)
+
+
+def describe():
+    emit({"verb": "enhance", "kind": "media.enhanced", "ops": ["panorama"],
+          "accepts": ["video"], "needs": ["opencv-python", "numpy"]})
+    sys.exit(0)
+
+
+def init():
+    try:
+        import cv2  # noqa: F401
+        import numpy  # noqa: F401
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write("panorama needs: opencv-python + numpy (pip install opencv-python numpy, or the uv venv) — %s\n" % e)
+        sys.exit(13)
+    sys.exit(0)
+
+
+def parse_args(argv):
+    inp = ""
+
+    def val(j):
+        return argv[j + 1] if j + 1 < len(argv) else ""
+
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--input":
+            inp = val(i); i += 2
+        elif a in ("--ops", "--prompt", "--speakers", "--at"):
+            i += 2  # accepted; consume the value (--ops is the dispatch key)
+        elif a == "--masks-only":
+            i += 1
+        elif a == "run":
+            i += 1
+        elif not a.startswith("-"):
+            inp = a; i += 1
+        else:
+            i += 1
+    return inp
+
+
+def _outdir(inp):
+    base = os.environ.get("OVERCAST_MEDIA_DIR") or os.path.dirname(os.path.abspath(inp)) or "."
+    d = os.path.join(base, "panorama")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def sample_frames(cv2, np, inp):
+    """Uniformly sample ~TARGET_FRAMES across the clip, dropping black +
+    near-duplicate frames. Returns a list of BGR frames (in temporal order)."""
+    cap = cv2.VideoCapture(inp)
+    if not cap.isOpened():
+        return []
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+    frames = []
+    prev_gray = None
+
+    def consider(frame):
+        nonlocal prev_gray
+        if frame is None:
+            return
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        if float(gray.mean()) < BLACK_MEAN:
+            return  # black/near-black frame
+        if prev_gray is not None and prev_gray.shape == gray.shape:
+            if float(cv2.absdiff(gray, prev_gray).mean()) < DUP_MEAN_ABS:
+                return  # near-duplicate of the last kept frame
+        prev_gray = gray
+        frames.append(frame)
+
+    if total > 1:
+        # oversample positions so filtering still leaves a healthy overlap set
+        n = min(total, TARGET_FRAMES * 2)
+        idxs = sorted({int(round(k * (total - 1) / (n - 1))) for k in range(n)})
+        for idx in idxs:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+            ok, frame = cap.read()
+            if ok:
+                consider(frame)
+            if len(frames) >= TARGET_FRAMES:
+                break
+    else:
+        # unknown/streaming length: read sequentially, keep every Kth non-dup
+        step = 1
+        i = 0
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            if i % step == 0:
+                consider(frame)
+            i += 1
+            if len(frames) >= TARGET_FRAMES:
+                break
+    cap.release()
+    return frames
+
+
+def run():
+    inp = parse_args(sys.argv[1:])
+    if not inp or not os.path.exists(inp):
+        fail("input not found: %r" % inp)
+    if not inp.lower().endswith(VID_EXTS):
+        fail("panorama is video-only (%s); give it a panning clip" % os.path.basename(inp))
+
+    try:
+        import cv2
+        import numpy as np
+    except Exception as e:  # noqa: BLE001
+        fail("panorama deps missing: %s (pip install opencv-python numpy)" % e)
+
+    frames = sample_frames(cv2, np, inp)
+    if len(frames) < 2:
+        fail("panorama needs at least 2 usable frames from %s (got %d after dropping "
+             "black/duplicate frames)" % (os.path.basename(inp), len(frames)))
+
+    mode = getattr(cv2, "Stitcher_PANORAMA", getattr(cv2, "STITCHER_PANORAMA", 0))
+    if hasattr(cv2, "Stitcher_create"):
+        stitcher = cv2.Stitcher_create(mode)
+    else:
+        stitcher = cv2.Stitcher.create(mode)
+
+    try:
+        status, pano = stitcher.stitch(frames)
+    except cv2.error as e:  # noqa: BLE001
+        fail("stitching failed (OpenCV error): %s" % str(e)[:200])
+
+    ok_code = getattr(cv2, "Stitcher_OK", getattr(cv2, "STITCHER_OK", 0))
+    if status != ok_code or pano is None:
+        fail("stitching failed (status %s) — the frames likely have too little overlap "
+             "or too much camera motion/parallax; try a slower, steadier pan" % status)
+
+    outdir = _outdir(inp)
+    base = os.path.splitext(os.path.basename(inp))[0]
+    pano_path = os.path.join(outdir, base + "_panorama.jpg")
+    if not cv2.imwrite(pano_path, pano):
+        fail("could not write stitched image to %s" % pano_path)
+
+    h, w = int(pano.shape[0]), int(pano.shape[1])
+    emit({
+        "verb": "enhance", "format": "json",
+        "payload": {
+            "op": "panorama", "ops": ["panorama"], "input": inp,
+            "frames_used": len(frames),
+            "outputs": [
+                {"kind": "panorama", "ref": pano_path, "label": "panorama",
+                 "width": w, "height": h},
+            ],
+            "caveat": CAVEAT,
+        },
+        "media": {"ref": inp},
+        "meta": {"provider": "local:panorama-cv2"},
+        "state": "ready",
+    })
+
+
+def main():
+    argv = sys.argv[1:]
+    op = argv[0] if argv else "run"
+    if op == "describe":
+        return describe()
+    if op == "init":
+        return init()
+    run()
+
+
+main()

--- a/examples/providers/enhance/panorama.py
+++ b/examples/providers/enhance/panorama.py
@@ -64,6 +64,7 @@ def init():
 
 def parse_args(argv):
     inp = ""
+    ops = ""
 
     def val(j):
         return argv[j + 1] if j + 1 < len(argv) else ""
@@ -73,8 +74,10 @@ def parse_args(argv):
         a = argv[i]
         if a == "--input":
             inp = val(i); i += 2
-        elif a in ("--ops", "--prompt", "--speakers", "--at"):
-            i += 2  # accepted; consume the value (--ops is the dispatch key)
+        elif a == "--ops":
+            ops = val(i); i += 2  # the dispatch key — must be 'panorama' here
+        elif a in ("--prompt", "--speakers", "--at"):
+            i += 2  # accepted; consume the value
         elif a == "--masks-only":
             i += 1
         elif a == "run":
@@ -83,7 +86,7 @@ def parse_args(argv):
             inp = a; i += 1
         else:
             i += 1
-    return inp
+    return inp, ops
 
 
 def _outdir(inp):
@@ -117,35 +120,43 @@ def sample_frames(cv2, np, inp):
         frames.append(frame)
 
     if total > 1:
-        # oversample positions so filtering still leaves a healthy overlap set
-        n = min(total, TARGET_FRAMES * 2)
+        # oversample positions across the FULL clip so black/dup filtering still
+        # leaves a healthy overlap set. Do NOT stop at TARGET_FRAMES mid-scan — that
+        # would keep only the first ~half of a pan; walk every position, then thin
+        # evenly below so the kept frames span the whole clip.
+        n = min(total, TARGET_FRAMES * 3)
         idxs = sorted({int(round(k * (total - 1) / (n - 1))) for k in range(n)})
         for idx in idxs:
             cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
             ok, frame = cap.read()
             if ok:
                 consider(frame)
-            if len(frames) >= TARGET_FRAMES:
-                break
     else:
-        # unknown/streaming length: read sequentially, keep every Kth non-dup
-        step = 1
-        i = 0
-        while True:
+        # unknown/streaming length: read sequentially, keeping non-dup frames into a
+        # bounded buffer (still spanning the clip), then thin below.
+        cap_buf = TARGET_FRAMES * 3
+        while len(frames) < cap_buf:
             ok, frame = cap.read()
             if not ok:
                 break
-            if i % step == 0:
-                consider(frame)
-            i += 1
-            if len(frames) >= TARGET_FRAMES:
-                break
+            consider(frame)
     cap.release()
+
+    # thin an oversampled set down to TARGET_FRAMES, evenly across its span, so the
+    # stitch input covers the full pan rather than a contiguous early slice.
+    if len(frames) > TARGET_FRAMES:
+        keep = sorted({int(round(k * (len(frames) - 1) / (TARGET_FRAMES - 1))) for k in range(TARGET_FRAMES)})
+        frames = [frames[j] for j in keep]
     return frames
 
 
 def run():
-    inp = parse_args(sys.argv[1:])
+    inp, ops = parse_args(sys.argv[1:])
+    # this provider handles ONLY --ops panorama; a different provider-only op routed
+    # here (because it is the bound enhance provider) must fail loudly, not silently
+    # stitch a panorama for, say, a requested ela.
+    if ops and ops.strip().lower() != "panorama":
+        fail("this provider only handles --ops panorama (got %r) — bind the provider that implements %r" % (ops, ops))
     if not inp or not os.path.exists(inp):
         fail("input not found: %r" % inp)
     if not inp.lower().endswith(VID_EXTS):

--- a/examples/providers/enhance/panorama.py
+++ b/examples/providers/enhance/panorama.py
@@ -102,7 +102,6 @@ def sample_frames(cv2, np, inp):
     cap = cv2.VideoCapture(inp)
     if not cap.isOpened():
         return []
-    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
     frames = []
     prev_gray = None
 
@@ -119,43 +118,32 @@ def sample_frames(cv2, np, inp):
         prev_gray = gray
         frames.append(frame)
 
-    if total > 1:
-        # oversample positions across the FULL clip so black/dup filtering still
-        # leaves a healthy overlap set. Do NOT stop at TARGET_FRAMES mid-scan — that
-        # would keep only the first ~half of a pan; walk every position, then thin
-        # evenly below so the kept frames span the whole clip.
-        n = min(total, TARGET_FRAMES * 3)
-        idxs = sorted({int(round(k * (total - 1) / (n - 1))) for k in range(n)})
-        for idx in idxs:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+    # Do NOT trust CAP_PROP_FRAME_COUNT: it is frequently wrong — 0/1 when metadata
+    # is missing, or UNDERSTATED — and a seek/space over that count confines sampling
+    # to the clip's opening segment. Instead COUNT the real frames with a cheap grab
+    # pass (no decode), then reopen and keep uniformly-spaced indices across the FULL
+    # clip by a position counter (reading, not seeking, which is also unreliable when
+    # the metadata is). Panorama inputs are short pans, so two passes are cheap.
+    count = 0
+    while cap.grab():
+        count += 1
+    cap.release()
+    cap = cv2.VideoCapture(inp)
+    if count > 1:
+        n = min(count, TARGET_FRAMES * 3)
+        want = {int(round(k * (count - 1) / (n - 1))) for k in range(n)}
+        idx = 0
+        while True:
             ok, frame = cap.read()
-            if ok:
+            if not ok:
+                break
+            if idx in want:
                 consider(frame)
-    else:
-        # unreliable metadata (frame_count 0/1): COUNT frames with a cheap grab pass
-        # (no decode), then reopen and keep uniformly-spaced indices across the FULL
-        # clip by COUNTING (not seeking — unreliable metadata often means seeking is
-        # unreliable too). This spans the whole pan instead of just its opening slice.
-        count = 0
-        while cap.grab():
-            count += 1
-        cap.release()
-        cap = cv2.VideoCapture(inp)
-        if count > 1:
-            n = min(count, TARGET_FRAMES * 3)
-            want = {int(round(k * (count - 1) / (n - 1))) for k in range(n)}
-            idx = 0
-            while True:
-                ok, frame = cap.read()
-                if not ok:
-                    break
-                if idx in want:
-                    consider(frame)
-                idx += 1
-        else:
-            ok, frame = cap.read()
-            if ok:
-                consider(frame)
+            idx += 1
+    elif count == 1:
+        ok, frame = cap.read()
+        if ok:
+            consider(frame)
     cap.release()
 
     # thin an oversampled set down to TARGET_FRAMES, evenly across its span, so the

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -36,7 +36,7 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 - `exif` — Extract embedded metadata — GPS, capture time, device — from an image or video (ExifTool).
 - `verify` — Check a media file's C2PA / Content Credentials provenance manifest (c2patool).
 - `screenshot` — Render a web page (or local HTML export) to a PNG evidence record via headless Chromium.
-- `enhance` — Produce better media (denoise/normalize/upscale) or split it (separate voices / segment objects) via ffmpeg or a bound model provider.
+- `enhance` — Produce better media (denoise/normalize/upscale), split it (separate voices / segment objects), or derive analysis artifacts (ela forensic overlays / panorama stitch) via ffmpeg or a bound provider.
 - `reconstruct` — Speculatively reposition the camera in a still (rotate/elevate/zoom, turntable sweep, 3D model, depth) via a bound generative provider — a hypothesis renderer, never evidence.
 - `view` — Open media in a lightweight local viewer (scrubbable player) or hand off to the OS.
 - `crop` — Materialize face/object detections as cropped image records with provenance.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -315,18 +315,18 @@ Emits `web.screenshot` records.
 
 ### `overcast enhance`
 
-Default: deterministic, modality-dispatched ops on the bundled ffmpeg (denoise/normalize/voice-isolate/upscale/stabilize/grayscale). Bind a model provider for AI restoration or the SPLIT ops via `setup provider enhance <spec>`: `--ops separate` splits an audio/video's voices into per-speaker tracks (add --summarize to transcribe each), `--ops segment --prompt "<thing>"` cuts requested objects out of an image as mask + cutout evidence. separate/segment need a bound provider (local-models = pyannote + GroundingDINO/SAM2, or fal = sam-audio + sam-3); image segmentation of a video is out of scope (segment a frame:// still). Emits a media.enhanced record per output — for the split ops, one child record per track/mask whose media.ref chains into watch/listen/see/view/crop.
+Default: deterministic, modality-dispatched ops on the bundled ffmpeg (denoise/normalize/voice-isolate/upscale/stabilize/grayscale). Bind a model/analysis provider for AI restoration or the PROVIDER-ONLY ops via `setup provider enhance <spec>`: `--ops separate` splits an audio/video's voices into per-speaker tracks (add --summarize to transcribe each), `--ops segment --prompt "<thing>"` cuts requested objects out of an image as mask + cutout evidence, `--ops ela` derives ELA/noise/luminance forensic overlays from an image (heuristic edit-detection leads), `--ops panorama` stitches a panning video into one wide still (skyline/landmark exposure for geolocation). These ops need a bound provider (local-models = pyannote + GroundingDINO/SAM2, fal = sam-audio + sam-3, or a shipped example script — enhance/ela.py, enhance/panorama.py); image segmentation/ela of a video is out of scope (run on a frame:// still). Emits a media.enhanced record per output — for the fan-out ops, one child record per track/mask/overlay whose media.ref chains into watch/listen/see/view/crop.
 
 ```
 overcast enhance <input> [options]
 
-  Produce better media (denoise/normalize/upscale) or split it (separate voices / segment objects) via ffmpeg or a bound model provider.
+  Produce better media (denoise/normalize/upscale), split it (separate voices / segment objects), or derive analysis artifacts (ela forensic overlays / panorama stitch) via ffmpeg or a bound provider.
 
 Arguments:
   input            Media file path
 
 Options:
-  --ops <string>         Comma list of ops (denoise,normalize,upscale,separate,segment,...)
+  --ops <string>         Comma list of ops (denoise,normalize,upscale,separate,segment,ela,panorama,...)
   --prompt <string>      What to segment (--ops segment) or the target voice to extract
   --speakers <string>    Speaker-count hint for --ops separate
   --summarize            Transcribe/summarize each separated track via the bound listen provider

--- a/src/providers/memory/fields.ts
+++ b/src/providers/memory/fields.ts
@@ -140,7 +140,20 @@ export function indexableFields(rec: OvercastRecord): IndexableField[] {
     seen.add(key);
     return true;
   });
-  return deduped.length ? deduped : fallbackFields(rec);
+  if (!deduped.length) return fallbackFields(rec);
+  // Honest-provenance caveat is always searchable, even when a verb's field
+  // policy omits it (e.g. enhance ela/panorama children, or a sense provider
+  // that attaches a caveat via senses passthrough). Policy-less verbs already
+  // index it through fallbackFields, so only the policy path needs this graft.
+  for (const value of valuesAt(p, "caveat")) {
+    const text = stringify(value);
+    if (!text) continue;
+    const key = `caveat\0${text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push({ path: "caveat", text });
+  }
+  return deduped;
 }
 
 export function indexableDocument(rec: OvercastRecord): IndexableDocument | undefined {

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -415,6 +415,7 @@ export interface EnhanceGalleryReport {
   sourceRef?: string; // the original media (separate: playable "mixed" track)
   overlaps?: Array<{ at: [number, number]; speakers: string[] }>;
   model?: string;
+  caveat?: string; // honest-provenance note surfaced in the gallery (a lead, not proof)
   items: EnhanceGalleryItem[];
 }
 
@@ -480,7 +481,13 @@ export function renderEnhanceGallery(r: EnhanceGalleryReport): string {
   const empty = r.items.length === 0
     ? `<section class="panel"><p class="meta">No ${isSep ? "tracks" : "instances"} to show.</p></section>` : "";
 
-  return csiShell(r.title, r.subtitle, `${stats}${overlaps}${empty}<section class="grid">${origCard}${cards}</section>`);
+  // surface the parent record's honest-provenance caveat (ela/panorama are
+  // heuristic leads) prominently in the gallery, not just in the JSON record.
+  const caveat = r.caveat
+    ? `<section class="panel" style="border-color:var(--amber);box-shadow:0 0 24px rgba(255,209,102,.15)"><h2 style="color:var(--amber)">Caveat — a lead, not proof</h2><p class="summary">${escapeHtml(r.caveat)}</p></section>`
+    : "";
+
+  return csiShell(r.title, r.subtitle, `${stats}${caveat}${overlaps}${empty}<section class="grid">${origCard}${cards}</section>`);
 }
 
 export interface ReconstructGalleryView {

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -415,7 +415,7 @@ export interface EnhanceGalleryReport {
   sourceRef?: string; // the original media (separate: playable "mixed" track)
   overlaps?: Array<{ at: [number, number]; speakers: string[] }>;
   model?: string;
-  caveat?: string; // honest-provenance note surfaced in the gallery (a lead, not proof)
+  caveat?: string; // honest-provenance note surfaced in the gallery (op-specific: ela=lead-not-proof, panorama=distortion)
   items: EnhanceGalleryItem[];
 }
 
@@ -484,7 +484,7 @@ export function renderEnhanceGallery(r: EnhanceGalleryReport): string {
   // surface the parent record's honest-provenance caveat (ela/panorama are
   // heuristic leads) prominently in the gallery, not just in the JSON record.
   const caveat = r.caveat
-    ? `<section class="panel" style="border-color:var(--amber);box-shadow:0 0 24px rgba(255,209,102,.15)"><h2 style="color:var(--amber)">Caveat — a lead, not proof</h2><p class="summary">${escapeHtml(r.caveat)}</p></section>`
+    ? `<section class="panel" style="border-color:var(--amber);box-shadow:0 0 24px rgba(255,209,102,.15)"><h2 style="color:var(--amber)">Caveat</h2><p class="summary">${escapeHtml(r.caveat)}</p></section>`
     : "";
 
   return csiShell(r.title, r.subtitle, `${stats}${caveat}${overlaps}${empty}<section class="grid">${origCard}${cards}</section>`);

--- a/src/verbs/enhance-fanout.ts
+++ b/src/verbs/enhance-fanout.ts
@@ -82,6 +82,11 @@ export function fanOutEnhance(parent: OvercastRecord, opts: { caseDir?: string }
   const sourceName = sourceMedia ? sourceMedia.split("/").pop() || sourceMedia : "input";
   const provider = parent.meta?.provider;
   const caseDir = opts.caseDir ?? (typeof parent.meta?.case === "string" ? parent.meta.case : CASE_UNSET);
+  // honest-provenance caveat rides from the parent onto EVERY child (ela/panorama
+  // stamp it on the envelope, not each artifact) — so a "lead, not proof" overlay
+  // or stitched still carries the disclaimer wherever it chains (see/crop/memory),
+  // matching reconstruct's per-child stamping.
+  const parentCaveat = typeof payload.caveat === "string" && payload.caveat ? payload.caveat : undefined;
 
   const children = outputs.map((item) => {
     // everything the provider attached to the artifact rides on the child payload
@@ -98,6 +103,8 @@ export function fanOutEnhance(parent: OvercastRecord, opts: { caseDir?: string }
         op,
         source_record: parent.id,
         source_media: sourceMedia,
+        // parent caveat first so a child that carries its OWN caveat (in ...rest) wins
+        ...(parentCaveat ? { caveat: parentCaveat } : {}),
         ...rest,
       },
       media,

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -890,6 +890,7 @@ async function maybeEnhanceGallery(ctx: VerbContext, rec: OvercastRecord): Promi
     subtitle: typeof p.input === "string" ? (p.input.split("/").pop() ?? rec.id) : rec.id,
     sourceRef: rec.media?.ref,
     model: typeof p.model === "string" ? p.model : typeof p.detect_model === "string" ? p.detect_model : undefined,
+    caveat: typeof p.caveat === "string" ? p.caveat : undefined,
     overlaps,
     items,
   };

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -606,15 +606,17 @@ export const enhanceVerb: VerbSpec = {
 
     // no custom binding: the provider-only ops can't run on ffmpeg.
     if (providerOps.length) {
-      return [
-        errorRecord(
-          "enhance",
-          `--ops ${providerOps.join(",")} needs a bound enhance provider. ` +
-            `Bind one with \`overcast setup provider enhance "exec:python3 examples/providers/enhance/<op>.py"\` ` +
-            `(ela / panorama), or run \`overcast provider setup plan --preset local-models\` (or --preset fal) ` +
-            `then \`--yes\` for separate/segment; local-models needs \`scripts/visual-db-uv.sh --enhance\`.`,
-        ),
-      ];
+      const op = providerOps[0];
+      // tailor the remediation to the op family — ela/panorama ship as example
+      // Python scripts; separate/segment need the local-models (or fal) preset —
+      // so the hint isn't misleading for whichever op was actually requested.
+      const hint =
+        op === "ela" || op === "panorama"
+          ? `Bind one with \`overcast setup provider enhance "exec:python3 examples/providers/enhance/${op}.py"\` ` +
+            `(${op === "panorama" ? "opencv-python + numpy" : "pillow + numpy"}).`
+          : `Run \`overcast provider setup plan --preset local-models\` (or --preset fal) then \`--yes\`; ` +
+            `local-models needs \`scripts/visual-db-uv.sh --enhance\`.`;
+      return [errorRecord("enhance", `--ops ${providerOps.join(",")} needs a bound enhance provider. ${hint}`)];
     }
 
     const requested = rawOps.length ? (rawOps as EnhanceOp[]) : undefined;

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -374,9 +374,11 @@ export const seeVerb: VerbSpec = {
 
 // ---- enhance (internal ffmpeg + bound split providers) ---------------------
 
-// Ops that CANNOT run on the internal ffmpeg toolkit — they split media into
-// many artifacts and require a bound model provider (local-models or fal).
-const PROVIDER_ONLY_OPS: ReadonlySet<string> = new Set(["separate", "segment"]);
+// Ops that CANNOT run on the internal ffmpeg toolkit — they fan a single input
+// out into many derived artifacts and require a bound model/analysis provider
+// (local-models, fal, or a shipped example script). separate/segment split media
+// into tracks/cutouts; ela overlays forensic maps; panorama stitches a wide still.
+const PROVIDER_ONLY_OPS: ReadonlySet<string> = new Set(["separate", "segment", "ela", "panorama"]);
 
 /** For each separated-voice track record, transcribe it via the bound listen
  *  provider and fold the transcript + a short spoken-summary onto the track
@@ -422,20 +424,22 @@ async function summarizeTracks(ctx: VerbContext, recs: OvercastRecord[]): Promis
 export const enhanceVerb: VerbSpec = {
   name: "enhance",
   group: "sense",
-  summary: "Produce better media (denoise/normalize/upscale) or split it (separate voices / segment objects) via ffmpeg or a bound model provider.",
+  summary: "Produce better media (denoise/normalize/upscale), split it (separate voices / segment objects), or derive analysis artifacts (ela forensic overlays / panorama stitch) via ffmpeg or a bound provider.",
   description:
     "Default: deterministic, modality-dispatched ops on the bundled ffmpeg (denoise/normalize/" +
-    "voice-isolate/upscale/stabilize/grayscale). Bind a model provider for AI restoration or the " +
-    "SPLIT ops via `setup provider enhance <spec>`: `--ops separate` splits an audio/video's voices " +
+    "voice-isolate/upscale/stabilize/grayscale). Bind a model/analysis provider for AI restoration or the " +
+    "PROVIDER-ONLY ops via `setup provider enhance <spec>`: `--ops separate` splits an audio/video's voices " +
     "into per-speaker tracks (add --summarize to transcribe each), `--ops segment --prompt \"<thing>\"` " +
-    "cuts requested objects out of an image as mask + cutout evidence. separate/segment need a bound " +
-    "provider (local-models = pyannote + GroundingDINO/SAM2, or fal = sam-audio + sam-3); image " +
-    "segmentation of a video is out of scope (segment a frame:// still). Emits a media.enhanced record " +
-    "per output — for the split ops, one child record per track/mask whose media.ref chains into " +
-    "watch/listen/see/view/crop.",
+    "cuts requested objects out of an image as mask + cutout evidence, `--ops ela` derives ELA/noise/" +
+    "luminance forensic overlays from an image (heuristic edit-detection leads), `--ops panorama` stitches " +
+    "a panning video into one wide still (skyline/landmark exposure for geolocation). These ops need a bound " +
+    "provider (local-models = pyannote + GroundingDINO/SAM2, fal = sam-audio + sam-3, or a shipped example " +
+    "script — enhance/ela.py, enhance/panorama.py); image segmentation/ela of a video is out of scope " +
+    "(run on a frame:// still). Emits a media.enhanced record per output — for the fan-out ops, one child " +
+    "record per track/mask/overlay whose media.ref chains into watch/listen/see/view/crop.",
   args: [{ name: "input", summary: "Media file path", required: true }],
   flags: [
-    { name: "ops", summary: "Comma list of ops (denoise,normalize,upscale,separate,segment,...)", type: "string" },
+    { name: "ops", summary: "Comma list of ops (denoise,normalize,upscale,separate,segment,ela,panorama,...)", type: "string" },
     { name: "prompt", summary: "What to segment (--ops segment) or the target voice to extract", type: "string" },
     { name: "speakers", summary: "Speaker-count hint for --ops separate", type: "string" },
     { name: "summarize", summary: "Transcribe/summarize each separated track via the bound listen provider", type: "boolean" },
@@ -599,14 +603,15 @@ export const enhanceVerb: VerbSpec = {
       return recs;
     }
 
-    // no custom binding: the split ops can't run on ffmpeg.
+    // no custom binding: the provider-only ops can't run on ffmpeg.
     if (providerOps.length) {
       return [
         errorRecord(
           "enhance",
           `--ops ${providerOps.join(",")} needs a bound enhance provider. ` +
-            `Run \`overcast provider setup plan --preset local-models\` (or --preset fal), ` +
-            `then \`--yes\` to apply; local-models needs \`scripts/visual-db-uv.sh --enhance\`.`,
+            `Bind one with \`overcast setup provider enhance "exec:python3 examples/providers/enhance/<op>.py"\` ` +
+            `(ela / panorama), or run \`overcast provider setup plan --preset local-models\` (or --preset fal) ` +
+            `then \`--yes\` for separate/segment; local-models needs \`scripts/visual-db-uv.sh --enhance\`.`,
         ),
       ];
     }
@@ -823,19 +828,25 @@ function errorRecord(verb: string, message: string): OvercastRecord {
   });
 }
 
-/** If `rec` is an enhance split-op PARENT (payload.op separate|segment), render an
+/** Provider-only enhance ops whose PARENT record fans out into gallery-able
+ *  children (audio tracks / image cutouts / forensic overlays / a stitched still).
+ *  Keep in sync with the fan-out ops in PROVIDER_ONLY_OPS. */
+const GALLERY_OPS: ReadonlySet<string> = new Set(["separate", "segment", "ela", "panorama"]);
+
+/** If `rec` is an enhance fan-out PARENT (payload.op in GALLERY_OPS), render an
  *  HTML gallery of its fanned-out children and return the view record; else null
  *  (so `view` falls through to its single-media player). A parent is identified by
  *  op + the ABSENCE of a top-level `kind` — a fanned-out CHILD carries `kind`
- *  (track/cutout/mask). This (not an outputs[] check) is used so a valid EMPTY
- *  result — op matches with outputs empty OR absent (handler guard case 3) — still
- *  renders the gallery, while children play/show normally. `source_record` isn't a
- *  discriminator: a parent can carry it too (capture provenance). */
+ *  (track/cutout/mask/ela/noise/luminance/panorama). This (not an outputs[] check)
+ *  is used so a valid EMPTY result — op matches with outputs empty OR absent
+ *  (handler guard case 3) — still renders the gallery, while children play/show
+ *  normally. `source_record` isn't a discriminator: a parent can carry it too
+ *  (capture provenance). */
 async function maybeEnhanceGallery(ctx: VerbContext, rec: OvercastRecord): Promise<OvercastRecord | null> {
   if (rec.verb !== "enhance" || typeof rec.payload !== "object" || !rec.payload) return null;
   const p = rec.payload as Record<string, unknown>;
   const op = p.op;
-  if ((op !== "separate" && op !== "segment") || typeof p.kind === "string") return null;
+  if (typeof op !== "string" || !GALLERY_OPS.has(op) || typeof p.kind === "string") return null;
   const children = ctx.case.records().filter(
     (r) => r.verb === "enhance" && (r.payload as Record<string, unknown> | undefined)?.source_record === rec.id,
   );
@@ -885,7 +896,7 @@ async function maybeEnhanceGallery(ctx: VerbContext, rec: OvercastRecord): Promi
   return makeRecord({
     verb: "view",
     format: "json",
-    payload: { mode: op === "separate" ? "separation" : "segmentation", op, viewer: htmlPath, items: items.length, source_record: rec.id },
+    payload: { mode: op === "separate" ? "separation" : op === "segment" ? "segmentation" : op, op, viewer: htmlPath, items: items.length, source_record: rec.id },
     media: { ref: htmlPath },
     meta: { case: ctx.case.dir },
     state: "ready",

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -519,14 +519,15 @@ export const enhanceVerb: VerbSpec = {
       ];
     }
 
-    // A split op (separate/segment) can't compose with any other op: the toolbox
-    // providers dispatch to exactly ONE handler, so `--ops segment,separate` or
-    // `--ops separate,denoise` would silently drop the rest. Require it solo.
+    // A provider-only op (separate/segment/ela/panorama) can't compose with any
+    // other op: the toolbox providers dispatch to exactly ONE handler, so
+    // `--ops segment,separate` or `--ops ela,denoise` would silently drop the rest.
+    // Require it solo.
     if (providerOps.length && rawOps.length !== 1) {
       return [
         errorRecord(
           "enhance",
-          `a split op (${providerOps.join(", ")}) must be the only --ops value (got: ${rawOps.join(",")}). Run separate/segment one at a time.`,
+          `a provider-only op (${providerOps.join(", ")}) must be the only --ops value (got: ${rawOps.join(",")}). Run these ops one at a time.`,
         ),
       ];
     }

--- a/src/verbs/senses.ts
+++ b/src/verbs/senses.ts
@@ -380,6 +380,18 @@ export const seeVerb: VerbSpec = {
 // into tracks/cutouts; ela overlays forensic maps; panorama stitches a wide still.
 const PROVIDER_ONLY_OPS: ReadonlySet<string> = new Set(["separate", "segment", "ela", "panorama"]);
 
+/** Remediation hint tailored to the provider-only op family — ela/panorama ship as
+ *  example Python scripts; separate/segment need the local-models (or fal) preset.
+ *  Shared by the no-binding and the wrong-provider (single-output) error paths so a
+ *  user is never told to bind a split preset for an op that doesn't use one. */
+function providerOpHint(op: string): string {
+  return op === "ela" || op === "panorama"
+    ? `Bind one with \`overcast setup provider enhance "exec:python3 examples/providers/enhance/${op}.py"\` ` +
+        `(${op === "panorama" ? "opencv-python + numpy" : "pillow + numpy"}).`
+    : `Run \`overcast provider setup plan --preset local-models\` (or --preset fal) then \`--yes\`; ` +
+        `local-models needs \`scripts/visual-db-uv.sh --enhance\`.`;
+}
+
 /** For each separated-voice track record, transcribe it via the bound listen
  *  provider and fold the transcript + a short spoken-summary onto the track
  *  record itself (self-contained evidence). Non-fatal per track: a failed
@@ -581,7 +593,7 @@ export const enhanceVerb: VerbSpec = {
             errorRecord(
               "enhance",
               `the bound enhance provider did not perform '--ops ${providerOps[0]}' (it returned a single output). ` +
-                `Bind a split-capable provider: \`overcast provider setup plan --preset local-models\` (or --preset fal).`,
+                providerOpHint(providerOps[0]),
             ),
           ];
         }
@@ -606,17 +618,12 @@ export const enhanceVerb: VerbSpec = {
 
     // no custom binding: the provider-only ops can't run on ffmpeg.
     if (providerOps.length) {
-      const op = providerOps[0];
-      // tailor the remediation to the op family — ela/panorama ship as example
-      // Python scripts; separate/segment need the local-models (or fal) preset —
-      // so the hint isn't misleading for whichever op was actually requested.
-      const hint =
-        op === "ela" || op === "panorama"
-          ? `Bind one with \`overcast setup provider enhance "exec:python3 examples/providers/enhance/${op}.py"\` ` +
-            `(${op === "panorama" ? "opencv-python + numpy" : "pillow + numpy"}).`
-          : `Run \`overcast provider setup plan --preset local-models\` (or --preset fal) then \`--yes\`; ` +
-            `local-models needs \`scripts/visual-db-uv.sh --enhance\`.`;
-      return [errorRecord("enhance", `--ops ${providerOps.join(",")} needs a bound enhance provider. ${hint}`)];
+      return [
+        errorRecord(
+          "enhance",
+          `--ops ${providerOps.join(",")} needs a bound enhance provider. ${providerOpHint(providerOps[0])}`,
+        ),
+      ];
     }
 
     const requested = rawOps.length ? (rawOps as EnhanceOp[]) : undefined;

--- a/test/unit/enhance-fanout.test.ts
+++ b/test/unit/enhance-fanout.test.ts
@@ -101,6 +101,34 @@ test("fanOutEnhance keeps box + box_normalized on segment children (crop interop
   assert.equal(child.media?.ref, "/m/x_1.png");
 });
 
+test("fanOutEnhance copies the parent's honest-provenance caveat onto every child", () => {
+  // ela/panorama stamp payload.caveat on the ENVELOPE, not each artifact — so the
+  // "lead, not proof" disclaimer must travel onto the children (which chain into
+  // see/crop/memory), matching reconstruct's per-child stamping.
+  const parent = makeRecord({
+    verb: "enhance", format: "json",
+    payload: { op: "ela", caveat: "ELA maps are heuristic — a lead, not proof.", outputs: [
+      { kind: "ela", ref: "/m/x_ela.png" },
+      { kind: "noise", ref: "/m/x_noise.png", caveat: "child-specific note" },
+    ] },
+    media: { ref: "/m/photo.jpg" }, meta: { provider: "exec:python" }, state: "ready",
+  });
+  const [, c0, c1] = fanOutEnhance(parent);
+  assert.equal((c0.payload as Record<string, unknown>).caveat, "ELA maps are heuristic — a lead, not proof.");
+  // a child carrying its OWN caveat keeps it (parent doesn't clobber)
+  assert.equal((c1.payload as Record<string, unknown>).caveat, "child-specific note");
+});
+
+test("fanOutEnhance without a parent caveat leaves children caveat-free (separate/segment)", () => {
+  const parent = makeRecord({
+    verb: "enhance", format: "json",
+    payload: { op: "separate", outputs: [{ kind: "track", ref: "/m/a_S0.wav", speaker: "S0" }] },
+    media: { ref: "/m/a.mp4" }, state: "ready",
+  });
+  const [, child] = fanOutEnhance(parent);
+  assert.equal((child.payload as Record<string, unknown>).caveat, undefined);
+});
+
 // ---- enhance verb end-to-end (fixture providers) ----------------------------
 
 test("enhance --ops separate fans out one record per track", async () => {

--- a/test/unit/provider-contract.test.ts
+++ b/test/unit/provider-contract.test.ts
@@ -42,6 +42,8 @@ const PROVIDERS: Prov[] = [
   py("detect/detect.py"),
   py("visual-db/enhance_voice.py"),
   py("visual-db/enhance_segment.py"),
+  py("enhance/ela.py"),
+  py("enhance/panorama.py"),
   ts("ts/see.ts"),
   sh("sources/youtube.sh", "source"),
   sh("sources/tiktok.sh", "source"),

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -44,6 +44,20 @@ test("indexable field policy prefers verb-specific fields, including notes", () 
   assert.match(fields.map((f) => f.text).join("\n"), /white van/);
 });
 
+test("indexable fields always graft the honest-provenance caveat, even when the verb policy omits it", () => {
+  // enhance's field policy lists summary/ops/etc but NOT caveat; an ela/panorama
+  // child carries payload.caveat, and ask/brief must be able to surface it.
+  const child = makeRecord({ verb: "enhance", payload: { summary: "ELA overlay", op: "ela", caveat: "ELA maps are heuristic — a lead, not proof." } });
+  const fields = indexableFields(child);
+  assert.ok(fields.some((f) => f.path === "caveat"), "caveat should be indexed");
+  assert.match(fields.map((f) => f.text).join("\n"), /heuristic — a lead, not proof/);
+  // no duplication when the caveat is already the only content, and policy-less
+  // verbs still fall through to fallbackFields (which indexes every field).
+  const chrono = makeRecord({ verb: "chronolocate", payload: { caveat: "a lead, not proof", other: "kept" } });
+  const chronoPaths = indexableFields(chrono).map((f) => f.path).sort();
+  assert.deepEqual(chronoPaths, ["caveat", "other"]);
+});
+
 test("local memory memo: repeated identical queries return byte-identical passages (cache-hit path)", async () => {
   await withCase((c) => {
     const mem = new LocalMemoryProvider(c);


### PR DESCRIPTION
## Summary

Two provider-only `enhance` ops that reuse the existing `separate`/`segment` fan-out plumbing (one input → a parent audit record + derived children). Stacked on #88.

### `enhance --ops ela` — image-forensics overlays (`examples/providers/enhance/ela.py`, PIL + numpy)
Derives three heuristic tamper-analysis overlays from a still and fans out to **parent + 3 children**:
- **ELA** — re-save at JPEG quality 90 and amplify the per-pixel difference (recompression seams surface edits).
- **noise residual** — input minus a blurred copy, normalized.
- **luminance gradient** — Sobel magnitude of luminance.

Every record carries a caveat: these are *leads, not proof* — compression/resize/texture also trigger them.

### `enhance --ops panorama` — video → stitched wide still (`examples/providers/enhance/panorama.py`, OpenCV)
Samples ~18 frames across a panning clip (drops black/near-duplicate frames), runs `cv2.Stitcher` in PANORAMA mode, and fans out the stitched still — exposing a skyline/landmark for downstream `see`/`crop`/reverse-search. Stitch failure / too little overlap → a clean error record, never a crash.

### `view` gallery
The enhance gallery now renders `ela`/`panorama` parents (`GALLERY_OPS` kept in sync with `PROVIDER_ONLY_OPS`); the parent-vs-child guard is unchanged.

## Validation
- `npm run typecheck` clean; **`npm test` 952/952**; both providers added to the provider-contract test; `py_compile` clean.
- Both are provider-only (like separate/segment): with nothing bound, `--ops ela`/`--ops panorama` return a clean "bind a provider" error; an unknown op still fails (`--ops elaa` → "unknown --ops"). `commands --json` lists both.
- **Live fan-out** (repo uv venv has PIL/numpy/cv2): ELA → parent + 3 children with real files on disk + gallery render; panorama → parent + 1 stitched child (1432×601, 8 frames) + gallery render; error paths (ela-on-video, panorama-on-image, low-overlap clip) all return clean error records.

_pip/uv deps documented in each script header (opencv-python+numpy are the uv base install; pillow comes via `--segment`/`--clip`)._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enhance providers and UX/docs/tests; no auth or core record-contract changes beyond optional caveat indexing and fan-out stamping.
> 
> **Overview**
> Adds two **provider-only** `enhance` ops that reuse the existing `separate`/`segment` fan-out model (parent + `payload.outputs[]` children, gallery via `view`).
> 
> **`--ops ela`** — new `examples/providers/enhance/ela.py` (Pillow + numpy): from one image, writes ELA, noise residual, and luminance-gradient overlays; image-only with `payload.caveat` (heuristic, not proof). **`--ops panorama`** — new `examples/providers/enhance/panorama.py` (OpenCV): samples frames from a panning video, stitches with `cv2.Stitcher`, emits one wide still for geolocation; clean error records on stitch failure.
> 
> Core wiring: `ela` and `panorama` join `PROVIDER_ONLY_OPS` / `GALLERY_OPS` in `senses.ts`, with **`providerOpHint`** so bind errors point at the example scripts (not local-models/fal). **`fanOutEnhance`** copies the parent `payload.caveat` onto every child. **`indexableFields`** always grafts `caveat` for search; **`renderEnhanceGallery`** shows an amber caveat panel. Docs/skills updated; provider-contract and unit tests extended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8fd6d7fcfff291e95c52c11a496cbbe58841ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->