### PR TITLE
VS Code extension: release packaging — vsix on the release train, marketplace-ready metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,43 @@ jobs:
             npm publish
           fi
 
+  # VS Code extension: package the .vsix and attach it to the same GitHub
+  # Release. Its version is stamped by scripts/sync-version.mjs (checked in the
+  # npm-publish job), so the .vsix always matches the tag.
+  vsix:
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            vscode/package-lock.json
+      # Root deps too: the extension's typecheck/build import types from src/.
+      - run: npm ci
+      - run: npm ci --prefix vscode
+      - run: npm run --prefix vscode typecheck
+      - run: npm run --prefix vscode build
+      - run: npm run --prefix vscode test
+      - run: mkdir -p .dev && npm run --prefix vscode package
+      - name: Attach the .vsix to the GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: .dev/*.vsix
+          fail_on_unmatched_files: true
+      - name: Upload the .vsix as a workflow artifact (manual run)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: overcast-vscode-vsix
+          path: .dev/*.vsix
+          if-no-files-found: error
+          include-hidden-files: true
+
   binaries:
     needs: npm-publish
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ language-model tools when a chat provider is installed. Every action spawns
 `overcast … --json`; records land in the case and the sidebar follows the
 `.overcast/` store live.
 
+Install the `overcast-vscode-<version>.vsix` attached to the
+[latest release](https://github.com/kdr/overcast/releases) (`code
+--install-extension overcast-vscode-<version>.vsix`, or "Install from VSIX…" in
+the Extensions view), or build it from source:
+
 ```bash
 cd vscode && npm install && npm run build && npm run package
 code --install-extension ../.dev/overcast-vscode-*.vsix

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,15 @@
 # Releasing overcast
 
-overcast ships from one source tree to three places on every release:
+overcast ships from one source tree to four places on every release:
 
 - **npm** — `@kdrrr/overcast` (the CLI + pi package), published from CI via **npm
   OIDC trusted publishing** (no tokens, provenance attached automatically).
 - **GitHub Releases** — the standalone **bun binary**, cross-compiled for macOS
   (arm64/x64) and Linux (x64/arm64) and attached as
   `overcast-<os>-<arch>.tar.gz`.
+- **GitHub Releases** — the **VS Code extension** packaged as
+  `overcast-vscode-<version>.vsix` (install via `code --install-extension …` or
+  "Install from VSIX…" in the Extensions view).
 - **Claude plugin + agent skills** — the `.claude-plugin/` manifests and
   `skills/` are read straight from the repo (GitHub), so they go live when the
   release commit lands on the default branch.
@@ -24,6 +27,8 @@ propagates it into the files that hard-code a version:
 - `src/version.ts` (`OVERCAST_VERSION`)
 - `.claude-plugin/plugin.json`
 - `.claude-plugin/marketplace.json` (`metadata.version` + every `plugins[].version`)
+- `vscode/package.json` + `vscode/package-lock.json` (the `.vsix` rides the
+  release train, so the extension version always matches the CLI it pairs with)
 
 (`scripts/bun-sidecar.mjs` reads `package.json` directly, so it needs no sync.)
 
@@ -96,8 +101,8 @@ node scripts/sync-version.mjs --check     # all surfaces match (should already)
 ```
 
 `--no-git-tag-version` edits + syncs every surface (`package.json`,
-`package-lock.json`, `src/version.ts`, both `.claude-plugin/*.json`) **without**
-committing or tagging.
+`package-lock.json`, `src/version.ts`, both `.claude-plugin/*.json`, and the
+`vscode/` package + lockfile) **without** committing or tagging.
 
 **2. Open + merge the PR** (squash or merge — either is fine; step 3 tags `main`
 *after* it lands, so the tagged commit is always whatever ends up on `main`):
@@ -123,6 +128,8 @@ Pushing the `vX.Y.Z` tag triggers `release.yml`, which:
 3. **Publishes to npm** over OIDC (skipped if that version is already on npm).
 4. Cross-compiles the bun binary for the four targets and attaches the tarballs
    to the GitHub Release for the tag.
+5. Builds + tests the VS Code extension and attaches
+   `overcast-vscode-<version>.vsix` to the same Release.
 
 You can also run it manually from the Actions tab (**workflow_dispatch**) with the
 version as input; in that mode the binaries are uploaded as workflow artifacts
@@ -150,6 +157,8 @@ npm i -g @kdrrr/overcast@latest && overcast --version --json
 ```
 
 - Binaries: download a tarball from the release, `tar -xzf …`, run `./overcast --version`.
+- VS Code extension: download the `.vsix` from the release, `code
+  --install-extension overcast-vscode-<version>.vsix`, open the Overcast view.
 - Provenance: the npm package page shows a "Provenance" panel linking back to the run.
 - Plugin/skills: `/plugin marketplace add kdr/overcast` then `/plugin install overcast@overcast`,
   or `npx skills add kdr/overcast`.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "dev": "tsx bin/overcast.ts",
     "sync-version": "node scripts/sync-version.mjs",
     "pack:check": "node scripts/sync-version.mjs --check && node scripts/check-dist-fresh.mjs",
-    "version": "node scripts/sync-version.mjs && git add -A src/version.ts .claude-plugin/plugin.json .claude-plugin/marketplace.json",
+    "version": "node scripts/sync-version.mjs && git add -A src/version.ts .claude-plugin/plugin.json .claude-plugin/marketplace.json vscode/package.json vscode/package-lock.json",
     "prepack": "npm run pack:check",
     "prepublishOnly": "npm run build",
     "postinstall": "node scripts/brand-pi.mjs",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -79,24 +79,35 @@ if (mktDirty && !CHECK) writeJson(mktPath, mkt);
 // the root release so the .vsix attached to a GitHub Release matches the tag.
 // Surgical string replace (NOT parse + re-stringify): the manifest's compact
 // hand-formatting must survive the sync.
-const replaceVersions = (relPath, re) => {
+const replaceVersions = (relPath, re, expectedSites) => {
   const path = join(ROOT, relPath);
   const text = readFileSync(path, "utf8");
+  let sites = 0;
   const next = text.replace(re, (whole, pre, current, post) => {
+    sites += 1;
     if (current === VERSION) return whole;
     drift.push(`${relPath} (version=${current})`);
     return `${pre}${VERSION}${post}`;
   });
+  // A silent zero-match would let --check pass while the .vsix version
+  // diverges — fail loudly like the OVERCAST_VERSION path does.
+  if (sites !== expectedSites) {
+    console.error(
+      `[sync-version] expected ${expectedSites} version site(s) in ${relPath}, matched ${sites} — the file's formatting drifted from the sync regex`
+    );
+    process.exit(1);
+  }
   if (next !== text && !CHECK) writeFileSync(path, next);
 };
 // The manifest's own top-level version (2-space indent, so nested "version"
 // keys — e.g. inside contributes — can't match).
-replaceVersions("vscode/package.json", /^(  "version": ")([^"]*)(")/m);
+replaceVersions("vscode/package.json", /^(  "version": ")([^"]*)(")/m, 1);
 // The lockfile stamps the package version twice: at the top level and in the
 // root "" packages entry — both directly follow the package name.
 replaceVersions(
   "vscode/package-lock.json",
-  /("name": "overcast-vscode",\n\s*"version": ")([^"]*)(")/g
+  /("name": "overcast-vscode",\n\s*"version": ")([^"]*)(")/g,
+  2
 );
 
 if (CHECK) {

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -4,6 +4,8 @@
 //   - src/version.ts                  (OVERCAST_VERSION)
 //   - .claude-plugin/plugin.json      (.version)
 //   - .claude-plugin/marketplace.json (.metadata.version + every .plugins[].version)
+//   - vscode/package.json             (.version — the .vsix rides the release train)
+//   - vscode/package-lock.json        (.version + .packages[""].version)
 // scripts/bun-sidecar.mjs reads package.json directly, so it needs no syncing.
 //
 // Usage:
@@ -72,6 +74,30 @@ for (const p of mkt.plugins ?? []) {
   }
 }
 if (mktDirty && !CHECK) writeJson(mktPath, mkt);
+
+// 4) vscode/package.json + its lockfile — the VS Code extension version tracks
+// the root release so the .vsix attached to a GitHub Release matches the tag.
+// Surgical string replace (NOT parse + re-stringify): the manifest's compact
+// hand-formatting must survive the sync.
+const replaceVersions = (relPath, re) => {
+  const path = join(ROOT, relPath);
+  const text = readFileSync(path, "utf8");
+  const next = text.replace(re, (whole, pre, current, post) => {
+    if (current === VERSION) return whole;
+    drift.push(`${relPath} (version=${current})`);
+    return `${pre}${VERSION}${post}`;
+  });
+  if (next !== text && !CHECK) writeFileSync(path, next);
+};
+// The manifest's own top-level version (2-space indent, so nested "version"
+// keys — e.g. inside contributes — can't match).
+replaceVersions("vscode/package.json", /^(  "version": ")([^"]*)(")/m);
+// The lockfile stamps the package version twice: at the top level and in the
+// root "" packages entry — both directly follow the package name.
+replaceVersions(
+  "vscode/package-lock.json",
+  /("name": "overcast-vscode",\n\s*"version": ")([^"]*)(")/g
+);
 
 if (CHECK) {
   if (drift.length) {

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -8,3 +8,6 @@ tsconfig.json
 tsup.config.ts
 **/*.map
 .gitignore
