### PR TITLE
Release v0.0.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.8"
+    "version": "0.0.9"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": {
     "name": "kdr"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "Apache-2.0",
   "author": "kdr",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.3.
 
-export const OVERCAST_VERSION = "0.0.8";
+export const OVERCAST_VERSION = "0.0.9";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.3";


### PR DESCRIPTION
## Summary
- Bump version to 0.0.9 across all surfaces (`package.json`, `package-lock.json`, `src/version.ts`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) via `npm version 0.0.9 --no-git-tag-version` + `sync-version`.

## Ships since v0.0.8
- Provider restructure: `examples/providers/` → `providers/` + `shipped:` ref scheme; drop the wayback source (#104)

## Release process (RELEASING.md)
- [x] Bump + sync on `release-v0.0.9` branch
- [ ] Merge this PR
- [ ] Tag `main`: `git tag v0.0.9 && git push origin v0.0.9` (triggers `release.yml`: npm OIDC publish + bun binaries on the GitHub Release)
- [ ] Verify: `npm view @kdrrr/overcast version`

Made with [Cursor](https://cursor.com)