### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,3 +463,32 @@ and inspect the emitted record JSONL. For skill/doc changes, check against
 CLI router, bun binary), run the live suite (`npm run test:e2e:live`) and inspect
 the generated `report.md`. Keep pi touch-points isolated in `src/extension/` and
 `src/registry/to-agent-tool.ts` so a pi bump has a small blast radius.
+
+## Cursor Cloud specific instructions
+
+The startup update script runs `npm ci` (root) and `npm ci --prefix vscode`; the
+root `postinstall` (`scripts/brand-pi.mjs`) runs automatically. `ffmpeg`/`ffprobe`
+are already installed system-wide. Standard verb/test/build commands live in the
+`## Commands` section above and in `package.json` — reference those, not copies.
+
+Non-obvious caveats for this environment:
+
+- **Node version.** The default `node` is 22.14.x, which runs the CLI, build,
+ typecheck, and all test suites fine. `@earendil-works/pi-tui` declares
+ `engines.node >= 22.19.0`, so `npm ci` prints an `EBADENGINE` **warning** (not an
+ error). If the interactive pi TUI (bare `overcast` / `npm run dev`) misbehaves,
+ `nvm use 22.22.2` (already installed) satisfies that engine floor.
+- **Offline by default — no keys needed for core dev.** `overcast doctor` will
+ report `cloudglue`/`tinycloud`, `playwright`, `uv`/`visual-db`/`audio-db`,
+ `exiftool`, and `c2patool` as missing/failed — these are all *optional*
+ cloud/OSINT/Python backends. The core product (case management + local senses
+ like `chronolocate`, plus `note`/`target`/`finding`/`brief`) works fully offline.
+- **What needs secrets to run for real** (add via Secrets, not required for tests):
+ tinycloud CLI + `CLOUDGLUE_API_KEY` for the default `watch`/`listen`/`face`/`index`
+ senses; a brain-LLM key (BYO, e.g. `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`) for the
+ agent TUI and the default vision `see`; OSINT source keys per `.env.example`.
+- **Fast test loop.** After one `npm run build`, reuse `dist/` with
+ `SKIP_BUILD=1 npm run test:e2e`. Offline unit + e2e suites need no network/creds;
+ the live suite (`npm run test:e2e:live`) does and is not runnable here without
+ `.env` keys + media.
+- **No ESLint.** Lint in CI is `shellcheck -S warning` over `*.sh` only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the overcast development environment for Cursor Cloud agents, and documents durable startup caveats in `AGENTS.md` (symlinked to `CLAUDE.md`).

overcast is a CLI-first video/OSINT investigation toolkit (built on the `pi` harness) — no long-running backend server; verbs are one-shot CLI commands over a case folder.

## What was set up

- Installed root deps (`npm ci`) + the `vscode/` sub-package deps (`npm ci --prefix vscode`).
- Confirmed system `ffmpeg`/`ffprobe` present (required media prerequisite) and Node 22.
- Recorded the startup **update script**: `npm ci` then `npm ci --prefix vscode` (both idempotent, lockfiles committed; root `postinstall` brand-pi runs automatically).

## Verification

| Check | Command | Result |
|---|---|---|
| Typecheck | `npm run typecheck` | ✅ pass |
| Build | `npm run build` (tsup + vite) | ✅ pass |
| Unit tests | `npm test` | ✅ 1152/1152 |
| Offline e2e | `SKIP_BUILD=1 npm run test:e2e` | ✅ 318/318 |
| vscode ext | `npm run --prefix vscode typecheck/build/test` | ✅ 51/51 |
| Doctor | `node dist/bin/overcast.js doctor` | ✅ pi/ffmpeg/ffprobe ok (cloud/OSINT backends optional) |

### Hello-world investigation flow (offline, no keys)

`case init` → `target add` → `chronolocate verify` (pure offline solar math) → `note` → `brief` produced an investigation report citing 2 evidence records.

[overcast_env_demo.log](https://cursor.com/agents/bc-8b472a4a-463d-4e11-be2e-15b14d011fca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fovercast_env_demo.log)

## Docs

Added a `## Cursor Cloud specific instructions` section covering: Node 22.14 works for CLI/build/test while `pi-tui` wants ≥22.19 (`nvm use 22.22.2` if the TUI misbehaves), which `doctor` failures are optional, which features need secrets, the `SKIP_BUILD=1` fast test loop, and that lint is `shellcheck` only.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b472a4a-463d-4e11-be2e-15b14d011fca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b472a4a-463d-4e11-be2e-15b14d011fca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

