### PR TITLE
Add showcase/ runbooks for the overcast.video case studies

### DIFF
--- a/showcase/.gitignore
+++ b/showcase/.gitignore
@@ -1,0 +1,18 @@
+# Showcase workspace: keep the runbooks + HOWTO as committed documentation, but
+# ignore regenerable/bulky artifacts. Case stores (.overcast/) are already ignored
+# globally. Raw HTML exports here still carry local file:// + /Users refs — the
+# scrubbed, hostable copies live in the overcast.video repo (public/cases/).
+*.html
+*.mp4
+*.mov
+*.webm
+*.png
+*.jpg
+*.jpeg
+*.webp
+*.gif
+*.glb
+*.svg
+*.wav
+*.m4a
+media/

--- a/showcase/HOWTO.md
+++ b/showcase/HOWTO.md
@@ -1,0 +1,115 @@
+# Showcase case-generation — operating manual (for agents)
+
+You are producing one **showcase case**: run a real overcast flow on real data,
+export its visual artifacts, publish them to the marketing site, and hand back a
+registry entry. Follow this exactly.
+
+## Golden rules
+
+1. **Always run from the repo root** so creds auto-load:
+   `cd ~/.supacode/repos/overcast/case-studies`
+   The `overcast` binary is on PATH (global 0.0.8). `bin/overcast.ts` auto-loads
+   `.env` from cwd, so every API key + fixture path is already in the environment
+   of the overcast process when you run from here.
+2. **Get fixture paths as shell vars** at the top of a bash block when you need
+   them as CLI args: `set -a; source .env; set +a` (double-loading is harmless).
+   Concrete fixture paths are tabled below — you may also just use `$OC_...`.
+3. **Isolate your case**: pass `--case showcase/<slug>` to *every* overcast
+   command. Start with `overcast case init --case showcase/<slug> --json`.
+4. **Discover exact flags** — do NOT guess. Use:
+   `overcast <verb> --help`, `overcast commands --json`,
+   `docs/flows.md`, and the matching `skills/<skill>/SKILL.md`.
+5. **Export artifacts into `showcase/<slug>/`** as HTML, CSI theme, no auto-open:
+   e.g. `--export showcase/<slug>/map.html --theme csi --no-open` (flag names vary
+   per verb — check `--help`). Prefer the self-contained surfaces (graph, map,
+   cluster gallery, reconstruct viewers, image-only brief).
+6. **Publish** (this scrubs `/Users/` + `file://` leaks, copies any local media,
+   patches CSP, and renders a Chrome thumbnail; it FAILS LOUDLY on any leak):
+   ```
+   node ~/dev/github/overcast.video/scripts/publish-case.mjs \
+     --slug <slug> \
+     --src ~/.supacode/repos/overcast/case-studies/showcase/<slug> \
+     --scrub ~/.supacode/repos/overcast/case-studies \
+     --thumb <the-most-visual-artifact>.html
+   ```
+   If it fails on a leak, fix the *export* (re-run the verb / choose a different
+   surface). Do not hand-edit the HTML. Verify after:
+   `grep -rEc "file://|/Users/" ~/dev/github/overcast.video/public/cases/<slug>/*.html` → all 0.
+7. **Write `showcase/<slug>/RUNBOOK.md`** — the exact command sequence you ran,
+   with a one-paragraph story intro (this is the reproducible transcript).
+8. **Never** use identity/PII sources (person/phone/username/facesearch/plate).
+   Faces: only the public-figure fixtures below.
+9. Leave the shared overcast **profile** alone unless your case needs a binding
+   (only `reconstruct` does — see its note). If you bind, say so in your report.
+
+## Fixture media (all verified present)
+
+| env var | path | notes |
+|---|---|---|
+| OC_EXIF_IMAGE | ~/Downloads/test-videos/exif-geotagged-sf.jpg | GPS-tagged SF photo |
+| OC_EXIF_IMAGE_2 | ~/Downloads/test-videos/exif-geotagged-la.jpg | GPS-tagged LA photo |
+| OC_IMAGE | ~/Downloads/test-videos/sample-image.jpg | generic still |
+| OC_VIDEO_VISUAL | ~/Downloads/test-videos/browse-hackernews.mp4 | screen recording ~30s |
+| OC_VIDEO_OBJECTS | ~/Downloads/test-videos/worker_without_helmet.mp4 | people+objects, for --detect |
+| OC_VIDEO_SMALL | ~/Downloads/test-videos/bbq.mp4 | short clip |
+| OC_VIDEO_SPEECH | ~/Downloads/test-videos/bobbyleetheoasian.mp4 | clear speech (Bobby Lee, public figure) |
+| OC_AUDIO | ~/Downloads/test-videos/sample-audio.m4a | audio clip |
+| OC_CLUSTER_FIXTURE_DIR | ~/Downloads/test-videos/face-crops | folder of face crops |
+| OC_LOCAL_FACE_VIDEO | ~/Downloads/test-videos/video-willsmith-…mp4 | Will Smith (public figure) |
+| OC_LOCAL_FACE_IMAGE | ~/Downloads/will.jpg | Will Smith reference face |
+| OC_LOCAL_IMAGE_REF | ~/Downloads/Starbucks_Corporation_Logo_2011.jpg | logo for RANSAC match |
+| OC_LOCAL_IMAGE_VIDEO_A | ~/Downloads/video-therealdri-…mp4 | clip containing the logo |
+| OC_LOCAL_IMAGE_VIDEO_B | ~/Downloads/video-iheartdest-…mp4 | second clip |
+| OC_VOICE_SPEAKER_VIDEO | ~/Downloads/test-videos/bobbyleetheoasian.mp4 | reference speaker |
+| OC_VOICE_OTHER_VIDEO | ~/Downloads/test-videos/tinycloud-launch.mov | other speaker (314MB) |
+
+Keyless sources (no key needed): `dispatch:sf`, `gdelttv:"<q>"`, `wayback:<url>`,
+`overpass:...`, `firms:<bbox>`, `flights:<bbox>`. Keyed (already configured):
+cloudglue (watch/listen/see/face), fal (reconstruct/enhance), apify (x/lens/
+yandeximg/tiktok/instagram), tavily (web), serper (dork), shodan, windy (webcam).
+
+## Round 2 — fresh REAL media (CC0/CC/public-domain)
+
+We're replacing synthetic-serial fixtures with real web media. Rights: **CC0 /
+public-domain / CC-BY only**, re-hosting in artifacts is fine.
+
+**Staged & verified EXIF photos** (`showcase/_media/exif/`, all CC0 Unsplash-via-Wikimedia, real EXIF):
+| file | camera | serial | capture time | GPS | software | content |
+|---|---|---|---|---|---|---|
+| `gg-1.jpg` | Canon EOS REBEL T5 | **222074031107** | 2016:12:16 17:24:14 | — | Snapseed 2.14 (edited) | aerial Golden Gate Bridge |
+| `gg-2.jpg` | Canon EOS REBEL T5 | **222074031107** (SAME body) | 2016:08:12 18:06:43 | **37.2423,-121.7604 (San Jose!)** | Instagram (edited) | Golden Gate tower in fog |
+| `gg-3.jpg` | Nikon D800 | 6114213 | 2016:09:20 19:05:22 | — | Capture One 9 | (different camera, contrast) |
+
+Real narrative hooks (use these, they're genuine):
+- **camera-ballistics**: gg-1 + gg-2 share serial `222074031107` (one real Canon T5 body, 4 months apart); gg-3 is a different body (Nikon D800). Both Canon frames carry editing-software tags.
+- **scene-locate**: gg-2 unmistakably shows the **Golden Gate Bridge** but its geotag points to **San Jose ~40mi away** — a real geotag-vs-content contradiction. Landmark `see` + reverse-image corroborate the bridge; `chronolocate` checks whether the 2016:08:12 18:06 capture time is sun/shadow-consistent (fold the time-of-day beat in here).
+- **is-this-real**: gg-2 = Instagram-re-saved + a GPS that doesn't match the scene + no C2PA manifest → real "provenance can't be trusted" leads.
+
+**Recipe to fetch MORE CC media yourself** (enhance, face-clustering need their own):
+- Images: Wikimedia Commons geosearch/search API → filter `extmetadata.LicenseShortName` = CC0/PD/CC-BY → download the **original** `imageinfo.url` (retains EXIF) with curl → verify with `exiftool`. Example that worked:
+  `curl -s 'https://commons.wikimedia.org/w/api.php?action=query&generator=geosearch&ggscoord=LAT%7CLNG&ggsradius=900&ggslimit=40&ggsnamespace=6&prop=imageinfo&iiprop=url|extmetadata|metadata&format=json' -A 'overcast-showcase/1.0'`
+- Video (multi-person face-clustering): prefer **public-domain US-government footage** (White House / congressional hearing / NASA press conference — PD by default, multiple recognizable public figures) via `dl:<url>` or `youtube:`. Public figures only; verify faces are identifiable public figures before publishing a gallery.
+- Stage fetched media under `showcase/_media/<kind>/` and note provenance + license in your RUNBOOK.
+
+## What to return (strict)
+
+End your final message with a fenced block titled `REGISTRY ENTRY` containing a
+JS object literal ready to paste into `src/caseStudies.ts`:
+
+```
+REGISTRY ENTRY
+{
+  slug: '<slug>',
+  codename: '<Title Case name>',
+  tagline: '<one line: what this proves>',
+  badge: '<KEYLESS|FORENSICS|LIVE DATA|3D|OSINT|AUDIO|FACES>',
+  accent: '<mint|sky|butter|blush>',
+  verbs: ['verb1','verb2',...],
+  thumb: '/cases/<slug>/thumb.png',
+  links: [ { label: 'open <x>', href: '/cases/<slug>/<file>.html' }, ... ],
+}
+```
+
+Then, below it, note: (a) which artifacts you published and whether each is fully
+self-contained, (b) the scrub-grep result, (c) any provider you had to bind, and
+(d) anything that failed or is a caveat. Keep it tight.

--- a/showcase/_media/wiretap/SOURCES.md
+++ b/showcase/_media/wiretap/SOURCES.md
@@ -1,0 +1,27 @@
+# Wiretap — source media provenance
+
+The "tape" is a short (~2 min) analysis excerpt from a publicly published podcast,
+used here for a technical demonstration of speaker separation, audio cleanup, and
+voice-print speaker verification.
+
+## interview-tape.wav — the multi-speaker "tape"
+
+- Episode: **Lightcone: Consumer is back, What's getting funded now, The vibes
+  immaculate** — the Lightcone Podcast.
+- Channel: **Y Combinator** (hosts: Garry Tan, Harj Taggar, Jared Friedman, Diana Hu).
+- URL: https://www.youtube.com/watch?v=e1Yhs9BEOSw
+- Segment used: **01:30–03:30** (120 s), fetched audio-only with `yt-dlp`, downmixed
+  to mono / 16 kHz. Chosen for clear multi-speaker back-and-forth with distinct turns
+  (four speakers, one dominant, minimal cross-talk).
+- Public figures, used as a short analysis excerpt. Speakers are referred to by the
+  diarizer's neutral labels (Speaker A/B/…) — the voice print verifies a VOICE, it
+  does not assert a named identity.
+
+## Degraded-intercept demonstration (synthetic noise, labeled)
+
+Lightcone is clean studio audio, so to showcase the audio-cleanup step as a visible
+before/after, ONE separated speaker track is deliberately degraded into a
+"degraded intercept": a telephone-band band-pass (300–3400 Hz) plus added hiss /
+room tone. The enhance pass (ElevenLabs voice isolation) then cleans it back. The
+degradation is synthetic and is labeled as such everywhere it appears — it is a
+demonstration of the cleanup on a real speaker, not a real intercepted recording.

--- a/showcase/audio-match/RUNBOOK.md
+++ b/showcase/audio-match/RUNBOOK.md
@@ -1,0 +1,120 @@
+# RUNBOOK — audio-match ("Shazam for evidence")
+
+A low-bitrate 11-second clip shows up somewhere it shouldn't. Is it a re-upload of
+a recording we already hold — or something new? This case fingerprints three
+reference recordings into a local `audio-fp` index (Wang-2003 constellation
+hashes, numpy/scipy, fully offline), then throws four clips at it: a disguised
+re-upload (sliced at +6s, re-encoded to 32 kbps mp3, volume dropped), an unrelated
+control, and two speed-tampered copies. The true re-upload lands at offset
+**+5.99s** (ground truth +6.00s) with **723 aligned votes** and a **361.5× margin**
+over the runner-up offset; the control returns "no confident match"; a 6% sped-up
+copy degrades to an 11.8× margin with the aligned span collapsing 9.57s → 2.18s;
+a 12% sped-up copy falls to 1.39× and is rejected outright by `--min-margin 2` —
+the honest caveat: fingerprinting survives transcode and noise, NOT pitch/speed
+change.
+
+All commands run from the repo root (creds auto-load from `.env`).
+
+## 1. Case + media prep
+
+```bash
+overcast case init --case showcase/audio-match --json
+mkdir -p showcase/audio-match/media
+
+# three distinct reference recordings
+ffmpeg -y -ss 30 -t 40 -i "$OC_VIDEO_SPEECH" -vn -c:a aac -b:a 128k showcase/audio-match/media/ref-speech.m4a
+ffmpeg -y -ss 10 -t 40 -i "$OC_VIDEO_SMALL"  -vn -c:a aac -b:a 128k showcase/audio-match/media/ref-bbq.m4a
+cp "$OC_AUDIO" showcase/audio-match/media/ref-sample-audio.m4a
+
+# QUERY: disguised re-upload — 11s slice at +6s, 32kbps mp3, volume 0.85
+ffmpeg -y -ss 6 -t 11 -i "$OC_AUDIO" -vn -af "volume=0.85" -c:a libmp3lame -b:a 32k showcase/audio-match/media/query-reupload.mp3
+
+# NEGATIVE control: unrelated audio, never indexed
+ffmpeg -y -ss 20 -t 15 -i "$OC_VOICE_OTHER_VIDEO" -vn -c:a aac -b:a 128k showcase/audio-match/media/control-unrelated.m4a
+
+# speed-tampered re-uploads (same slice, atempo)
+ffmpeg -y -ss 6 -t 11 -i "$OC_AUDIO" -vn -af "atempo=1.06,volume=0.85" -c:a libmp3lame -b:a 32k showcase/audio-match/media/query-spedup.mp3
+ffmpeg -y -ss 6 -t 11 -i "$OC_AUDIO" -vn -af "atempo=1.12,volume=0.85" -c:a libmp3lame -b:a 32k showcase/audio-match/media/query-spedup12.mp3
+```
+
+## 2. Target + fingerprint index
+
+```bash
+overcast target add "re-upload provenance: query-reupload.mp3" \
+  --question "Is the low-bitrate clip query-reupload.mp3 the SAME underlying recording as one of the three reference tracks — and if so, at what time offset?" \
+  --case showcase/audio-match --json                      # → tgt_5c64e4
+
+overcast index create fingerprints --type audio-fp --local \
+  --description "Wang-2003 acoustic fingerprints of the three reference recordings" \
+  --case showcase/audio-match --json
+
+overcast audio add showcase/audio-match/media/ref-sample-audio.m4a --to fingerprints --case showcase/audio-match --json  # 12490 hashes / 20.0s
+overcast audio add showcase/audio-match/media/ref-speech.m4a       --to fingerprints --case showcase/audio-match --json  # 26114 hashes / 40.0s
+overcast audio add showcase/audio-match/media/ref-bbq.m4a          --to fingerprints --case showcase/audio-match --json  # 19553 hashes / 40.0s
+```
+
+## 3. Match: positive, control, speed-tampered
+
+```bash
+# POSITIVE — rec_8952e809fa5cc231:
+#   matches ref-sample-audio.m4a at +5.99s (ground truth +6.00s),
+#   723 aligned votes / 5879 query hashes (ratio 0.123), margin 361.5x, span 9.57s
+#   → auto-suggested finding rec_d2dcb4ced758bd9b (signal:audio-match)
+overcast audio match showcase/audio-match/media/query-reupload.mp3 \
+  --index fingerprints --min-margin 2 --draw --case showcase/audio-match --json
+
+# NEGATIVE control — rec_3953e8dff2560dc1: "no confident audio match"
+#   (best rejected alignment: 2 votes, margin 2.0, span 1.02s)
+overcast audio match showcase/audio-match/media/control-unrelated.m4a \
+  --index fingerprints --min-margin 2 --draw --case showcase/audio-match --json
+
+# 6% SPED-UP — rec_d21dd46bfb6ba7b8: still aligns (+6.18s) but degraded:
+#   400 votes, margin 11.8x, span collapsed 9.57s → 2.18s (time-stretch drift)
+overcast audio match showcase/audio-match/media/query-spedup.mp3 \
+  --index fingerprints --min-margin 2 --draw --case showcase/audio-match --json
+
+# 12% SPED-UP — rec_c27b0f3d01745bd4: REJECTED by --min-margin 2
+#   (best rejected: 71 votes, margin 1.39, span 1.16s)
+overcast audio match showcase/audio-match/media/query-spedup12.mp3 \
+  --index fingerprints --min-margin 2 --draw --case showcase/audio-match --json
+```
+
+## 4. Triage + narrate
+
+```bash
+overcast finding list --state triage --case showcase/audio-match --json
+overcast finding accept  rec_d2dcb4ced758bd9b --target tgt_5c64e4 --case showcase/audio-match --json   # true match → evidence
+overcast finding dismiss rec_9d1055e2f2074519 --target tgt_5c64e4 --case showcase/audio-match --json   # 6% sped-up impostor lead
+
+overcast finding create "Speed-tamper signature: a 6% sped-up re-encode of the same recording still aligns at +6.18s but the margin collapses 361.5x -> 11.8x and the aligned span shrinks 9.57s -> 2.18s (time-stretch drift breaks Wang-2003 alignment); at 12% speedup the margin falls to 1.39x and --min-margin 2 rejects it outright." \
+  --ref rec_d21dd46bfb6ba7b8 --target tgt_5c64e4 --confidence high --case showcase/audio-match --json
+
+overcast note "query-reupload.mp3 IS ref-sample-audio.m4a: 723 hash votes align at offset +5.99s (ground truth: the slice was cut at +6.00s), margin 361.5x over the runner-up offset, aligned span 9.57s of an 11s query — an exact-recording match that survived 32kbps re-encode and a volume change." \
+  --ref rec_8952e809fa5cc231 --tag "thread:tgt_5c64e4,provenance" --confidence high --case showcase/audio-match --json
+overcast note "Discrimination checks: unrelated control clip -> no confident match (best rejected alignment: 2 votes, margin 2.0, span 1.0s). A 6% sped-up copy degraded to margin 11.8x with the aligned span collapsing 9.57s -> 2.18s (time-stretch drift); a 12% sped-up copy fell to margin 1.39x and was REJECTED by --min-margin 2. Wang-2003 fingerprints are robust to transcode/noise, NOT to pitch/speed change." \
+  --ref rec_c27b0f3d01745bd4 --tag "thread:tgt_5c64e4,caveat" --confidence high --case showcase/audio-match --json
+overcast note "Verdict: the low-bitrate 'query-reupload.mp3' is the SAME underlying recording as reference ref-sample-audio.m4a, aligned at +5.99s with 723 votes and a 361.5x margin — confirmed exact copy despite 32kbps transcode + volume change. Unrelated audio returns no match; speed-tampered copies collapse in margin/span and a 12% speedup is rejected outright by --min-margin 2." \
+  --tag tldr --confidence high --case showcase/audio-match --json
+
+overcast target close tgt_5c64e4 --as answered \
+  --note "Yes — query-reupload.mp3 is ref-sample-audio.m4a at offset +5.99s (723 aligned votes, 361.5x margin); finding rec_d2dcb4ced758bd9b accepted." \
+  --case showcase/audio-match --json
+```
+
+## 5. Artifacts + publish
+
+```bash
+overcast brief --theme csi --export showcase/audio-match/brief.html --case showcase/audio-match --json
+overcast graph --theme csi --export showcase/audio-match/graph.html --no-open --case showcase/audio-match --json
+
+node ~/dev/github/overcast.video/scripts/publish-case.mjs \
+  --slug audio-match \
+  --src ~/.supacode/repos/overcast/case-studies/showcase/audio-match \
+  --scrub ~/.supacode/repos/overcast/case-studies \
+  --thumb brief.html
+# scrub check: grep -rEc "file://|/Users/" public/cases/audio-match/*.html → all 0
+```
+
+The brief inlines two `--draw` SVG alignment plots (base64 data URIs, fully
+self-contained): the confirmed match (tight diagonal hash-pair band + one sharp
+offset-vote spike) and the speed-tampered contrast (short scattered cluster).

--- a/showcase/camera-ballistics/RUNBOOK.md
+++ b/showcase/camera-ballistics/RUNBOOK.md
@@ -1,0 +1,122 @@
+# Case: Camera Ballistics — "Same Camera Shot These"
+
+**What it proves:** overcast does media forensics with zero billed calls. Every
+photo a camera writes carries a device fingerprint in its EXIF — make, model,
+lens, and (on many bodies) a durable serial number. `exif` lifts that fingerprint
+from each file (ExifTool, free, local), `devices` rolls the case up by camera and
+labels each cluster STRONG (shared body serial = same physical unit) or WEAK
+(same make+model+lens = same model, which millions own), and the knowledge
+`graph` renders the device node physically linking the photos.
+
+The verdict here is real forensics on **real media**: three CC0 Golden Gate
+Bridge photographs from Wikimedia Commons (Unsplash-sourced, public-domain
+dedication) with their genuine, untouched EXIF. Two of the three came out of the
+**same physical Canon EOS REBEL T5 body — serial `222074031107`, same
+EF-S18-55mm f/3.5-5.6 IS II lens — four months apart** (2016-08-12 and
+2016-12-16). The third is a different body entirely (Nikon D800, serial
+`6114213`). Both Canon frames had been passed through consumer editing apps
+(Snapseed 2.14 and Instagram) — and the body serial survived both, which is the
+whole point of camera ballistics.
+
+## Media provenance (staged under `showcase/_media/exif/`)
+
+All three photos are **CC0 (public-domain dedication), Unsplash-via-Wikimedia
+Commons originals** downloaded at full resolution so the EXIF is intact and real
+— nothing synthetic, no injected tags:
+
+| file | camera | serial | capture time | GPS | software |
+|---|---|---|---|---|---|
+| `gg-1.jpg` | Canon EOS REBEL T5 | **222074031107** | 2016:12:16 17:24:14 | — | Snapseed 2.14 |
+| `gg-2.jpg` | Canon EOS REBEL T5 | **222074031107** (same body) | 2016:08:12 18:06:43 | 37.2423,-121.7604 (San Jose) | Instagram |
+| `gg-3.jpg` | Nikon D800 | 6114213 | 2016:09:20 19:05:22 | — | Capture One 9 |
+
+(Side plot the map surfaces: `gg-2` unmistakably shows the Golden Gate Bridge,
+but its geotag points to San Jose ~40 mi away — a genuine geotag-vs-content
+contradiction, explored further in the `scene-locate` case.)
+
+## Run
+
+```bash
+# 0. run from the repo root; overcast auto-loads .env
+cd <repo-root>
+MEDIA=$PWD/showcase/_media/exif
+
+# 1. a case is just a folder + its .overcast/ store
+overcast case init --case showcase/camera-ballistics --name "Camera Ballistics"
+
+# 2. open the line of investigation
+overcast target add "same-camera link" \
+  --question "Were these shot on the same camera?" \
+  --case showcase/camera-ballistics
+# -> tgt_e35678
+
+# 3. lift the device fingerprint from every file (ExifTool — free, local)
+overcast exif "$MEDIA/gg-1.jpg" --case showcase/camera-ballistics
+overcast exif "$MEDIA/gg-2.jpg" --case showcase/camera-ballistics
+overcast exif "$MEDIA/gg-3.jpg" --case showcase/camera-ballistics
+# -> gg-1: Canon EOS REBEL T5 · serial 222074031107 · EF-S18-55mm · 2016:12:16
+#          · sw: Snapseed 2.14 (auto-suggested editing-software lead)
+# -> gg-2: Canon EOS REBEL T5 · serial 222074031107 · EF-S18-55mm · 2016:08:12
+#          · GPS 37.2423,-121.7604 · sw: Instagram
+# -> gg-3: NIKON D800 · serial 6114213 · 50mm f/1.4 · 2016:09:20
+#          · sw: Capture One 9 (auto-suggested editing-software lead)
+
+# 4. roll the case up by camera fingerprint; --findings emits a suggested
+#    finding for the serial-linked (STRONG) cluster
+overcast devices --findings --case showcase/camera-ballistics
+# -> 1 cluster: serial:222074031107 · strength "serial" · 2 members (gg-1 + gg-2)
+#    total_exif: 3 · linked_media: 2 (the Nikon frame stands alone)
+
+# 5. triage: promote the serial-link lead to evidence, stamped onto the line
+overcast finding accept rec_a17e62ec68b2f3ba --target tgt_e35678 \
+  --case showcase/camera-ballistics
+# (the two editing-software leads stay in the triage queue — visible in the brief)
+
+# 6. narrate the thread + verdict, close the answered line
+overcast note "Camera ballistics confirmed: gg-1.jpg ... and gg-2.jpg ... SAME \
+physical Canon EOS REBEL T5 body — serial 222074031107 ... four months apart. \
+gg-3.jpg is a different camera (Nikon D800, serial 6114213). Serial numbers \
+survive editing apps." --tag tldr --confidence high --case showcase/camera-ballistics
+overcast note "Serial 222074031107 appears in two frames captured 2016:08:12 and \
+2016:12:16 — a durable device link across a four-month gap." \
+  --ref rec_a17e62ec68b2f3ba --tag thread:tgt_e35678 --confidence high \
+  --case showcase/camera-ballistics
+overcast target close tgt_e35678 --as answered \
+  --note "Yes — gg-1 and gg-2 share Canon T5 body serial 222074031107 (strong \
+device link); gg-3 is a different body (Nikon D800)." \
+  --case showcase/camera-ballistics
+
+# 7. export the visual artifacts (all self-contained HTML)
+overcast graph --theme csi --no-open --export showcase/camera-ballistics/graph.html --case showcase/camera-ballistics
+overcast map   --theme csi --no-open --export showcase/camera-ballistics/map.html   --case showcase/camera-ballistics
+overcast brief --theme csi           --export showcase/camera-ballistics/brief.html --case showcase/camera-ballistics
+```
+
+## What each artifact shows
+
+- **graph.html** (hero) — the case knowledge graph: one `device` node
+  (`Canon EOS REBEL T5 · serial 222074031107`) hub-linking the two Canon photo
+  records, plus the accepted serial-link finding, the answered line of
+  investigation, the San Jose place node, and the lifted serial entity. The
+  Nikon record sits apart — no device edge. The device edge IS the forensic
+  conclusion. (13 nodes, 11 edges.)
+- **map.html** — the one geotagged frame (gg-2) pinned at its EXIF coordinates
+  (37.2423, -121.7604 — San Jose, despite the Golden Gate in-frame), the marker
+  linking back to its `exif` record with thumbnail and capture time.
+- **brief.html** — the mission brief: analyst verdict up top, the answered
+  same-camera line with its accepted finding, the two editing-software leads
+  still in the triage queue, and the newest-first record trail. The CC0 photo
+  thumbnails render inline.
+
+## Honesty notes
+
+- Shared **serial** = STRONG (that exact camera body). Shared make+model+lens
+  without a serial would only be WEAK (same model) — `devices` labels which, and
+  only serial clusters auto-suggest findings.
+- The editing-software fields (Snapseed, Instagram, Capture One) are re-save
+  **leads**, not proof of manipulation.
+- EXIF is untrusted input: serials can be spoofed or carried across re-saves;
+  cross-check a strong link with content before concluding.
+
+No API keys used: ExifTool is local, and `devices`/`graph`/`map`/`brief` are
+pure reads over the case store. Zero network egress (no `--geocode` this run).

--- a/showcase/connect-the-dots/RUNBOOK.md
+++ b/showcase/connect-the-dots/RUNBOOK.md
@@ -1,0 +1,76 @@
+# connect-the-dots — showcase runbook
+
+Two unrelated clips land in a case: a comedy-podcast excerpt and a ~30s screen
+recording of someone browsing a news site. Two lines of investigation are opened
+(who is the speaker? what is being browsed?), the media is run through the senses
+(`watch`, `listen`, `see`), analyst notes and findings are stamped onto the
+targets — and then ONE command strings the whole board: `overcast graph --extract`
+builds the case knowledge graph, lifting typed entities (Bobby Lee, Hacker News,
+Cursor, usernames, locations) out of the evidence text with the brain LLM and
+wiring every edge back to the record that proves it. 60 nodes, 82 edges, one
+self-contained HTML force-graph — no CDN, no egress.
+
+## Commands (in order)
+
+```bash
+cd ~/.supacode/repos/overcast/case-studies   # creds auto-load from .env
+
+# 1. Case + lines of investigation
+overcast case init --case showcase/connect-the-dots --json                 # case_4e17d61b
+overcast target add "Who is speaking in the podcast clip and what identities/handles do they reference?" \
+  --case showcase/connect-the-dots --json                                  # tgt_f82f60
+overcast target add "What sites, stories, and usernames appear in the screen-recording browsing session?" \
+  --case showcase/connect-the-dots --json                                  # tgt_d8979b
+
+# 2. Ingest real media (cloudglue sense backend)
+overcast watch  "$OC_VIDEO_VISUAL" --case showcase/connect-the-dots --json # rec_a84034dcc28d3c2b (Hacker News session)
+overcast listen "$OC_VIDEO_SPEECH" --case showcase/connect-the-dots --json # rec_2177c3fdeca64c68 (Bobby Lee podcast)
+overcast see    "$OC_IMAGE"        --case showcase/connect-the-dots --json # rec_b7b2893414526de2 (construction-site still)
+
+# 3. Analyst notes anchored to the evidence
+overcast note "Screen recording confirms a Hacker News browsing session: front-page stories on macOS menu bar customization and AI coding tools; commenter usernames visible in threads. Supports the browsing-session line of investigation." \
+  --ref rec_a84034dcc28d3c2b --tag "thread:tgt_d8979b" --confidence high --case showcase/connect-the-dots --json
+overcast note "Still image shows an urban construction/road-work site near a residential building — context material only, no identity content." \
+  --ref rec_b7b2893414526de2 --confidence medium --case showcase/connect-the-dots --json
+overcast note "Speech clip is a two-speaker comedy podcast exchange; one speaker self-identifies as Korean (public figure Bobby Lee), correcting repeated Chinese/Mongolian misidentification. Anchors the who-is-speaking line." \
+  --ref rec_2177c3fdeca64c68 --tag "thread:tgt_f82f60" --confidence high --case showcase/connect-the-dots --json
+overcast note "Two threads, one board: the podcast clip resolves to Bobby Lee (Korean, self-identified on tape); the screen capture resolves to a Hacker News session (macOS menu-bar + AI-coding threads). Both lines answered; graph shows the media hubs and lifted entities tying them to their findings." \
+  --tag tldr --confidence high --case showcase/connect-the-dots --json
+
+# 4. Findings stamped onto the lines of investigation (finding→source + finding→target edges)
+overcast finding create "Speaker in the podcast clip self-identifies as Korean and is Bobby Lee (public figure); transcript repeatedly corrects Chinese/Mongolian misattribution." \
+  --ref rec_2177c3fdeca64c68 --target tgt_f82f60 --confidence high --case showcase/connect-the-dots --json
+overcast finding create "Browsing session is on news.ycombinator.com: front-page threads on macOS menu bar spacing and AI coding agents/editors, with commenter usernames visible in the discussions." \
+  --ref rec_a84034dcc28d3c2b --target tgt_d8979b --confidence high --case showcase/connect-the-dots --json
+
+# 5. Hero artifact: the knowledge graph with the opt-in LLM entity/relation pass
+overcast graph --theme csi --extract --no-open \
+  --export showcase/connect-the-dots/graph.html --case showcase/connect-the-dots --json
+# → 60 nodes / 82 edges / 2 components
+#   by_type: record 7 · media 3 · finding 2 · target 2 · entity 46
+#   --extract: 41 entities + 19 relations over 7 evidence records (cached to .overcast/graph/extract.jsonl)
+#   entity types: person 5 · username 6 · org 8 · location 3 · domain 2 · url 3 · event 2 · vehicle 1 · other 16
+
+# 6. Companion brief
+overcast brief --export showcase/connect-the-dots/brief.html --theme csi \
+  --case showcase/connect-the-dots --json
+```
+
+## Published artifacts
+
+- `graph.html` — the interactive knowledge graph (hand-rolled canvas force layout,
+  all JS inlined, zero remote refs; pan/zoom/drag, per-type toggles, text filter,
+  node inspector). Fully self-contained.
+- `brief.html` — CSI-theme mission brief: verdict, one story per line of
+  investigation, findings, coverage, record trail.
+- `thumb.png` — Chrome render of the graph.
+
+## Notes
+
+- `--extract` is the opt-in brain-LLM pass (BYO; cloudglue serves as brain here).
+  Every extracted node/edge carries `payload.caveat` — leads, not proof; the viewer
+  banner says so.
+- `graph` is operational: it stays out of ask/brief evidence. The findings are what
+  carry the confirmed links into the brief.
+- No profile bindings were changed; only the public-figure speech fixture was used
+  (no identity/PII sources).

--- a/showcase/copycat-sweep/RUNBOOK.md
+++ b/showcase/copycat-sweep/RUNBOOK.md
@@ -1,0 +1,83 @@
+# copycat-sweep — showcase runbook
+
+Two uploads circulate with different handles, different lengths, different
+encodes. Are they the same underlying content? This case proves it at the frame
+layer, entirely locally: an OpenCV **image-RANSAC** index ties the same
+siren-logo asset to frames inside both clips, with keypoint/inlier match
+overlays as visual proof. Reskins, burned-in captions, and re-encodes defeat
+exact hashes and text matching — they do not defeat frame-content matching.
+Each `image match` auto-suggests a finding; triage-accepting them stamps the
+proof onto the line of investigation the brief narrates. One `x:` video sweep
+(Apify) shows the external-reach tier of the funnel; the match proof itself
+needed no network at all.
+
+Fixtures (from `.env` at the repo root — `set -a; source .env; set +a`):
+
+- `$OC_LOCAL_IMAGE_REF` — Starbucks siren logo (the reference asset)
+- `$OC_LOCAL_IMAGE_VIDEO_A` — clip 1 (therealdri…, ~15s), contains the logo
+- `$OC_LOCAL_IMAGE_VIDEO_B` — clip 2 (iheartdest…, ~24s), contains the logo
+
+## Commands run (in order)
+
+```bash
+cd ~/.supacode/repos/overcast/case-studies   # creds + fixtures auto-load
+set -a; source .env; set +a
+CASE=showcase/copycat-sweep
+
+# 0. Case + line of investigation
+overcast case init --case $CASE --json
+overcast case setup --case $CASE --name "copycat-sweep" \
+  --target "Siren-logo clip: is the second upload the same underlying content as the original?" \
+  --yes --no-index --json
+
+# 1. Frame layer — RANSAC image matching (reskins survive; exact hashes don't)
+overcast index create logos --type image-ransac --local \
+  --description "Reference asset: Starbucks siren logo" --case $CASE --json
+overcast image add "$OC_LOCAL_IMAGE_REF" --index logos --case $CASE --json
+overcast image match "$OC_LOCAL_IMAGE_VIDEO_A" --index logos --fps 0.7 --draw --case $CASE --json
+overcast image match "$OC_LOCAL_IMAGE_VIDEO_B" --index logos --fps 0.7 --draw --case $CASE --json
+# → A: 2 frames matched, best 64 inliers / 103 matches, ratio 0.62 at 12.14s (+48-inlier frame at 13.57s)
+# → B: 3 frames matched, best 30 inliers / 59, ratio 0.51 at 0.71s (+ frames at 2.14s, 10.71s)
+# each match auto-suggests a finding; --draw writes keypoint/inlier overlays
+# that ride into the finding cards in the brief as visual proof
+
+# 2. Bonus: external reach — real X video sweep (Apify, billed per result)
+overcast source add 'x:video:starbucks siren logo cup' \
+  --name "X video sweep: siren-logo clips" --case $CASE --json
+overcast scan --source x --limit 5 --case $CASE --json      # → 2 scan.hit records
+
+# 3. Triage → accept the auto-suggested findings onto the line
+overcast finding list --state triage --case $CASE --json
+overcast finding accept rec_391ba95dd77f4c30 --target tgt_a9c445 --case $CASE --json  # image: clip A, 64 inliers
+overcast finding accept rec_bd8d86e507c7d683 --target tgt_a9c445 --case $CASE --json  # image: clip B, 30 inliers
+
+# 4. Narrate + close the line
+overcast note "VERDICT: the two uploads carry the same underlying visual content…" --tag tldr --case $CASE --json
+overcast target close tgt_a9c445 --as answered \
+  --note "Yes — same underlying content. Image RANSAC ties both uploads…" --case $CASE --json
+
+# 5. Export
+overcast brief --theme csi --export showcase/copycat-sweep/brief.html --case $CASE --json
+overcast graph --export showcase/copycat-sweep/graph.html --theme csi --no-open --case $CASE --json
+```
+
+## Measured results
+
+| layer | query | verdict | numbers |
+|---|---|---|---|
+| image (RANSAC) | clip A (therealdri) vs logo | MATCH | 64 inliers / 103 matches, ratio 0.62, at 12.14s (+ 48-inlier frame at 13.57s) |
+| image (RANSAC) | clip B (iheartdest) vs logo | MATCH | 30 inliers / 59 matches, ratio 0.51, at 0.71s (+ frames at 2.14s, 10.71s) |
+| x: sweep | `x:video:starbucks siren logo cup` | 2 hits | real SERP reach; metadata-only triage tier |
+
+## Notes
+
+- `image match` inlier counts are unbounded integers + a 0–1 ratio (no 0–100
+  scale); the homography gate + `--draw` overlays are the false-positive guard —
+  eyeball coherent correspondences vs lines collapsing to a point.
+- The frame layer keys on content, not container: transcodes, crops with
+  padding, and burned-in captions still match; that is why it is the copycat
+  workhorse.
+- The audio-fingerprint twin of this flow (`audio-fp` index, `audio match
+  --min-margin --draw`) lives in its own dedicated case.
+- Everything except the bonus `x:` sweep runs offline (local OpenCV DB via
+  `scripts/visual-db-uv.sh`; no API keys).

--- a/showcase/crime-board/RUNBOOK.md
+++ b/showcase/crime-board/RUNBOOK.md
@@ -1,0 +1,147 @@
+# crime-board — the CSI lineup / crime board (multi-person)
+
+**What this proves.** overcast can stand up a *persistent, fully local* face
+database out of raw footage — no faces ever leave the machine — and have it
+discover **several distinct people on its own**: one 160-second press-conference
+clip goes in, and the DB separates the four Artemis II crew members into four
+clean person clusters, re-identifies one of them across separated segments,
+survives a held-out official-portrait probe, and renders the whole book as a
+self-contained HTML contact sheet (every face crop embedded as a base64
+data-URI). The lineup is the deepface-local `face-cluster` provider
+(Facenet512 / retinaface via the uv-managed `OC_VISUAL_DB_PY` Python).
+
+The story: book each speaking segment of one short NASA presser clip →
+**4 distinct people** (Reid Wiseman, Victor Glover, Christina Koch, Jeremy
+Hansen — the Artemis II crew, all public figures). Glover speaks in two
+separated segments and the DB **matches his second appearance to his existing
+person (0 new people)** — cross-segment re-identification, the CCTV-handoff
+move. Then hand the book Christina Koch's official NASA portrait (never
+ingested): it points at her cluster at **65.5/100** with the runner-up at
+**3.4/100**.
+
+## Media provenance (staged under `showcase/_media/faces/`)
+
+- `artemis2-crew-presser-nasa-20250924.mp4` — trimmed from **NASA's official
+  YouTube channel**: "Artemis II Crew News Conference (Sept. 24, 2025)",
+  video id `9mq_lb_SmKE` (fetched with yt-dlp, the same engine behind the `dl:`
+  source). A NASA production = **US-government work, public domain**. Four 40 s
+  windows concatenated (ffmpeg) so each crew member gets a close-up segment in
+  one 160 s clip: source 228–268 s (Wiseman), 498–538 s (Glover), 782–822 s
+  (Koch), 1000–1040 s (Hansen); a wide panel shot sits inside the Glover
+  window at clip time 56–68 s.
+- `koch-portrait-nasa.jpg` — the held-out probe: Wikimedia Commons
+  "Christina Koch Artemis 2 Crew Portrait.jpg" (NASA / Josh Valcarcel, JSC),
+  **public domain**. Never ingested into the DB.
+
+All four people are clearly identifiable public figures (the Artemis II crew);
+identities were visually verified against the footage before labeling.
+
+## Reproduce
+
+All commands run from the repo root so `.env` auto-loads (`OC_VISUAL_DB_PY` for
+the deepface stack). Every command is isolated with `--case showcase/crime-board`.
+No `face` provider binding is needed — the shared profile is untouched.
+
+```bash
+# 0. fresh start (the old single-person build was cleared)
+overcast case clear --yes --case showcase/crime-board --json
+
+# 1. stand up a persistent LOCAL face-cluster index (the mugshot book)
+overcast index create people --type face-cluster --local --case showcase/crime-board --json
+IDX=local_face_cluster_29587d28
+V=showcase/_media/faces/artemis2-crew-presser-nasa-20250924.mp4
+
+# 2. book each speaking segment — detect + embed + assign-or-create at 0.5 fps.
+#    --min-similarity 52 was tuned on a scout pass (see Notes): >48 so Hansen
+#    doesn't glue onto Wiseman, ≤55 so profile poses still join their person.
+#    The wide-shot window 56–68s is deliberately skipped (junk signatures, Notes).
+overcast cluster add $V --index $IDX --fps 0.5 --min-similarity 52 --start 0   --end 40  --case showcase/crime-board --json   # rec_00a86601891b5a32: 20 faces -> 1 NEW person (Wiseman)
+overcast cluster add $V --index $IDX --fps 0.5 --min-similarity 52 --start 40  --end 56  --case showcase/crime-board --json   # rec_3817611d8ce720cc:  8 faces -> 1 NEW person (Glover)
+overcast cluster add $V --index $IDX --fps 0.5 --min-similarity 52 --start 68  --end 80  --case showcase/crime-board --json   # rec_3d8c840976eb1f34:  6 faces -> 0 new, ALL matched Glover (re-identified at 87-96)
+overcast cluster add $V --index $IDX --fps 0.5 --min-similarity 52 --start 80  --end 120 --case showcase/crime-board --json   # rec_9438364cc2a98de6: 20 faces -> 1 NEW person (Koch)
+overcast cluster add $V --index $IDX --fps 0.5 --min-similarity 52 --start 120 --end 160 --case showcase/crime-board --json   # rec_c5f30fb8ec9f010e: 20 faces -> 1 NEW person (Hansen)
+#   -> 74 faces, 4 people, zero junk detections; no recluster needed
+
+# 3. verify identities against the footage crops, then name the people
+overcast cluster label p_1 "Reid Wiseman (NASA astronaut, Artemis II commander)" --index $IDX --case showcase/crime-board --json
+overcast cluster label p_2 "Victor Glover (NASA astronaut, Artemis II pilot)"    --index $IDX --case showcase/crime-board --json
+overcast cluster label p_3 "Christina Koch (NASA astronaut, Artemis II)"         --index $IDX --case showcase/crime-board --json
+overcast cluster label p_4 "Jeremy Hansen (CSA astronaut, Artemis II)"           --index $IDX --case showcase/crime-board --json
+
+# 4. the lineup probe — run the held-out official portrait through the book
+overcast cluster identify showcase/_media/faces/koch-portrait-nasa.jpg \
+  --index $IDX --case showcase/crime-board --json
+#   -> rec_5e62a6f8a7799765: closest person p_3 "Christina Koch" at 65.5/100,
+#      confident, NOT a new person; runner-up (Wiseman) 3.4/100
+
+# 5. promote to evidence + narrate the verdict
+overcast finding create "Held-out official NASA portrait ... identified as p_3 'Christina Koch' at 65.5/100 ..." \
+  --ref rec_5e62a6f8a7799765 --confidence high --case showcase/crime-board --json   # rec_872aaaf40a072dba
+overcast note "Booked the four speaking segments ... 74 faces -> 4 distinct people ..." \
+  --tag tldr --case showcase/crime-board --json                                     # rec_47892ee6f05ed4a7
+
+# 6. HERO artifact — the multi-person contact-sheet gallery (one card per person,
+#    24 face crops embedded as data-URIs; fully self-contained)
+overcast cluster view --index $IDX --out showcase/crime-board/gallery.html --no-open \
+  --case showcase/crime-board --json
+
+# 7. second artifact — the relational crime board ("connect the dots"):
+#    the media hub fanning out to 5 booking records -> exactly 4 person nodes,
+#    plus the identify record, finding, and tldr note
+overcast graph --theme csi --export showcase/crime-board/graph.html --no-open \
+  --case showcase/crime-board --json          # 14 nodes / 13 edges
+```
+
+## Publish
+
+```bash
+node ~/dev/github/overcast.video/scripts/publish-case.mjs \
+  --slug crime-board \
+  --src  ~/.supacode/repos/overcast/case-studies/showcase/crime-board \
+  --scrub ~/.supacode/repos/overcast/case-studies \
+  --thumb gallery.html
+# -> public/cases/crime-board/{gallery.html, graph.html, runbook.html, thumb.png}
+# scrub grep file://|/Users/ : all 0
+```
+
+## Results
+
+- **Lineup:** 74 booked faces → **4 distinct people**, one card each, zero junk:
+  - `p_1` Reid Wiseman (NASA astronaut, Artemis II commander) — 20 faces, 1–39 s
+  - `p_2` Victor Glover (NASA astronaut, Artemis II pilot) — 14 faces, 41–79 s
+    (two separated segments; the second matched his existing person at 87–96)
+  - `p_3` Christina Koch (NASA astronaut, Artemis II) — 20 faces, 81–119 s
+  - `p_4` Jeremy Hansen (CSA astronaut, Artemis II) — 20 faces, 121–159 s
+- **Identification:** held-out `koch-portrait-nasa.jpg` → `p_3` at **65.5/100**
+  (confident, not flagged new); runner-up 3.4/100, then 2.2, 0.7.
+- **Hero artifact:** `gallery.html` — 4 named person cards, 24 face crops
+  embedded as base64 data-URIs, 0 external refs. Fully hostable.
+- **Second artifact:** `graph.html` — CSI force-graph, 14 nodes / 13 edges:
+  the presser-clip media hub fanning out to the 5 booking records → exactly the
+  4 cluster-person nodes, plus the probe image → identify record → finding.
+- **Published footprint:** ~1.1 MB (gallery + graph + runbook + thumb). Scrub
+  grep `file://|/Users/`: all 0.
+
+## Notes / caveats
+
+- **Junk exclusion (the false-positive prune, moved up front):** a full-clip
+  scout pass first produced 89 faces → 8 raw clusters, including two junk
+  "people" with the classic detector-false-positive signatures — retinaface
+  fallback boxes with `left_eye == null` (no landmarks → no alignment → noisy
+  embeddings) and sub-40 px motion-blur slivers, all inside the wide-shot
+  window at clip 56–68 s. Rather than booking them and pruning `faces.jsonl`
+  afterwards (the previous build's approach — it leaves dead cluster ids in the
+  booking records), the final booking skips that window with `--start/--end`,
+  so no junk ever enters the DB and every gallery card is a real face. The
+  signature test to find such clusters in any build:
+  `box.left_eye == null || box.w < 40` over the index's `faces.jsonl`.
+- **Threshold tuning (scout pass, scratch case):** at `--min-similarity 40`
+  Hansen's first face glued onto Wiseman's person at 48 similarity; Wiseman's
+  own profile-pose faces join as low as 55. 52 sits in the gap — all four stay
+  separate, poses still merge. Similarities are **0–100 (percent)**, not 0–1.
+- **Faces policy:** only clearly identifiable public figures (the Artemis II
+  crew) were booked, from public-domain US-government footage; identities were
+  visually verified before labeling/publishing. The audience/moderator portions
+  of the presser were deliberately not used.
+- **No profile changes.** `cluster` runs deepface directly via `OC_VISUAL_DB_PY`;
+  no provider binding was touched.