+package-lock.json
+*.vsix
+**/.DS_Store

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+Notable changes to the Overcast VS Code extension. The extension version rides
+the overcast release train — it matches the root `package.json` version stamped
+by `scripts/sync-version.mjs`, so a given `.vsix` version pairs with the same
+CLI version.
+
+## Unreleased
+
+Initial preview release.
+
+- Right-click senses on any media file — Watch, Listen, See, Detect Faces,
+  EXIF, Chronolocate, Enhance, Find Similar, Audio Fingerprint, Voice Match,
+  View, Grid — plus multi-select **Analyze All Selected**.
+- **Overcast** activity-bar view: case deck (intelligence-cycle actions),
+  Sources & Monitors, Records, Investigation (with inline lead accept/dismiss),
+  and Runs trees.
+- Evidence artifacts as editor tabs: Map, Graph, Wall, Brief, and the live
+  Situation panel.
+- `@overcast` chat participant (`/ask /scan /status /brief /capture /sense
+  /note`) and six `#overcast*` language-model tools for agent mode, each behind
+  a confirmation dialog showing the exact CLI command.

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -3,7 +3,8 @@
 **The situation room in your editor: senses on your media, OSINT on your
 sources, a wall to monitor the situation.**
 
-[overcast](../README.md) turns footage into cited evidence: it watches,
+[overcast](https://github.com/kdr/overcast#readme) turns footage into cited
+evidence: it watches,
 listens to, and reads your media, scans OSINT sources, and keeps everything
 in an investigation case where every answer cites the exact record and
 timestamp. This extension puts that power where your media already lives —
@@ -98,7 +99,22 @@ what to configure.
   (a `.js` path runs on the extension host's own Node).
 - A case folder in the workspace (or run "Overcast: Initialize Case Here").
 
-## Build & sideload
+## Install
+
+Install the packaged `.vsix`.
+
+**From a GitHub release** (recommended): every
+[overcast release](https://github.com/kdr/overcast/releases) attaches
+`overcast-vscode-<version>.vsix`. Download it, then either run
+
+```bash
+code --install-extension overcast-vscode-<version>.vsix
+```
+
+or, in VS Code: **Extensions** view → `···` menu → **Install from VSIX…** and
+pick the downloaded file.
+
+**From source:**
 
 ```bash
 cd vscode

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "overcast-vscode",
-  "version": "0.0.1",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "overcast-vscode",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "overcast-vscode",
   "displayName": "Overcast",
   "description": "The situation room in your editor — senses on your media (watch, listen, see, faces, EXIF via right-click), OSINT on your sources, and a wall to monitor the situation: maps, graphs, briefs, live feeds.",
-  "version": "0.0.1",
+  "version": "0.0.9",
   "publisher": "kdr",
   "private": true,
   "license": "Apache-2.0",
@@ -11,14 +11,22 @@
     "url": "git+https://github.com/kdr/overcast.git",
     "directory": "vscode"
   },
+  "homepage": "https://github.com/kdr/overcast/tree/main/vscode#readme",
+  "bugs": { "url": "https://github.com/kdr/overcast/issues" },
+  "qna": false,
+  "pricing": "Free",
   "type": "module",
   "engines": {
     "vscode": "^1.96.0"
   },
   "categories": [
-    "Other",
-    "Visualization"
+    "AI",
+    "Chat",
+    "Visualization",
+    "Other"
   ],
+  "keywords": ["osint", "investigation", "video", "forensics", "geolocation", "transcription", "media", "evidence"],
+  "galleryBanner": { "color": "#101418", "theme": "dark" },
   "main": "./dist/extension.cjs",
   "icon": "media/overcast.png",
   "activationEvents": [

--- a/vscode/tsup.config.ts
+++ b/vscode/tsup.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
   platform: "node",
   target: "node20",
   external: ["vscode"],
+  // Release-grade output: the same build is what gets packaged into the .vsix.
+  // Sourcemaps are emitted for local F5 debugging but .vscodeignore keeps them
+  // out of the package.
+  minify: true,
   sourcemap: true,
   clean: true,
   dts: false,


### PR DESCRIPTION
Gears the VS Code extension up for release: the `.vsix` now ships with every GitHub Release, the manifest is Marketplace-ready, and the packaging constraints from the [publishing docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) are verified against what `vsce` actually enforces.

## The SVG question (what prompted this)

`vsce`'s validation source confirms the "no user-provided SVG" rule covers only the **Marketplace-rendered surfaces**: the manifest `icon` (must be PNG ≥128px — ours is 256×256 ✓), images in README/CHANGELOG (HTTPS + non-SVG unless a trusted badge host), and badges. SVGs *inside* the package — our activity-bar/view/submenu icons — are allowed (and are VS Code's recommended format), so they stay. The one real Marketplace bug found: the extension README's `../README.md` relative link — `vsce` rewrites relative links against the repo **root**, so it would 404 on the listing page. Now absolute.

## Changes

- **release.yml**: new `vsix` job (gated on `npm-publish`, like `binaries`) — installs, typechecks, tests, packages, and attaches `overcast-vscode-<version>.vsix` to the GitHub Release; uploads as a workflow artifact on `workflow_dispatch`.
- **Version rides the release train**: `sync-version.mjs` now stamps `vscode/package.json` + its lockfile, so the `.vsix` version always matches the tag/CLI it ships with, and the existing CI drift check (`sync-version.mjs --check`) enforces it. The sync is a surgical regex replace, not parse-and-restringify, so the hand-compacted manifest formatting survives. Extension goes 0.0.1 → 0.0.9 here.
- **Marketplace-ready manifest**: `keywords`, `homepage`, `bugs`, `galleryBanner`, `pricing: Free`, `qna: false`, and AI/Chat added to `categories` (it ships a chat participant + LM tools). New `vscode/CHANGELOG.md` for the Marketplace changelog tab.
- **Release-grade build**: tsup now minifies the host bundle (169 → 103 KB); sourcemaps still emitted for F5 debugging but excluded from the package, and `.vscodeignore` also drops `package-lock.json` / `*.vsix` / `.DS_Store`.
- **Install-from-release docs**: `vscode/README.md`, the root README extension section, and RELEASING.md (ship list + release steps + verify) now cover downloading the release `.vsix` and `code --install-extension` / "Install from VSIX…".

## Verification

- `npm ci --prefix vscode` (validates the lockfile edit) → typecheck → 51 extension tests → build → `vsce package`: **zero warnings**, clean 14-file vsix (112 KB).
- `node scripts/sync-version.mjs --check` passes; `release.yml` parses.

Marketplace publishing itself (publisher setup, credentials, CI publish step, Open VSX) is deliberately **not** part of this PR and not documented in-repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CI, versioning sync, docs, and extension packaging metadata; no runtime CLI or security-sensitive logic changes.
> 
> **Overview**
> Adds **release automation** so `overcast-vscode-<version>.vsix` is built in CI and attached to every tag-driven GitHub Release (new `vsix` job after `npm-publish`; manual runs upload a workflow artifact instead).
> 
> **Version lockstep:** `scripts/sync-version.mjs` now stamps `vscode/package.json` and `vscode/package-lock.json` (regex-based, with a site-count guard); the root `version` npm hook stages those files. Extension version moves to **0.0.9** to match the CLI.
> 
> **Packaging / listing readiness:** Marketplace-oriented manifest fields (`keywords`, `homepage`, `bugs`, `galleryBanner`, AI/Chat categories), new `vscode/CHANGELOG.md`, README link fixed to absolute GitHub URL, **minified** extension host bundle via tsup, and `.vscodeignore` tightened (lockfile, `.vsix`, sourcemaps, `.DS_Store`).
> 
> **Docs:** Root README, `vscode/README.md`, and `RELEASING.md` document install-from-release and the fourth ship target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e723656015ad38b982dbecca606984386ee43d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->