--- a/showcase/enhance/RUNBOOK.md
+++ b/showcase/enhance/RUNBOOK.md
@@ -1,0 +1,107 @@
+# Showcase: enhance — "Enhance & Resolve"
+
+A CityJet Avro RJ85 sits in a ramp photo, its registration painted on the rear
+fuselage. Crop that registration and knock it down to surveillance quality — 64
+pixels wide, heavy sensor noise — and it becomes an unreadable smudge. Baseline
+OCR on the smudge misreads the tail number as **E-RUC**, a garbled and wrong
+identifier. One pass of overcast's `enhance` — a deterministic clean-up (ffmpeg
+denoise + 2× upscale, no generative model) — recovers it: re-OCR reads
+**EI-RJC**, which the full-resolution source crop confirms exactly. A generative
+super-resolution tier (fal `aura-sr`, clearly reconstructive) produces the
+crispest-looking result and also reads EI-RJC — but its pixels are synthesized:
+on repeat runs it slips the final letter (EI-RJ**O** / EI-RJ**Q**), the case's
+honesty beat. The recovered registration identifies the airframe: **CityJet Avro
+RJ85, EI-RJC**.
+
+## Source media (provenance / license)
+
+- `showcase/_media/enhance/cityjet-eirjc.jpg` — "EI-RJC Avro Regional Jet RJ85
+  CityJet taxiing at Schiphol (AMS - EHAM), The Netherlands, 18may2014, pic-3" by
+  **Alf van Beem**, Wikimedia Commons, **CC0** (public-domain dedication):
+  https://commons.wikimedia.org/wiki/File:EI-RJC_Avro_Regional_Jet_RJ85_CityJet_taxiing_at_Schiphol_(AMS_-_EHAM),_The_Netherlands,_18may2014,_pic-3.JPG
+  The registration EI-RJC is a public aircraft identifier, not personal data.
+- `reg-eirjc-full.png` — ffmpeg crop of the registration on the rear fuselage
+  (the ground-truth control):
+  `ffmpeg -i cityjet-eirjc.jpg -vf "crop=360:240:2660:1275" reg-eirjc-full.png`
+- `reg-eirjc-degraded.jpg` — the "surveillance-quality" input (64px wide + heavy
+  noise + JPEG recompression):
+  `ffmpeg -i reg-eirjc-full.png -vf "scale=60:-2,noise=alls=45:allf=t+u" -q:v 6 reg-eirjc-degraded.jpg`
+  (final crop is 64×42; noise is seeded randomly, so this exact file is kept for
+  reproducibility)
+
+## Command sequence
+
+```bash
+cd /path/to/case-studies
+overcast case init --case showcase/enhance --name "Enhance & Resolve" --json
+
+# make sure enhance uses the builtin deterministic ffmpeg ops (clears any binding)
+overcast provider setup apply --verb enhance --choice ffmpeg --yes --json --case showcase/enhance
+
+# line of investigation
+overcast target add "CityJet Avro RJ85 in the ramp photo" \
+  --question "Recover the aircraft registration from the surveillance-quality crop and identify the airframe" \
+  --case showcase/enhance --json                                   # -> tgt_6aca61
+
+# establish the scene
+overcast see showcase/_media/enhance/cityjet-eirjc.jpg \
+  --prompt "Establish the scene: what kind of aircraft is this and where is the registration marked?" \
+  --case showcase/enhance --json                                   # -> rec_dc59298f4b14844b
+
+# BASELINE: OCR the degraded crop — misreads the registration as E-RUC (wrong)
+overcast see showcase/_media/enhance/reg-eirjc-degraded.jpg --ocr \
+  --case showcase/enhance --json                                   # -> rec_abc87b3d222775db (OCR: "E-RUC")
+overcast note "BEFORE: 64px surveillance-quality crop ... baseline OCR misreads as 'E-RUC' ..." \
+  --ref rec_abc87b3d222775db --tag enhance,before,ocr --confidence low --case showcase/enhance
+
+# ENHANCE (deterministic, builtin ffmpeg: hqdn3d denoise + 2x upscale)
+overcast enhance showcase/_media/enhance/reg-eirjc-degraded.jpg --ops denoise,upscale \
+  --case showcase/enhance --json                                   # -> .overcast/media/reg-eirjc-degraded_enhanced_4b29594531.png (provider: ffmpeg)
+
+# AFTER: re-OCR the enhanced output — reads EI-RJC (the true registration)
+overcast see showcase/enhance/.overcast/media/reg-eirjc-degraded_enhanced_4b29594531.png --ocr \
+  --case showcase/enhance --json                                   # -> rec_8cff224fc268734c (OCR: "EI-RJC")
+overcast note "AFTER (deterministic): denoise + 2x upscale ... reads 'EI-RJC' ..." \
+  --ref rec_8cff224fc268734c --tag enhance,after,ocr,recovered --confidence medium --case showcase/enhance
+
+# GENERATIVE TIER (clearly reconstructive): bind fal, aura-sr restore, re-OCR, unbind
+overcast provider setup apply --verb enhance --choice fal --yes --json --case showcase/enhance
+FAL_ENHANCE_IMAGE_MODEL=fal-ai/aura-sr overcast enhance showcase/_media/enhance/reg-eirjc-degraded.jpg \
+  --case showcase/enhance --json                                   # -> .overcast/media/reg-eirjc-degraded_fal.png (model: fal:fal-ai/aura-sr)
+overcast see showcase/enhance/.overcast/media/reg-eirjc-degraded_fal.png --ocr \
+  --case showcase/enhance --json                                   # -> rec_67ad88235e1a7e52 (OCR: "EI-RJC"; repeat runs slip to EI-RJO / EI-RJQ)
+overcast provider setup apply --verb enhance --choice ffmpeg --yes --json --case showcase/enhance   # restore profile
+
+# CONTROL: full-resolution source crop confirms EI-RJC
+overcast see showcase/_media/enhance/reg-eirjc-full.png --ocr \
+  --case showcase/enhance --json                                   # -> rec_a60d758c191b839b (OCR: "EI-RJC")
+
+# finding + verdict
+overcast finding create "Registration recovered from the degraded crop: CityJet Avro RJ85 EI-RJC ..." \
+  --ref rec_8cff224fc268734c --target tgt_6aca61 --confidence medium --case showcase/enhance
+overcast note "ENHANCE & RESOLVE — verdict: ... EI-RJC ..." --tag tldr --confidence medium --case showcase/enhance
+
+# export
+overcast brief --export showcase/enhance/brief.html --theme csi --case showcase/enhance
+```
+
+## OCR before / after (verbatim)
+
+| stage | registration read | notes |
+|---|---|---|
+| degraded (baseline, rec_abc87b3d222775db) | `E-RUC` | WRONG — a dropped character and garbled letters |
+| enhance denoise+upscale (rec_8cff224fc268734c) | `EI-RJC` | correct; deterministic, invents no detail |
+| fal aura-sr, reconstructive (rec_67ad88235e1a7e52) | `EI-RJC` | crispest to the eye; synthesized pixels, slips to EI-RJO / EI-RJQ on repeat runs |
+| full-res control (rec_a60d758c191b839b) | `EI-RJC` | ground truth, confirms the recovery |
+
+## Honesty caveats
+
+- Upscaling is interpolation and generative restores are reconstructive — both
+  can hallucinate. The recovered registration was treated as a LEAD until the
+  full-resolution control confirmed it; the finding says so explicitly.
+- The deterministic clean-up (denoise + 2× upscale) invents no detail and read
+  EI-RJC correctly and stably. The generative super-resolution looks crisper but
+  is non-deterministic: across repeat runs its final character came back as C, O,
+  or Q — "AI enhance" is a lead to corroborate, not sole proof.
+- The `enhance` provider binding was temporarily set to fal for the aura-sr tier
+  and restored to the builtin ffmpeg choice immediately after.

--- a/showcase/hologram/RUNBOOK.md
+++ b/showcase/hologram/RUNBOOK.md
@@ -1,0 +1,106 @@
+# hologram — speculative scene reconstruction (RUNBOOK)
+
+One flat photo of a parked car goes in; interactive "holograms" come out. The
+`reconstruct` verb holds the camera at a captured moment and then *moves* it —
+lifting a textured 3D mesh you can orbit in a hand-rolled WebGL viewer (no
+three.js, no CDN), synthesizing a full 360° turntable so you can walk around the
+car, and estimating depth for a drag-to-parallax hologram. Every pixel it emits
+is generative: each record carries a `payload.caveat` banner ("synthesized by a
+model, speculative, NOT photographic evidence") and is quarantined from
+`ask`/`brief` evidence. It's a hypothesis renderer — decide where to look next,
+then verify with real captures.
+
+A rigid, recognizable subject on a plain background reconstructs cleanest, so the
+subject is a single vintage car in a front-three-quarter view against an empty
+foggy dune backdrop.
+
+## Source media (provenance / license)
+
+- `showcase/_media/hologram/car-source.jpg` — **"Vintage gray car (Unsplash)"**,
+  a 1960s **Peugeot 404** parked at Parnassia aan Zee, Overveen, Netherlands
+  (2017-03-29), photo by **Peter Kisteman** (Unsplash `peterkisteman`,
+  <https://unsplash.com/photos/68pDhPHptQQ>), re-hosted on Wikimedia Commons as
+  *File:Vintage gray car (Unsplash).jpg*. **License: CC0 1.0** (Creative Commons
+  Zero / Public Domain Dedication) per the Commons `extmetadata`. 6000×3376.
+  (A residual in-camera "Copyright 2017. All rights reserved." EXIF string is
+  stale text superseded by the uploader's CC0 dedication; the working crop below
+  strips all metadata.)
+- `showcase/_media/hologram/car.jpg` — the reconstruction input: a metadata-
+  stripped 2000×910 crop of `car-source.jpg` that centres the whole vehicle with
+  a plain-background margin (better mesh isolation).
+
+Fetched with the Round-2 Wikimedia recipe (Commons search API →
+`extmetadata.LicenseShortName` = CC0 → download original `imageinfo.url`).
+
+```bash
+# fetch (Wikimedia Commons original) + crop to a clean, centred subject
+curl -s -A 'overcast-showcase/1.0' -o showcase/_media/hologram/car-source.jpg \
+  'https://upload.wikimedia.org/wikipedia/commons/4/43/Vintage_gray_car_%28Unsplash%29.jpg'
+ffmpeg -y -i showcase/_media/hologram/car-source.jpg \
+  -vf "crop=3780:1720:300:1500,scale=2000:-1" -map_metadata -1 \
+  showcase/_media/hologram/car.jpg
+```
+
+## The run (all commands from the repo root; `.env` auto-loads creds)
+
+```bash
+# 0. one-time: reconstruct has no builtin — bind the fal provider (FAL_KEY in .env)
+overcast provider setup apply --verb reconstruct --choice fal --yes
+
+# 1. isolate + reset the case
+overcast case init  --case showcase/hologram --json
+overcast case clear --case showcase/hologram --yes
+
+# 2. image→3D — Trellis via the fal QUEUE api → textured GLB (1.6 MB), base64-
+#    embedded in a no-dependency WebGL orbit viewer                    (~1 m 58 s)
+overcast reconstruct showcase/_media/hologram/car.jpg --ops model --case showcase/hologram --json
+#   → parent rec_3b9f4a756513c55f + one mesh child
+overcast view rec_3b9f4a756513c55f --no-open --case showcase/hologram --json
+#   → .overcast/media/reconstruct-orbit-rec_3b9f4a756513c55f.html   → hologram-3d.html
+
+# 3. depth hologram — Depth-Anything V2 → drag-parallax WebGL viewer        (~5 s)
+overcast reconstruct showcase/_media/hologram/car.jpg --ops depth --case showcase/hologram --json
+#   → parent rec_f4b408b905c8fd44 + one depth-map child
+overcast view rec_f4b408b905c8fd44 --no-open --case showcase/hologram --json
+#   → .overcast/media/reconstruct-parallax-rec_f4b408b905c8fd44.html → hologram-depth.html
+
+# 4. 360° sweep — Qwen multi-angle: 8 synthesized camera stops (az 0…315) →
+#    labeled cards + contact sheet + turntable mp4                    (~1 m 31 s)
+overcast reconstruct showcase/_media/hologram/car.jpg --ops sweep --count 8 --case showcase/hologram --json
+#   → parent rec_24b56909c6f69079 + 8 view stops + sheet + turntable
+
+# 5. keep the sweep gallery light: the viewer inlines every stop as a data-URI,
+#    so downscale the 8 stops to 800px in place (30 MB → 4.3 MB), then re-view.
+for a in 0 45 90 135 180 225 270 315; do
+  f=showcase/hologram/.overcast/media/reconstruct/car_14840e178e_az${a}.png
+  ffmpeg -y -i "$f" -vf scale=800:-1 /tmp/az.png && mv /tmp/az.png "$f"
+done
+overcast view rec_24b56909c6f69079 --no-open --case showcase/hologram --json
+#   → .overcast/media/reconstruct-gallery-rec_24b56909c6f69079.html → hologram-sweep.html
+
+# 6. copy the self-contained viewers into the showcase folder
+cp showcase/hologram/.overcast/media/reconstruct-orbit-rec_3b9f4a756513c55f.html    showcase/hologram/hologram-3d.html
+cp showcase/hologram/.overcast/media/reconstruct-gallery-rec_24b56909c6f69079.html  showcase/hologram/hologram-sweep.html
+cp showcase/hologram/.overcast/media/reconstruct-parallax-rec_f4b408b905c8fd44.html showcase/hologram/hologram-depth.html
+
+# 7. publish (scrubs path leaks, copies the turntable mp4, renders the thumbnail)
+node …/overcast.video/scripts/publish-case.mjs --slug hologram \
+  --src …/case-studies/showcase/hologram --scrub …/case-studies \
+  --thumb hologram-3d.html
+node …/overcast.video/scripts/publish-runbook.mjs --slug hologram \
+  --md …/case-studies/showcase/hologram/RUNBOOK.md --scrub …/case-studies
+```
+
+Local quirk + workaround: this machine's Homebrew ffmpeg 8.x mis-renders the
+`tile` filter fed by the image2 sequence demuxer (and lacks `drawtext`), so the
+sweep's auto-assembled contact sheet came out blank (~2 KB). Reproduced the
+sheet manually by `hstack`/`vstack`-ing the same 8 stop PNGs (ordered by
+azimuth) into a 4×2 grid at the record's sheet path, then re-ran `overcast view`
+so the gallery embeds the fixed sheet — same content, same geometry, no HTML
+edits.
+
+Honesty note: the amber "generative reconstruction" banner burned into every
+viewer is part of the product, not an apology — reconstruct's records never
+enter case evidence, never trigger findings, and exist to point real sensors in
+the right direction. The mesh, the eight turntable stops, and the depth map are
+all a model's *guess* at the unseen sides of a real car, not a measurement.

--- a/showcase/is-this-real/RUNBOOK.md
+++ b/showcase/is-this-real/RUNBOOK.md
@@ -1,0 +1,158 @@
+# Case: Is This Real? — media authenticity funnel (real media)
+
+**What it proves:** overcast runs the whole "is this photo real?" funnel locally
+on a REAL, real-world-edited photograph — and stays honest about what each
+signal can and cannot say. `verify` reads C2PA / Content Credentials (system
+`c2patool`) and teaches the most important lesson in provenance: **most media
+carries no cryptographic manifest at all**, and overcast reports that as a
+clean `ready` record (`has_manifest: false`), never as a fake-flag. `exif`
+lifts the capture metadata (ExifTool): device fingerprint, capture time, and
+the editing-software field — here a *genuine* `Snapseed 2.14` tag, left behind
+when the photographer re-saved the frame through Google's mobile editor —
+which auto-fires a "possibly edited" suggested finding. `enhance --ops ela`
+derives three forensic overlays (ELA recompression error, sensor-noise
+residual, luminance gradient) that make spliced regions light up. **ELA is a
+heuristic LEAD, not proof**, and the flow treats it that way: you look at the
+overlays, weigh the accumulated signals, and say exactly how far the evidence
+goes.
+
+**Subject media (real, CC0):** `showcase/_media/exif/gg-1.jpg` — an aerial
+photo of the Golden Gate Bridge (4623x2942), CC0 Unsplash-via-Wikimedia
+Commons, original file with its real EXIF intact: Canon EOS REBEL T5, body
+serial `222074031107`, lens EF-S18-55mm f/3.5-5.6 IS II, captured
+`2016:12:16 17:24:14`, no GPS, **Software: Snapseed 2.14.141428617** — a real
+mobile-edit re-save, not a planted fixture. (Its sibling `gg-2.jpg` — same
+camera body — belongs to the scene-locate and camera-ballistics cases.)
+
+**The verdict this run reached:** gg-1.jpg is **edited but not fabricated, as
+far as checked** (medium confidence). Positive edit signal: the genuine
+Snapseed EXIF tag (global tone/color re-save). No C2PA manifest — the common
+case, proves nothing either way. All three forensic overlays are consistent
+with a *global* edit, not a splice: ELA response follows scene detail only
+(bridge cables, skyline, boat wakes — classic edge response), the noise floor
+is homogeneous across sky/water/city, and the luminance-gradient edges run
+unbroken with no feathered seam or localized recompression patch. A
+calibration exhibit (a copy test-signed with c2patool's dev cert) shows what
+*positive* provenance looks like: `has_manifest:true · C2PA Test Signing
+Cert · Valid`, whose declared ingredient auto-fires its own suggested finding.
+
+## Run
+
+```bash
+# 0. run from the repo root; overcast auto-loads .env
+cd <repo-root>
+
+# 1. a case is just a folder + its .overcast/ store (rebuild: clear first)
+overcast case clear --case showcase/is-this-real --yes
+
+# 2. open the line of investigation
+overcast target add "Is gg-1.jpg (aerial Golden Gate Bridge photo) an authentic, unedited capture?" \
+  --case showcase/is-this-real            # -> tgt_91234e
+
+# 3. C2PA / Content Credentials provenance (system c2patool; brew install c2patool)
+overcast verify showcase/_media/exif/gg-1.jpg --case showcase/is-this-real
+# -> has_manifest:false — "no content credentials (no C2PA manifest)" — a clean
+#    ready record: NO manifest is the common case, not proof of fakery
+
+# 3b. positive control: sign a copy with c2patool's built-in dev test cert
+cat > /tmp/manifest.json <<'EOF'
+{
+  "claim_generator": "overcast-showcase-demo/0.1",
+  "assertions": [
+    { "label": "c2pa.actions",
+      "data": { "actions": [ { "action": "c2pa.edited",
+        "softwareAgent": "overcast showcase (test-signed demo copy)" } ] } }
+  ]
+}
+EOF
+mkdir -p showcase/is-this-real/exhibits
+c2patool showcase/_media/exif/gg-1.jpg -m /tmp/manifest.json \
+  -o showcase/is-this-real/exhibits/gg-1-signed.jpg
+overcast verify "$PWD/showcase/is-this-real/exhibits/gg-1-signed.jpg" \
+  --case showcase/is-this-real
+# -> has_manifest:true · signer "C2PA Test Signing Cert" · Valid — and the
+#    manifest's declared ingredient auto-fires a SUGGESTED finding (triage queue)
+
+# 4. capture metadata (system exiftool) — the REAL editing-software signal
+overcast exif showcase/_media/exif/gg-1.jpg --case showcase/is-this-real
+# -> 104 tags: Canon EOS REBEL T5 · serial 222074031107 · lens EF-S18-55mm ·
+#    2016:12:16 17:24:14 · no GPS · sw:Snapseed 2.14.141428617 — the genuine
+#    mobile re-save tag auto-fires a "possibly edited" suggested finding
+
+# 5. ELA / noise / luminance forensic overlays — a provider-only enhance op;
+#    bind the shipped local script (pillow + numpy, no API key) in a throwaway
+#    profile so the shared default profile stays untouched
+overcast setup provider enhance \
+  "exec:<python-with-pillow-numpy> $PWD/examples/providers/enhance/ela.py" \
+  --profile showcase-ela
+overcast enhance showcase/_media/exif/gg-1.jpg --ops ela \
+  --profile showcase-ela --case showcase/is-this-real
+# -> 1 parent (rec_7586c22ca77a3b8d) + 3 fanned-out children: *_ela.png,
+#    *_noise.png, *_luminance.png. LOOK at them (heuristic leads, not verdicts):
+#    ELA lights up only on scene edges (cables/skyline/wakes), noise floor is
+#    one homogeneous texture everywhere, luminance edges unbroken — a GLOBAL
+#    re-save signature (matches the Snapseed tag), no splice patch, no seam
+
+# 6. triage the auto-suggested leads, then record the analyst verdict
+overcast finding list --state triage --case showcase/is-this-real
+overcast finding accept <exif-snapseed-finding-id> --target tgt_91234e \
+  --case showcase/is-this-real            # the real Snapseed lead → the line
+overcast finding accept <verify-declared-edits-id> \
+  --case showcase/is-this-real            # calibration exhibit, unattached
+overcast finding create "gg-1.jpg verdict: EDITED but NOT fabricated as far as \
+checked. Positive edit signal: EXIF Software=Snapseed 2.14 (mobile re-save; \
+Canon EOS REBEL T5 serial 222074031107, capture 2016:12:16 17:24:14, no GPS). \
+No C2PA manifest (the common case). ELA/noise/luminance: response follows \
+scene detail only; noise floor homogeneous; no localized recompression patch, \
+no feathered seam — consistent with a GLOBAL Snapseed tone edit + re-save, \
+not a splice/composite." \
+  --ref rec_7586c22ca77a3b8d --target tgt_91234e --confidence medium \
+  --case showcase/is-this-real
+overcast note "VERDICT — gg-1.jpg is EDITED (real Snapseed 2.14 re-save in \
+EXIF) but shows NO splice/composite lead: ELA + noise + luminance uniform. No \
+C2PA manifest = the common case, not fakery. Edited-but-not-fabricated as far \
+as checked (medium confidence). ELA is a heuristic LEAD, never proof." \
+  --tag tldr --case showcase/is-this-real
+overcast target close tgt_91234e --as answered \
+  --note "Edited (genuine Snapseed EXIF re-save flag) but no compositing lead \
+across C2PA, EXIF, and ELA/noise/luminance forensics." \
+  --case showcase/is-this-real
+
+# 7. export the artifacts (CSI theme)
+#    display-size the overlay PNGs first (analysis ran at full 4623x2942; the
+#    gallery embeds them as data URIs — full-res would be a ~48MB page)
+for f in ela noise luminance; do
+  p=showcase/is-this-real/.overcast/media/ela/gg-1_$f.png
+  ffmpeg -y -i "$p" -vf scale=1600:-1 "$p.tmp.png" && mv "$p.tmp.png" "$p"
+done
+overcast view rec_7586c22ca77a3b8d --no-open --case showcase/is-this-real
+cp showcase/is-this-real/.overcast/media/enhance-gallery-rec_7586c22ca77a3b8d.html \
+   showcase/is-this-real/gallery.html      # 7.7MB, fully self-contained
+overcast brief --theme csi --export showcase/is-this-real/brief.html \
+  --case showcase/is-this-real             # ~49MB: re-embeds the 4.1MB subject
+                                           # per record card — NOT published
+```
+
+## Notes
+
+- **Real media, real edit**: the subject is CC0 (Unsplash-via-Wikimedia), and
+  the `Snapseed 2.14` editing-software tag is genuinely in the file — the
+  "possibly edited" suggested finding fires on real-world metadata, not a
+  planted fixture. Provenance + license noted here per the showcase recipe.
+- **Honesty framing** is the point of this case: a missing C2PA manifest is
+  NOT proof of fakery (most media has none), an editing-software tag proves a
+  re-save but not a fabrication, and ELA overlays are heuristic leads you must
+  eyeball. The verdict is the *accumulation*: here, honestly, "edited but not
+  fabricated as far as checked".
+- The signed exhibit uses c2patool's **built-in dev test certificate**
+  (`C2PA Test Signing Cert`) — valid signature, development trust chain
+  (`signingCredential.untrusted` code); it exists purely to show what a signed
+  manifest looks like in a `verify` record.
+- The three overlay PNGs were downscaled to 1600px wide **after** the analysis
+  (which ran at the full 4623x2942) so the self-contained gallery stays
+  publishable; the forensic read was done on the full-resolution maps.
+- `brief.html` (~49MB) embeds the 4.1MB subject JPEG once per referencing
+  record card, so it blows the publish budget; only `gallery.html` (the hero)
+  was published.
+- Everything here is keyless and local: c2patool + exiftool (system binaries)
+  and a pillow/numpy python for the ELA script. No billed API calls.

--- a/showcase/paris-sources/RUNBOOK.md
+++ b/showcase/paris-sources/RUNBOOK.md
@@ -1,0 +1,104 @@
+# paris-sources — one topic, every source
+
+One subject — "Paris" — swept across six overcast source providers in a single
+pass: Tavily web search, TikTok, X, live ADS-B flights over CDG/Orly, Windy
+webcams around the city center, and OpenStreetMap attractions via Overpass.
+79 hits in one sweep, 30 of them GPS-bearing (5 aircraft positions — including a
+three-point RJA268 track crossing Paris eastbound — plus 25 OSM features) that
+plot straight onto one case map. The brief's coverage table is the point: every
+source, its ref, last-scan freshness, and hit count in one table. This is the
+breadth demo — the same `source add` / `scan` machinery, six very different
+backends, one record contract.
+
+All commands run from the repo root (creds auto-load from `.env`), isolated with
+`--case showcase/paris-sources`.
+
+```bash
+# 1. Case
+overcast case init --case showcase/paris-sources --json
+
+# 2. Register the sources (one topic, six providers)
+overcast source add "web:Paris"                       --name "Web search: Paris"                     --case showcase/paris-sources --json
+overcast source add "tiktok:#paris"                   --name "TikTok #paris"                         --case showcase/paris-sources --json
+overcast source add "x:Paris"                         --name "X search: Paris"                       --case showcase/paris-sources --json
+overcast source add "flights:2.10,48.75,2.55,48.95"   --name "ADS-B over Paris (CDG/Orly)"           --case showcase/paris-sources --json
+overcast source add "webcam:48.8566,2.3522,50"        --name "Windy webcams near Paris center"       --case showcase/paris-sources --json
+overcast source add "overpass:tourism=attraction@around:2500,48.8566,2.3522" \
+                                                      --name "OSM attractions around Paris center"   --case showcase/paris-sources --json
+
+# 3. Sweep — one scan per source (limits kept modest)
+overcast scan --source web      --limit 10 --case showcase/paris-sources --json   # 10 hits
+overcast scan --source tiktok   --limit 12 --case showcase/paris-sources --json   # 12 hits
+overcast scan --source x        --limit 12 --case showcase/paris-sources --json   # 12 hits
+overcast scan --source webcam   --limit 15 --case showcase/paris-sources --json   # 15 hits
+overcast scan --source flights  --limit 25 --case showcase/paris-sources --json   # polled 3x (~3 AM Paris,
+                                                                                  # quiet airspace) -> 5 positions,
+                                                                                  # 2 aircraft, one 3-point track
+overcast scan --source overpass --limit 25 --case showcase/paris-sources --json   # 25 hits (the public
+                                                                                  # overpass-api.de instance throttles
+                                                                                  # intermittently with HTTP 406 —
+                                                                                  # wait ~40s and rescan)
+
+# 4. Analyst verdict for the brief
+overcast note "One subject, every source: a single 'Paris' sweep across six providers — Tavily web search (10), TikTok #paris (12), X keyword search (12), live ADS-B flights over CDG/Orly (5, incl. a 3-point RJA268 track), Windy webcams (15), and OSM attractions via Overpass (25) — returned 79 hits in one pass, 30 of them GPS-bearing and plotted straight onto the case map. Webcam hits carry coordinates in-payload but not payload.gps, so they list in the coverage table rather than pin on the map." \
+  --tag tldr --title "Paris source sweep — final tally" --case showcase/paris-sources
+
+# 5. Artifacts (map + brief)
+overcast map   --theme csi --no-open --export showcase/paris-sources/map.html   --case showcase/paris-sources --json
+overcast brief --theme csi           --export showcase/paris-sources/brief.html --case showcase/paris-sources --json
+
+# 6. Video/feed hero — pull the social-VIDEO results into the case, then snapshot
+#    the live `situation` page (video wall + reverse-chron source feed).
+# 6a. Capture ~8 of the TikTok video hits already in the case (any of the tiktok:
+#     scan.hit URLs; each downloads via the tiktok source provider).
+overcast capture "https://www.tiktok.com/@paris.in.mood/video/7619057607319325974"        --case showcase/paris-sources --json
+overcast capture "https://www.tiktok.com/@lolatraveltheworldwithme/video/7661352162294811934" --case showcase/paris-sources --json
+overcast capture "https://www.tiktok.com/@katemaries/video/7618154564432268575"           --case showcase/paris-sources --json
+overcast capture "https://www.tiktok.com/@juliasingerr/video/7603548609266732301"         --case showcase/paris-sources --json
+overcast capture "https://www.tiktok.com/@paris.in.mood/video/7648916793830018337"        --case showcase/paris-sources --json
+overcast capture "https://www.tiktok.com/@achileneinspire/video/7660234504564428063"      --case showcase/paris-sources --json
+overcast capture "https://www.tiktok.com/@maniknish/video/7654952501086604566"            --case showcase/paris-sources --json
+overcast capture "https://www.tiktok.com/@paris.in.mood/video/7629354267760938262"        --case showcase/paris-sources --json
+# (clips were then trimmed to a short ~6s window each — brightest moment, no audio —
+#  to keep them SHORT and rights-light, and so every wall tile shows content.)
+
+# 6b. Serve the live situation page over the case, wall + feed panels (operator/CLI
+#     only — blocks; prints a token pairing URL). Screenshot it, then stop.
+overcast situation serve --case showcase/paris-sources --panels wall,feed --no-open --theme csi
+#   -> screenshot the printed http://127.0.0.1:PORT/#t=... URL (scripts/shoot.mjs, --wait 9000)
+overcast situation stop  --case showcase/paris-sources --force
+```
+
+## Result
+
+| source | ref | hits | gps |
+| --- | --- | ---: | ---: |
+| web (Tavily) | `web:Paris` | 10 | — |
+| tiktok (Apify) | `tiktok:#paris` | 12 | — |
+| x (Apify) | `x:Paris` | 12 | — |
+| flights (OpenSky, keyless) | `flights:2.10,48.75,2.55,48.95` | 5 | 5 |
+| webcam (Windy) | `webcam:48.8566,2.3522,50` | 15 | — |
+| overpass (OSM, keyless) | `overpass:tourism=attraction@around:2500,48.8566,2.3522` | 25 | 25 |
+| **total** | | **79** | **30** |
+
+- `map.html` — 30 pins over Paris: the RJA268/SRR6646 aircraft positions ringing
+  the city plus 25 OSM attractions dense in the center. Self-contained HTML
+  (inlined JS; OSM raster tiles fetched by the browser at view time).
+- `brief.html` — verdict (tldr note) + the six-row coverage table + the full
+  newest-first record trail.
+- `wall.png` / `wall.html` — the hero: a snapshot of the live `situation` page over
+  this case (panels `wall,feed`). The top is a control-room **video wall** of the
+  eight captured TikTok clips looping at their moments; the bottom is a
+  reverse-chronological **feed** of the whole mixed sweep with per-source badges
+  (OSM · Flights · X · TikTok · Webcam). Video + feed — deliberately *not* a map.
+
+## Caveats
+
+- Webcam hits carry `lat`/`lng` as flat payload fields, not `payload.gps{lat,lng}`,
+  so they don't pin on `map` (in overcast 0.0.8 the scan layer does not lift them);
+  they still count in coverage. The overpass source was added to give the hero map
+  real Paris-center pins.
+- Flights were scanned at ~3 AM Paris time — quiet airspace; three polls
+  accumulated 5 positions. A daytime sweep of the same bbox returns dozens.
+- overpass-api.de intermittently returns HTTP 406 under rapid requests; one retry
+  after a cooldown succeeded with a full 25 hits.

--- a/showcase/scene-locate/RUNBOOK.md
+++ b/showcase/scene-locate/RUNBOOK.md
@@ -1,0 +1,108 @@
+# Case: The Geotag Lies — scene-locate
+
+**What it proves:** a geotag is a claim, not a fact — and overcast can catch it
+lying. The subject is a REAL photo (`showcase/_media/exif/gg-2.jpg`, CC0 —
+Unsplash via Wikimedia Commons, original EXIF intact): a fog-shrouded
+International Orange suspension tower that is unmistakably the **Golden Gate
+Bridge**. Its EXIF, though, pins it to **37.2423, -121.7604 — the hills SE of
+San Jose, ~40 miles away** — with an `Instagram` software tag betraying a
+re-save. The funnel runs metadata → VLM scene read → OSM ground truth at BOTH
+coordinates → reverse image search → sun/shadow math, and lands on a two-part
+verdict: the WHERE is wrong, the WHEN checks out. The map is the punchline —
+one pin in the San Jose hills surrounded by freeway undercrossings, and 40 mi
+NW the bridge itself (OSM: `bridge:structure=suspension`, `colour=#f04a00`)
+ringed by 15 tourist viewpoints, with the chronolocate point on top.
+
+**Media provenance:** `gg-2.jpg` is CC0 (Unsplash-era upload re-hosted on
+Wikimedia Commons), Canon EOS REBEL T5 serial `222074031107`, captured
+2016:08:12 18:06:43, GPS + software tags as shipped in the original file —
+nothing was synthesized or edited for this case.
+
+## Run
+
+```bash
+# 0. rebuild from scratch
+overcast case clear --case showcase/scene-locate --yes
+overcast case init --case showcase/scene-locate --name "Where Was This Shot? (and When)"
+
+# 1. metadata first — ExifTool GPS, capture time, device, editing software
+overcast exif showcase/_media/exif/gg-2.jpg --case showcase/scene-locate
+# → GPS 37.2423,-121.7604 (San Jose!) · Canon EOS REBEL T5 · 2016:08:12 18:06:43
+#   · sw:Instagram · serial 222074031107 · lens EF-S18-55mm
+
+# 2. open the line of investigation
+overcast target add "Where was gg-2.jpg actually taken — and does its geotag + timestamp hold up?" \
+  --question "The EXIF pin (37.2423,-121.7604, San Jose) matches what the pixels show — or the geotag is wrong and the true location can be corroborated" \
+  --case showcase/scene-locate                                # → tgt_5a77b2
+
+# 3. read the scene with the brain VLM (cloudglue)
+overcast see showcase/_media/exif/gg-2.jpg \
+  --prompt "Where could this be? Identify any landmark precisely. Describe the structure, its color and architecture, weather/light conditions, terrain, and any location clues." \
+  --case showcase/scene-locate
+# → "highly consistent with the Golden Gate Bridge": International Orange,
+#   Art Deco tower legs + portal bracing, marine-layer fog. No OCR-able text.
+
+# 4. OSM ground truth at BOTH coordinates (keyless Overpass API)
+overcast source add 'overpass:man_made=bridge@around:2000,37.2423,-121.7604' --case showcase/scene-locate  # the claimed pin
+overcast source add 'overpass:man_made=bridge@around:1500,37.8199,-122.4783' --case showcase/scene-locate  # the candidate
+overcast source add 'overpass:tourism=viewpoint@around:2000,37.8199,-122.4783' --case showcase/scene-locate
+overcast scan --source overpass --limit 25 --case showcase/scene-locate
+# → at the geotag: Bernal Road Undercrossing, a creek, a 101/85 HOV separation — freeway concrete only
+# → at the candidate: way 370672707 "Golden Gate Bridge", bridge:structure=suspension,
+#   colour=#f04a00 (International Orange), + 15 named viewpoints (Fort Point, Battery East…)
+# (overpass-api.de intermittently 406s on one mirror — retry the scan; it round-robins clean)
+
+# 5. reverse image search (Apify) — where does this image actually live?
+overcast source add "lens:showcase/_media/exif/gg-2.jpg" --case showcase/scene-locate
+overcast scan --source lens --limit 12 --case showcase/scene-locate
+# → Google Lens: ZERO matches on the fog shot (first run timed out at 240 s, retries returned [])
+overcast source add "yandeximg:showcase/_media/exif/gg-2.jpg" --case showcase/scene-locate
+overcast scan --source yandeximg --limit 12 --case showcase/scene-locate
+# → Yandex: "File:Above Golden Gate Bridge (Unsplash).jpg — Wikimedia Commons" (the source
+#   family of this photo) + a Golden Gate tour page; zero San Jose hits
+
+# 6. CHRONOLOCATION — is the claimed WHEN consistent? (offline solar math, no key)
+overcast chronolocate <exif-record-id> --lat 37.8199 --lng -122.4783 \
+  --at-time "2016-08-12T18:06:43-07:00" --case showcase/scene-locate
+# → daylight:true · sun 22.4° up, bearing 271.5° (due west) · expected shadows 91.5° at 2.5:1
+#   · solar time 16:51. A bright, fog-diffused frame fits a summer evening; fog hides
+#   shadows, so the bearing check is inconclusive — NOT contradicted. WHERE lied; WHEN holds.
+
+# 7. analyst layer — findings on the line, thread notes, verdict, close
+overcast finding create "Geotag contradicts the pixels: … only freeway undercrossings near the pin" --ref <see-rec> --confidence high --target tgt_5a77b2 --case showcase/scene-locate
+overcast finding create "True location corroborated: Golden Gate Bridge (37.8199,-122.4783) …" --ref <osm-bridge-rec> --confidence high --target tgt_5a77b2 --case showcase/scene-locate
+overcast finding create "Timestamp is sun-consistent: sun 22.4° up bearing 271.5° at 18:06 PDT …" --ref <chronolocate-rec> --confidence medium --target tgt_5a77b2 --case showcase/scene-locate
+overcast target close tgt_5a77b2 --as answered --note "Photo = Golden Gate Bridge; geotag (San Jose) wrong; timestamp sun-consistent." --case showcase/scene-locate
+overcast note "Verdict: geotag says San Jose, pixels say Golden Gate. …" --tag tldr --case showcase/scene-locate
+
+# 8. artifacts — the map is the punchline (both pins, 44 points)
+overcast map --theme csi --no-open --export showcase/scene-locate/map.html --case showcase/scene-locate
+overcast brief --theme csi --export showcase/scene-locate/brief.html --case showcase/scene-locate
+```
+
+## Signals scoreboard
+
+| signal | verb | says |
+|---|---|---|
+| EXIF metadata | `exif` | GPS = San Jose hills; **Instagram** software tag; Canon T5 serial `222074031107` |
+| Scene read | `see` (brain VLM, cloudglue) | "highly consistent with the **Golden Gate Bridge**" — Int'l Orange, Art Deco, marine fog |
+| OSM at the geotag | `scan` overpass (keyless) | only freeway undercrossings + a creek — no suspension bridge within 2 km |
+| OSM at the bridge | `scan` overpass (keyless) | way 370672707 = suspension bridge, `colour=#f04a00`, + 15 viewpoints |
+| Reverse image | `scan` yandeximg (Apify) | Wikimedia Commons "Golden Gate Bridge (Unsplash)" page; **zero San Jose hits** (Lens: no matches) |
+| Sun/shadow | `chronolocate` (offline) | 18:06 PDT → sun 22.4° up, due west — daylight fog scene fits; WHEN holds |
+
+**Verdict:** the photo is the Golden Gate Bridge; the geotag (San Jose,
+~40 mi away) is wrong — an artifact of the file's Instagram-era handling, not
+the scene. The 2016-08-12 18:06 PDT timestamp is sun-consistent.
+
+## Artifacts
+
+- `map.html` — the false San Jose pin (exif + its freeway-undercrossing
+  surroundings) AND the true Golden Gate cluster (the OSM bridge way, 15
+  viewpoints, the chronolocate point) on live OSM tiles — 44 markers, each
+  linking back to its record. The 40-mile contradiction is visible at a glance.
+- `brief.html` — the CSI-themed case brief: verdict, the closed line of
+  investigation with its 3 findings + thread, coverage table, record trail.
+
+Both are exported verbatim by the CLI. The only post-processing for hosting is
+the path scrub in the site's `scripts/publish-case.mjs`.

--- a/showcase/sf-scanner/RUNBOOK.md
+++ b/showcase/sf-scanner/RUNBOOK.md
@@ -1,0 +1,56 @@
+# Case: Police Scanner — San Francisco
+
+**What it proves:** overcast turns a live, keyless public-records feed into a
+geolocated, triaged case brief. The San Francisco Police Department publishes its
+computer-aided-dispatch (CAD) calls-for-service on the Socrata SODA open-data API
+— no key required. overcast's `dispatch` source reads that feed, tags every call
+with GPS, and plots them on a map you can hand to an analyst.
+
+Everything below is reproducible on any machine with overcast installed — there
+are **no API keys** in this case.
+
+## Run
+
+```bash
+# 1. a case is just a folder + its .overcast/ store
+overcast case init --case showcase/sf-scanner
+
+# 2. register the San Francisco CAD feed (a shipped preset; any Socrata city works
+#    via dispatch:<domain>/<dataset>). No key — SOCRATA_APP_TOKEN only raises limits.
+overcast source add "dispatch:sf" --case showcase/sf-scanner
+
+# 3. validate the feed with a single scan — confirm rows parse and carry
+#    gps / call-type / id columns (auto-detected per row)
+overcast scan --source dispatch --limit 50 --case showcase/sf-scanner
+
+# 4. open a line of investigation
+overcast target add "Where are tonight's assault, battery, and suspicious-activity \
+  calls clustering across SF districts?" --case showcase/sf-scanner
+
+# 5. plot every geolocated call on one self-contained HTML map (live OSM tiles)
+overcast map --since 24h --no-open --theme csi \
+  --export showcase/sf-scanner/map.html --case showcase/sf-scanner
+
+# 6. export the case brief (story-first: verdict, the line of investigation,
+#    coverage, and the newest-first record trail)
+overcast brief --theme csi \
+  --export showcase/sf-scanner/brief.html --case showcase/sf-scanner
+```
+
+`monitor` turns the one-shot scan into a standing watch — the SF feed is a rolling
+~48h real-time window, so it's a strong fit:
+
+```bash
+overcast monitor --once --case showcase/sf-scanner              # one diff pass
+overcast monitor --source dispatch --every 15m --limit 20 --case showcase/sf-scanner
+```
+
+## Artifacts
+
+- `map.html` — ~40+ live CAD calls plotted over San Francisco on OpenStreetMap
+  tiles, each marker linking back to the source SODA row (PETTY THEFT, TRAF
+  VIOLATION CITE, ASSAULT / BATTERY, WELL BEING CHECK, …). Fully self-contained.
+- `brief.html` — the CSI-themed case brief.
+
+Both are exported verbatim by the CLI. The only post-processing for hosting is a
+scrub of the local case-directory path (see the site's `scripts/publish-case.mjs`).

--- a/showcase/situation-room/RUNBOOK.md
+++ b/showcase/situation-room/RUNBOOK.md
@@ -1,0 +1,53 @@
+# Case: The Situation Room
+
+**What it proves:** overcast can stand up a live, self-updating control-room page
+over a case — "monitor the situation." The `situation` verb serves a
+token-authenticated local dashboard: a map of every geolocated record, a
+reverse-chronological feed of incoming hits, refreshing webcam/browser stills, and
+a video wall — panels auto-picked from the case's configured sources, refreshing
+themselves as new records land.
+
+This case wires three **keyless / no-extra-cost** live San Francisco sources:
+police CAD dispatch, live traffic-camera locations, and (when aircraft are
+overhead) ADS-B flights.
+
+> The page is **live** — it needs its local server running, so unlike the other
+> case files it can't be hosted as a static page. The image on the card is a real
+> snapshot of the running dashboard. Run the commands below to get the live one.
+
+## Run
+
+```bash
+overcast case init --case showcase/situation-room
+
+# wire live sources (dispatch + windy webcams are keyless / free-tier; flights is
+# keyless OpenSky). Any of these alone is enough to drive a panel.
+overcast source add "dispatch:sf"                              --case showcase/situation-room
+overcast source add "webcam:37.7749,-122.4194,50"             --case showcase/situation-room
+overcast source add "flights:-122.55,37.70,-122.35,37.83"     --case showcase/situation-room
+
+# seed the case with one pass of each source
+overcast scan --source dispatch --limit 25 --case showcase/situation-room
+overcast scan --source webcam   --limit 6  --case showcase/situation-room
+overcast scan --source flights  --limit 40 --case showcase/situation-room
+
+# stand up the live page (blocking; runs in its own terminal). --every makes the
+# serving process own the monitor cadence, so this one command IS "monitor the
+# situation" — the dashboard refreshes itself as new calls/flights land.
+overcast situation serve --case showcase/situation-room --panels map,feed,stills --every 5m
+```
+
+`situation set` retunes panels/filters on the fly and `situation stop` shuts it
+down — both from another terminal (or the agent), applied within ~2s:
+
+```bash
+overcast situation set  --panels map,feed --case showcase/situation-room
+overcast situation stop --case showcase/situation-room
+```
+
+## Artifact
+
+`situation.png` — a snapshot of the running dashboard: 21 geolocated SF dispatch
+calls on the map, a live feed interleaving traffic-camera locations and CAD calls
+(SUSPICIOUS PERSON, CITIZEN STANDBY, PETTY THEFT…), a ticking clock and a LIVE
+pulse. In the real page these update on their own.

--- a/showcase/wiretap/RUNBOOK.md
+++ b/showcase/wiretap/RUNBOOK.md
@@ -1,0 +1,112 @@
+# Case: Wiretap — "Who Is On This Tape?"
+
+**What it proves:** overcast works a recorded multi-speaker conversation
+end-to-end. A 2-minute panel excerpt goes in; `enhance --ops separate` (local
+pyannote, no media leaves the machine) splits it into one clean track per voice —
+**four speakers, only four cross-talk regions** — each with its own spectrogram.
+Then it cleans a noisy track: one speaker is degraded into a telephone-band
+"intercept" (band-limit + hiss), and `enhance` voice-isolation (ElevenLabs) drops
+the noise floor from a full-spectrum haze to black. Finally the local `voice-print`
+DB verifies WHO: the **cleaned** dominant speaker is enrolled as a reference, and
+`voice match` re-identifies him on the tape at **100/100** while a different
+panelist scores **58/100** — a clean positive-vs-negative on the same recording.
+Every voice record carries the honest caveat: similarity is a 0–100 rank score,
+NOT liveness — a cloned voice can score high, so a match is a corroborated lead,
+never an identification.
+
+**Source tape:** a ~2-min analysis excerpt (01:30–03:30) of *Lightcone: Consumer is
+back, What's getting funded now* — the **Lightcone Podcast**, channel **Y
+Combinator** (hosts Garry Tan, Harj Taggar, Jared Friedman, Diana Hu),
+https://www.youtube.com/watch?v=e1Yhs9BEOSw . Fetched audio-only with `yt-dlp`,
+downmixed to mono/16 kHz. Speakers are referred to by the diarizer's neutral labels
+(Speaker A–D), not named. The "degraded intercept" noise is synthetic and labeled
+as such. Full provenance in `showcase/_media/wiretap/SOURCES.md`.
+
+## Run
+
+```bash
+cd <case-studies repo root>            # creds auto-load from .env
+set -a; source .env; set +a
+
+# 0. Two dedicated profiles so both enhance bindings coexist (shared default untouched)
+overcast provider setup apply --verb enhance --choice local-models --profile showcase-wiretap     --yes --json   # pyannote separate
+overcast provider setup apply --verb enhance --choice elevenlabs   --profile showcase-wiretap-iso --yes --json   # voice isolation
+
+# 1. Fetch the tape (audio-only) and cut a 2-min multi-speaker window (mono/16k)
+yt-dlp -f bestaudio -o /tmp/lightcone.webm "https://www.youtube.com/watch?v=e1Yhs9BEOSw"
+mkdir -p showcase/_media/wiretap
+ffmpeg -y -ss 90 -t 120 -i /tmp/lightcone.webm -vn -ac 1 -ar 16000 -acodec pcm_s16le showcase/_media/wiretap/interview-tape.wav
+
+# 2. Case + line of investigation + transcript (default tinycloud backend)
+overcast case init --case showcase/wiretap --json
+overcast target add "voice-on-the-tape" --question "How many people speak, and once a degraded track is cleaned up, does the reference voice print re-identify the subject and reject the others?" --case showcase/wiretap --json
+overcast listen showcase/_media/wiretap/interview-tape.wav --case showcase/wiretap --json   # names it a Lightcone panel
+
+# 3. Separate the speakers (local pyannote; HF_TOKEN + accepted license)
+overcast enhance showcase/_media/wiretap/interview-tape.wav --ops separate --summarize \
+  --case showcase/wiretap --profile showcase-wiretap --json
+# -> parent + 4 tracks: SPEAKER_03 (A, 64.0s, dominant) / SPEAKER_02 (B, 30.3s) / SPEAKER_01 (C, 18.0s) / SPEAKER_00 (D, 5.9s), 4 cross-talk regions
+
+# 4. Cleanup step: degrade Speaker A's track into a noisy "intercept", then voice-isolate it back
+MED=showcase/wiretap/.overcast/media
+ffmpeg -y -i $MED/separate/interview-tape_SPEAKER_03.wav \
+  -filter_complex "[0:a]highpass=f=300,lowpass=f=3400,acompressor=threshold=-18dB:ratio=4,volume=1.6[v]; \
+                   anoisesrc=color=pink:amplitude=0.05:sample_rate=16000[hiss]; \
+                   sine=frequency=60:sample_rate=16000,volume=0.015[hum]; \
+                   [v][hiss][hum]amix=inputs=3:duration=first:normalize=0,alimiter=limit=0.95[out]" \
+  -map "[out]" -ac 1 -ar 16000 -acodec pcm_s16le $MED/interview-tape_SPEAKER_03_degraded.wav
+overcast enhance $MED/interview-tape_SPEAKER_03_degraded.wav \
+  --case showcase/wiretap --profile showcase-wiretap-iso --json   # -> *_degraded_voiceiso.mp3 (noise floor -> black)
+
+# 5. Voice print: enroll the CLEANED Speaker A + two other panelists, then match
+overcast index create voices --type voice-print --local --case showcase/wiretap --json
+overcast voice add $MED/interview-tape_SPEAKER_03_degraded_voiceiso.mp3 --index voices --case showcase/wiretap --json  # Speaker A (cleaned reference)
+overcast voice add $MED/separate/interview-tape_SPEAKER_02.wav --index voices --case showcase/wiretap --json           # Speaker B
+overcast voice add $MED/separate/interview-tape_SPEAKER_01.wav --index voices --case showcase/wiretap --json           # Speaker C
+
+overcast voice match showcase/_media/wiretap/interview-tape.wav $MED/interview-tape_SPEAKER_03_degraded_voiceiso.mp3 --case showcase/wiretap --json
+# POSITIVE: cleaned Speaker A found on the tape — best 100.0 at 15.8s, 20/159 windows >= floor, margin 30 -> auto-suggested finding
+overcast voice match $MED/separate/interview-tape_SPEAKER_02.wav $MED/interview-tape_SPEAKER_03_degraded_voiceiso.mp3 --case showcase/wiretap --json
+# NEGATIVE: Speaker B vs cleaned Speaker A -> best 58.4 (cosine 0.32) — rejected
+overcast voice match $MED/separate/interview-tape_SPEAKER_03.wav --index voices --case showcase/wiretap --json
+# LINEUP: probe Speaker A against the enrolled panel -> A member 100 vs next-best 61
+
+# 6. Analyst loop: accept the lead, record findings + notes, close, brief
+overcast finding accept <positive-finding-id> --target <tgt> --case showcase/wiretap --json
+overcast finding create "Four speakers on the tape ... 4 cross-talk regions" --ref <separate-parent> --target <tgt> --confidence high --case showcase/wiretap --json
+overcast finding create "Audio cleanup recovers a degraded intercept ... cleaned track re-IDs at 100/100" --ref <enhance-clean> --target <tgt> --confidence high --case showcase/wiretap --json
+overcast finding create "Voice print discriminates: 100/100 vs 58/100 ... NOT liveness" --ref <negative-match> --target <tgt> --confidence high --case showcase/wiretap --json
+overcast note "... 100/100 vs 58/100 ... Not liveness; the degradation is a labeled demonstration." --tag tldr --case showcase/wiretap --json
+overcast target close <tgt> --as answered --note "..." --case showcase/wiretap --json
+overcast brief --theme csi --export showcase/wiretap/brief.html --case showcase/wiretap --json
+```
+
+The before/after gallery (`gallery.html`) is a hand-built self-contained page:
+per-speaker separated tracks + spectrograms, then the degraded-vs-cleaned pair with
+matched 16 kHz spectrograms (data-URI) and compact mp3 players.
+
+## Publish
+
+```bash
+node <overcast.video>/scripts/publish-case.mjs --slug wiretap \
+  --src <case-studies>/showcase/wiretap --scrub <case-studies> --thumb gallery.html
+node <overcast.video>/scripts/publish-runbook.mjs --slug wiretap \
+  --md <case-studies>/showcase/wiretap/RUNBOOK.md --scrub <case-studies>
+# ~5.8MB media copied (6 x 64k-mono mp3), scrub grep all-0
+```
+
+## Notes / caveats
+
+- `enhance --ops separate` ran on the **local** pyannote binding
+  (`speaker-diarization-community-1`, HF_TOKEN + accepted license); the voice-
+  isolation cleanup ran on the **ElevenLabs** binding. They live in two dedicated
+  profiles (`showcase-wiretap`, `showcase-wiretap-iso`) so the shared default
+  profile is never touched.
+- The "degraded intercept" is a **synthetic** degradation (telephone band-pass +
+  pink hiss + faint mains hum) applied to a real speaker's separated track, so the
+  audio-cleanup before/after is an obvious noisy→clean. It is labeled as synthetic
+  in the gallery, brief, and provenance.
+- Voice-print scores are 0–100 rank scores (never 0–1). Every `voice` record carries
+  `payload.caveat`: similarity is NOT liveness — a cloned/synthetic voice can score
+  high; corroborate before treating a match as identification. Speakers are labeled
+  A–D by the diarizer, never named.


### PR DESCRIPTION
The reproducible command trail behind the **13 CASE FILES** published on overcast.video 

- `showcase/<slug>/RUNBOOK.md` — the exact overcast flow for each case, with a short story intro (a reproducible transcript).
- `showcase/HOWTO.md` — the operating manual used to generate the cases (golden rules, fixture table, the CC0/public-domain fresh-media recipe).
- `showcase/_media/wiretap/SOURCES.md` — media provenance/licensing.
- `showcase/.gitignore` — keeps runbooks/docs, ignores regenerable raw exports + media.

Raw HTML exports, media, and `.overcast/` case stores are gitignored; the scrubbed, hostable artifacts live in the overcast.video repo under `public/cases/`. Home-directory paths are scrubbed to `~`.

The 13 cases: connect-the-dots, sf-scanner, crime-board, copycat-sweep, paris-sources, scene-locate, wiretap, audio-match, camera-ballistics, is-this-real, enhance, situation-room, hologram.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, auth, or application code changes.
> 
> **Overview**
> Adds a **`showcase/`** documentation tree that records how the **13 overcast.video case files** were built: reproducible CLI transcripts, an agent operating manual, and gitignore rules so bulky exports stay out of git.
> 
> **`showcase/HOWTO.md`** defines the end-to-end workflow (repo-root creds, `--case showcase/<slug>`, export/publish via `overcast.video` scripts with path scrubbing, registry entry shape, fixture tables, and Round 2 CC0 media guidance including shared `gg-*` EXIF photos).
> 
> **Per-slug `RUNBOOK.md`** files document each demo’s story and exact `overcast` command sequence—forensics (`camera-ballistics`, `is-this-real`, `scene-locate`), local matching (`audio-match`, `copycat-sweep`), faces/audio (`crime-board`, `wiretap`), live OSINT (`sf-scanner`, `paris-sources`, `situation-room`), and generative viewers (`enhance`, `hologram`), plus `connect-the-dots`.
> 
> **`showcase/.gitignore`** commits markdown only; ignores HTML, media, and `media/` because hostable artifacts live in **overcast.video** `public/cases/`. **`showcase/_media/wiretap/SOURCES.md`** documents wiretap podcast provenance and labeled synthetic degradation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba96aa5acf424c6668ca1c731c3725dc521b1eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->