### PR TITLE
tinycloud 0.3.12 floor: single-call watch/listen transcripts from inline envelope speech

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,13 @@ package** (extension + skills + prompts + theme), a **standalone bun binary**, a
 - `@cloudglue/cloudglue-js` — the default sense backend (via the tinycloud CLI,
   `exec`). Cloudglue is **also** a pickable *brain* LLM provider (anthropic-messages
   API) so it appears in `/model` — never forced. The tinycloud CLI is a runtime
-  prerequisite (like ffmpeg), not an npm dep; `face` + `index` need **≥ 0.3.4**,
-  and current docs recommend tinycloud **0.3.10** — `listen` pulls VERBATIM
-  transcript cues via the public `caption` verb (0.3.10 watch envelopes ship
-  `segments: []`; older tinyclouds fall back to inline envelope speech), and
-  image `see`/`extract` (the opt-in `see:tinycloud` provider) need ≥ 0.3.7.
+  prerequisite (like ffmpeg), not an npm dep; the floor is tinycloud
+  **≥ 0.3.12** (`watch.speech.v1`) — the watch envelope inlines VERBATIM speech
+  (`segments[].speech`), so `watch`/`listen` transcripts are single-call
+  (`listen --diarize` still rides the public `caption` verb, which is also the
+  fallback for 0.3.10/0.3.11 envelopes that ship `segments: []`); `face` +
+  `index` need ≥ 0.3.4, and image `see`/`extract` (the opt-in `see:tinycloud`
+  provider) need ≥ 0.3.7.
 - `ffmpeg` + `ffprobe` — a **system prerequisite** (on `PATH`, or via
   `OVERCAST_FFMPEG` / `OVERCAST_FFPROBE`); the internal media toolkit, NOT bundled.
 - uv-managed visual/audio DB Python — optional for visual/audio DBs,

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ another backend or your own script with no code changes.
   (or point `OVERCAST_FFMPEG` / `OVERCAST_FFPROBE` at specific binaries).
 - **[tinycloud CLI](https://www.npmjs.com/package/@cloudglue/tinycloud)** — the
   default `watch` / `listen` / `face` / `index` backend (Cloudglue); set
-  `CLOUDGLUE_API_KEY`. The `face` + `index` verbs need **tinycloud ≥ 0.3.4**
-  and overcast currently recommends **0.3.10** (`npm i -g @cloudglue/tinycloud@0.3.10`
-  or `tinycloud update`): `listen` fetches its VERBATIM transcript cues through
-  the `caption` verb (0.3.10's watch envelope no longer inlines per-segment
-  speech; older tinyclouds fall back to the envelope's inline speech). The image
-  `see`/`extract` verbs (≥ 0.3.7) sit behind the opt-in `see` provider; override
-  the invocation with `OVERCAST_TINYCLOUD_CMD`.
+  `CLOUDGLUE_API_KEY`. overcast needs **tinycloud ≥ 0.3.12**
+  (`npm i -g @cloudglue/tinycloud@0.3.12` or `tinycloud update`): 0.3.12
+  (`watch.speech.v1`) inlines the VERBATIM speech in the watch envelope
+  (`segments[].speech`), so `watch`/`listen` transcripts come from a single
+  call — on the older 0.3.10/0.3.11 (empty `segments`) `listen` falls back to
+  fetching the cues through the `caption` verb, which `--diarize` still uses on
+  every version. `face` + `index` need ≥ 0.3.4; the image `see`/`extract` verbs
+  (≥ 0.3.7) sit behind the opt-in `see` provider; override the invocation with
+  `OVERCAST_TINYCLOUD_CMD`.
 - **[qmd](https://github.com/tobi/qmd)** — optional local semantic case search:
   `npm install -g @tobilu/qmd`. The first qmd rebuild downloads/caches
   `embeddinggemma-300M-Q8_0` for embeddings. Plain `ask` does not require qmd.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1234,8 +1234,8 @@ library collection surfaces (invariant #9: public verbs only; mapped to the loos
 record by the shared `runTinycloud` boundary in
 [`src/providers/tinycloud/envelope.ts`](../src/providers/tinycloud/envelope.ts)).
 Point `OVERCAST_TINYCLOUD_CMD` at a specific binary/wrapper if `tinycloud` isn't
-on `PATH`; `overcast doctor` reports the installed version, warns below 0.3.4,
-and recommends the latest tested tinycloud, currently 0.3.8.
+on `PATH`; `overcast doctor` reports the installed version, warns below the
+0.3.12 floor, and recommends the latest tested tinycloud, currently 0.3.12.
 
 ### `face` — detect / match / search
 
@@ -1307,7 +1307,8 @@ accept a path, URL, or a case record id (a `capture`/`watch` record → its medi
 ## Readiness
 
 `overcast doctor` checks pi, the system ffmpeg/ffprobe, Cloudglue creds, the
-tinycloud CLI **and its version** (`face`/`index` need ≥ 0.3.4; the opt-in
-`see:tinycloud` provider needs ≥ 0.3.7), the
-home/profiles, and the active provider bindings. Version 0.3.8 is the current
+tinycloud CLI **and its version** (the floor is ≥ 0.3.12 — `watch.speech.v1`
+inlines the verbatim `watch`/`listen` transcripts; `face`/`index` need ≥ 0.3.4;
+the opt-in `see:tinycloud` provider needs ≥ 0.3.7), the
+home/profiles, and the active provider bindings. Version 0.3.12 is the current
 recommended tinycloud build.

--- a/skills/overcast-init/SKILL.md
+++ b/skills/overcast-init/SKILL.md
@@ -22,11 +22,13 @@ One-time setup for overcast.
    (`~/.claude/skills`), and `--harness claude-code` is the explicit Claude
    target.
 3. **Install/update tinycloud** — the default perception backend. Get the latest
-   (`npm i -g @cloudglue/tinycloud@0.3.8` then `tinycloud install --latest`, or
-   `tinycloud update`). The `face` + `index` verbs need **tinycloud ≥ 0.3.4**,
-   and overcast currently recommends **0.3.8** (the image `see`/`extract`
-   verbs behind the opt-in `see:tinycloud` provider need ≥ 0.3.7);
-   override the invocation with `OVERCAST_TINYCLOUD_CMD` if it isn't on `PATH`.
+   (`npm i -g @cloudglue/tinycloud@0.3.12` then `tinycloud install --latest`, or
+   `tinycloud update`). overcast needs **tinycloud ≥ 0.3.12** — its watch
+   envelope inlines the verbatim `watch`/`listen` transcripts
+   (`watch.speech.v1`); the `face` + `index` verbs need ≥ 0.3.4, and the image
+   `see`/`extract` verbs behind the opt-in `see:tinycloud` provider need
+   ≥ 0.3.7. Override the invocation with `OVERCAST_TINYCLOUD_CMD` if it isn't
+   on `PATH`.
 4. **Verify** — `overcast doctor --json` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI + version, optional uv/visual-db readiness).
 5. **Cloudglue key** — the default `watch`/`listen`/`face`/`index` providers

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -236,8 +236,8 @@ overcast index entities <entity-index-id> ./clip.mp4 --json
 ```
 
 `face` needs tinycloud ≥ 0.3.4 (`overcast doctor` flags an older install);
-overcast currently recommends tinycloud 0.3.8 for the latest face validation,
-CLI reliability, and image `see`/`extract` behavior. Face detection counts are boxes per sampled frame, not
+overcast's floor is tinycloud 0.3.12, which also carries the latest face
+validation, CLI reliability, and image `see`/`extract` behavior. Face detection counts are boxes per sampled frame, not
 unique people; use `--match <photo>` for a specific person and `crop` when
 you need durable cropped image evidence. If a local video lacks descriptive
 content evidence, add it to the index with `overcast index add ./clip.mp4 --to

--- a/src/providers/tinycloud/envelope.ts
+++ b/src/providers/tinycloud/envelope.ts
@@ -69,6 +69,30 @@ export function envelopeData(parsed: unknown): Record<string, unknown> {
   return o;
 }
 
+/** Verbatim speech cues for one watch-envelope segment. tinycloud ≥ 0.3.12
+ *  (`watch.speech.v1`) ships `speech: string[]` per segment; older envelopes
+ *  inlined a single transcript/speech/text string. A cue that straddles a
+ *  segment boundary lands in BOTH neighboring segments' arrays, so `fresh`
+ *  excludes cues already present in the PREVIOUS segment — thread the returned
+ *  `cues` back in as the next call's `prev`. A speechless segment yields an
+ *  empty `cues` set, clearing that state: only ADJACENT segments can share a
+ *  straddling cue, so an identical utterance repeated after a gap survives. */
+export function segmentSpeechCues(
+  seg: Record<string, unknown>,
+  prev: ReadonlySet<string>,
+): { fresh: string[]; cues: Set<string> } {
+  const arr = Array.isArray(seg.speech)
+    ? seg.speech.filter((l): l is string => typeof l === "string" && l.trim() !== "")
+    : [];
+  const legacy =
+    (typeof seg.transcript === "string" && seg.transcript) ||
+    (typeof seg.speech === "string" && seg.speech) ||
+    (typeof seg.text === "string" && seg.text) ||
+    "";
+  const texts = arr.length > 0 ? arr : legacy ? [legacy] : [];
+  return { fresh: texts.filter((t) => !prev.has(t)), cues: new Set(texts) };
+}
+
 /** The first string-y status found across the envelope + data (envelope wins). */
 function rawStatus(env: Record<string, unknown>, data: Record<string, unknown>): string {
   for (const v of [env.status, env.state, data.status, data.state]) {

--- a/src/providers/tinycloud/listen.ts
+++ b/src/providers/tinycloud/listen.ts
@@ -2,12 +2,13 @@
 // Maps the tinycloud envelope to an `audio.analysis` record at
 // the exec boundary. Swap to a local whisper via http/in-proc for offline use.
 //
-// Two-step default path: `tinycloud watch --speech-only` creates/refreshes the
-// speech enrichment, then the public `tinycloud caption` verb (local once the
-// enrichment is cached) supplies the VERBATIM cues. tinycloud ≥ 0.3.10 stopped
-// inlining per-segment speech in the watch envelope (segments: [] for audio /
-// short sources), so mapping the envelope alone would silently store the LLM
-// summary as the "transcript" — never let a summary pose as the spoken words.
+// Single-call default path: tinycloud ≥ 0.3.12 (the documented floor) ships the
+// VERBATIM cues inline in the watch envelope again (`segments[].speech`, an
+// array of cue strings per segment). The public `tinycloud caption` verb still
+// backs two gaps: `--diarize` (watch has no diarize flag) and older tinyclouds
+// (0.3.10/0.3.11 shipped `segments: []` for audio / short sources), where
+// mapping the envelope alone would silently store the LLM summary as the
+// "transcript" — never let a summary pose as the spoken words.
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -50,7 +51,11 @@ function toSeconds(v: unknown): number | undefined {
 
 /** Build a transcript + speaker-tagged segments[] from tinycloud segments.
  *  SPEECH fields only — a segment's `summary`/`description` is scene prose,
- *  not spoken words; the caller decides (and marks) any summary fallback. */
+ *  not spoken words; the caller decides (and marks) any summary fallback.
+ *  tinycloud ≥ 0.3.12 ships verbatim cues as `speech: string[]` per segment;
+ *  a cue touching a segment boundary lands in BOTH neighbors, so a line
+ *  identical to the one just emitted is dropped. Older envelopes inlined a
+ *  single transcript/speech/text string per segment. */
 function segments(data: Record<string, unknown>): {
   transcript: string;
   segments: Array<Record<string, unknown>>;
@@ -58,16 +63,26 @@ function segments(data: Record<string, unknown>): {
   const raw = Array.isArray(data.segments) ? data.segments : [];
   const out: Array<Record<string, unknown>> = [];
   const lines: string[] = [];
+  let lastText = "";
   for (const s of raw) {
     if (!s || typeof s !== "object") continue;
     const seg = s as Record<string, unknown>;
-    const text =
-      (seg.transcript as string) ?? (seg.speech as string) ?? (seg.text as string) ?? "";
+    const cues = Array.isArray(seg.speech)
+      ? seg.speech.filter((l): l is string => typeof l === "string" && l.trim() !== "")
+      : [];
+    const legacy =
+      (typeof seg.transcript === "string" && seg.transcript) ||
+      (typeof seg.speech === "string" && seg.speech) ||
+      (typeof seg.text === "string" && seg.text) ||
+      "";
+    const texts = cues.length > 0 ? cues : legacy ? [legacy] : [];
     // tolerate numeric-string timestamps from external APIs ("12.5").
     const start = toSeconds(seg.start_time ?? seg.start_seconds ?? seg.start);
     const end = toSeconds(seg.end_time ?? seg.end_seconds ?? seg.end);
     const speaker = seg.speaker;
-    if (text) {
+    for (const text of texts) {
+      if (text === lastText) continue; // boundary cue repeated in the next segment
+      lastText = text;
       const entry: Record<string, unknown> = { speaker, text };
       // only attach a numeric [start,end] anchor when both endpoints are real
       // numbers — never emit [null,null] / [undefined,undefined].
@@ -335,11 +350,14 @@ export async function runListen(
         ? "pending"
         : "ready";
 
-  // Default path: prefer the caption verb's VERBATIM cues over whatever the
-  // watch envelope inlined — tinycloud ≥ 0.3.10 ships segments: [] for audio /
-  // short sources, and older envelopes' segment text is the same speech anyway.
+  // Default path: tinycloud ≥ 0.3.12 (the floor) inlines the VERBATIM cues in
+  // the watch envelope (`segments[].speech`), so a ready envelope with speech
+  // needs no second call. The public `caption` verb still covers two gaps:
+  // --diarize (watch has no diarize flag) and an older tinycloud whose
+  // speech-only envelope shipped segments: [] (0.3.10/0.3.11).
   // Best-effort: a caption failure keeps the envelope mapping.
-  if (isDefault && state === "ready") {
+  let warning: string | undefined;
+  if (isDefault && state === "ready" && (opts.diarize || !transcript)) {
     const cap = await captionTranscript(input, {
       diarize: opts.diarize,
       env: opts.env,
@@ -350,6 +368,9 @@ export async function runListen(
       transcript = cap.transcript;
       segs = cap.segments;
       transcriptSource = "caption";
+    } else if (opts.diarize && transcript) {
+      warning =
+        "diarization was unavailable (the caption pass failed) — `transcript` is the undiarized verbatim speech from the watch envelope.";
     }
   }
 
@@ -358,7 +379,6 @@ export async function runListen(
   // READY records only: a pending async envelope hasn't run the caption pass
   // yet, so copying its summary into `transcript` now would ship the exact
   // summary-as-speech confusion this file exists to prevent.
-  let warning: string | undefined;
   if (!transcript && state === "ready") {
     if (typeof data.transcript === "string" && data.transcript) {
       transcript = data.transcript;

--- a/src/providers/tinycloud/listen.ts
+++ b/src/providers/tinycloud/listen.ts
@@ -16,7 +16,7 @@ import { join } from "node:path";
 import { makeRecord, type OvercastRecord } from "../../record.js";
 import { redactSecrets } from "../../env.js";
 import { execCapture, renderCommand, parseFirstJson } from "../exec.js";
-import { tinycloudBase } from "./envelope.js";
+import { segmentSpeechCues, tinycloudBase } from "./envelope.js";
 
 const DEFAULT_RUN = "tinycloud watch {{input}} --speech-only --json";
 
@@ -52,10 +52,8 @@ function toSeconds(v: unknown): number | undefined {
 /** Build a transcript + speaker-tagged segments[] from tinycloud segments.
  *  SPEECH fields only — a segment's `summary`/`description` is scene prose,
  *  not spoken words; the caller decides (and marks) any summary fallback.
- *  tinycloud ≥ 0.3.12 ships verbatim cues as `speech: string[]` per segment;
- *  a cue touching a segment boundary lands in BOTH neighbors, so a line
- *  identical to the one just emitted is dropped. Older envelopes inlined a
- *  single transcript/speech/text string per segment. */
+ *  Cue extraction + boundary dedupe live in the shared `segmentSpeechCues`
+ *  (envelope.ts), the same seam `watch` renders through. */
 function segments(data: Record<string, unknown>): {
   transcript: string;
   segments: Array<Record<string, unknown>>;
@@ -63,26 +61,17 @@ function segments(data: Record<string, unknown>): {
   const raw = Array.isArray(data.segments) ? data.segments : [];
   const out: Array<Record<string, unknown>> = [];
   const lines: string[] = [];
-  let lastText = "";
+  let prev: ReadonlySet<string> = new Set<string>();
   for (const s of raw) {
     if (!s || typeof s !== "object") continue;
     const seg = s as Record<string, unknown>;
-    const cues = Array.isArray(seg.speech)
-      ? seg.speech.filter((l): l is string => typeof l === "string" && l.trim() !== "")
-      : [];
-    const legacy =
-      (typeof seg.transcript === "string" && seg.transcript) ||
-      (typeof seg.speech === "string" && seg.speech) ||
-      (typeof seg.text === "string" && seg.text) ||
-      "";
-    const texts = cues.length > 0 ? cues : legacy ? [legacy] : [];
+    const { fresh, cues } = segmentSpeechCues(seg, prev);
+    prev = cues;
     // tolerate numeric-string timestamps from external APIs ("12.5").
     const start = toSeconds(seg.start_time ?? seg.start_seconds ?? seg.start);
     const end = toSeconds(seg.end_time ?? seg.end_seconds ?? seg.end);
     const speaker = seg.speaker;
-    for (const text of texts) {
-      if (text === lastText) continue; // boundary cue repeated in the next segment
-      lastText = text;
+    for (const text of fresh) {
       const entry: Record<string, unknown> = { speaker, text };
       // only attach a numeric [start,end] anchor when both endpoints are real
       // numbers — never emit [null,null] / [undefined,undefined].

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -26,22 +26,34 @@ function envelopeData(parsed: unknown): Record<string, unknown> {
   return {};
 }
 
-/** Render a transcript string from tinycloud segments[], when present. */
+/** Render a transcript string from tinycloud segments[], when present.
+ *  tinycloud ≥ 0.3.12 ships verbatim speech as `speech: string[]` per segment;
+ *  a cue touching a segment boundary lands in BOTH neighboring segments, so
+ *  lines already emitted for the previous segment are dropped. Older envelopes
+ *  inlined a single transcript/speech/text string per segment. */
 function transcriptFromSegments(data: Record<string, unknown>): string {
   const segs = data.segments;
   if (!Array.isArray(segs)) return "";
   const lines: string[] = [];
+  let prev = new Set<string>();
   for (const s of segs) {
     if (!s || typeof s !== "object") continue;
     const seg = s as Record<string, unknown>;
-    const t =
-      (seg.transcript as string) ??
-      (seg.speech as string) ??
-      (seg.text as string) ??
+    const cues = Array.isArray(seg.speech)
+      ? seg.speech.filter((l): l is string => typeof l === "string" && l.trim() !== "")
+      : [];
+    const legacy =
+      (typeof seg.transcript === "string" && seg.transcript) ||
+      (typeof seg.speech === "string" && seg.speech) ||
+      (typeof seg.text === "string" && seg.text) ||
       "";
-    if (!t) continue;
-    const start = seg.start_seconds ?? seg.start ?? "";
-    lines.push(start !== "" ? `[${start}] ${t}` : String(t));
+    const texts = cues.length > 0 ? cues : legacy ? [legacy] : [];
+    const fresh = texts.filter((t) => !prev.has(t));
+    prev = new Set(texts);
+    if (fresh.length === 0) continue;
+    const t = fresh.join(" ");
+    const start = seg.start_time ?? seg.start_seconds ?? seg.start ?? "";
+    lines.push(start !== "" ? `[${start}] ${t}` : t);
   }
   return lines.join("\n");
 }

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -11,7 +11,7 @@ import {
   renderCommand,
   parseFirstJson,
 } from "../exec.js";
-import { tinycloudBase } from "./envelope.js";
+import { segmentSpeechCues, tinycloudBase } from "./envelope.js";
 import type { ProviderDescriptor } from "../../profile.js";
 
 const DEFAULT_RUN = "tinycloud watch {{input}} --json";
@@ -27,29 +27,18 @@ function envelopeData(parsed: unknown): Record<string, unknown> {
 }
 
 /** Render a transcript string from tinycloud segments[], when present.
- *  tinycloud ≥ 0.3.12 ships verbatim speech as `speech: string[]` per segment;
- *  a cue touching a segment boundary lands in BOTH neighboring segments, so
- *  lines already emitted for the previous segment are dropped. Older envelopes
- *  inlined a single transcript/speech/text string per segment. */
+ *  Cue extraction + boundary dedupe live in the shared `segmentSpeechCues`
+ *  (envelope.ts), the same seam `listen` maps through. */
 function transcriptFromSegments(data: Record<string, unknown>): string {
   const segs = data.segments;
   if (!Array.isArray(segs)) return "";
   const lines: string[] = [];
-  let prev = new Set<string>();
+  let prev: ReadonlySet<string> = new Set<string>();
   for (const s of segs) {
     if (!s || typeof s !== "object") continue;
     const seg = s as Record<string, unknown>;
-    const cues = Array.isArray(seg.speech)
-      ? seg.speech.filter((l): l is string => typeof l === "string" && l.trim() !== "")
-      : [];
-    const legacy =
-      (typeof seg.transcript === "string" && seg.transcript) ||
-      (typeof seg.speech === "string" && seg.speech) ||
-      (typeof seg.text === "string" && seg.text) ||
-      "";
-    const texts = cues.length > 0 ? cues : legacy ? [legacy] : [];
-    const fresh = texts.filter((t) => !prev.has(t));
-    prev = new Set(texts);
+    const { fresh, cues } = segmentSpeechCues(seg, prev);
+    prev = cues;
     if (fresh.length === 0) continue;
     const t = fresh.join(" ");
     const start = seg.start_time ?? seg.start_seconds ?? seg.start ?? "";

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -255,8 +255,8 @@ overcast index entities <entity-index-id> ./clip.mp4 --json
 \`\`\`
 
 \`face\` needs tinycloud ≥ 0.3.4 (\`overcast doctor\` flags an older install);
-overcast currently recommends tinycloud 0.3.8 for the latest face validation,
-CLI reliability, and image \`see\`/\`extract\` behavior. Face detection counts are boxes per sampled frame, not
+overcast's floor is tinycloud 0.3.12, which also carries the latest face
+validation, CLI reliability, and image \`see\`/\`extract\` behavior. Face detection counts are boxes per sampled frame, not
 unique people; use \`--match <photo>\` for a specific person and \`crop\` when
 you need durable cropped image evidence. If a local video lacks descriptive
 content evidence, add it to the index with \`overcast index add ./clip.mp4 --to
@@ -448,11 +448,13 @@ One-time setup for overcast.
    (\`~/.claude/skills\`), and \`--harness claude-code\` is the explicit Claude
    target.
 3. **Install/update tinycloud** — the default perception backend. Get the latest
-   (\`npm i -g @cloudglue/tinycloud@0.3.8\` then \`tinycloud install --latest\`, or
-   \`tinycloud update\`). The \`face\` + \`index\` verbs need **tinycloud ≥ 0.3.4**,
-   and overcast currently recommends **0.3.8** (the image \`see\`/\`extract\`
-   verbs behind the opt-in \`see:tinycloud\` provider need ≥ 0.3.7);
-   override the invocation with \`OVERCAST_TINYCLOUD_CMD\` if it isn't on \`PATH\`.
+   (\`npm i -g @cloudglue/tinycloud@0.3.12\` then \`tinycloud install --latest\`, or
+   \`tinycloud update\`). overcast needs **tinycloud ≥ 0.3.12** — its watch
+   envelope inlines the verbatim \`watch\`/\`listen\` transcripts
+   (\`watch.speech.v1\`); the \`face\` + \`index\` verbs need ≥ 0.3.4, and the image
+   \`see\`/\`extract\` verbs behind the opt-in \`see:tinycloud\` provider need
+   ≥ 0.3.7. Override the invocation with \`OVERCAST_TINYCLOUD_CMD\` if it isn't
+   on \`PATH\`.
 4. **Verify** — \`overcast doctor --json\` (pi pinned, ffmpeg/ffprobe runnable,
    Cloudglue key, tinycloud CLI + version, optional uv/visual-db readiness).
 5. **Cloudglue key** — the default \`watch\`/\`listen\`/\`face\`/\`index\` providers

--- a/src/verbs/setup.ts
+++ b/src/verbs/setup.ts
@@ -73,11 +73,14 @@ function nodeProbeExecutable(): string {
   return exe === "node" || exe === "node.exe" ? process.execPath : "node";
 }
 
-/** Minimum tinycloud the face + index verbs need (`face match` landed in
- *  0.3.4). Older installs run watch/listen fine but lack face/index support. */
-export const MIN_TINYCLOUD = "0.3.4";
+/** Minimum tinycloud this overcast build supports: 0.3.12 restored inline
+ *  verbatim speech in the watch envelope (`segments[].speech`, feature
+ *  `watch.speech.v1`), which the single-call watch/listen transcript path maps
+ *  directly. Older installs (≥ 0.3.10) still work through the caption-verb
+ *  fallback but are flagged by doctor; face/index need ≥ 0.3.4. */
+export const MIN_TINYCLOUD = "0.3.12";
 /** Latest tinycloud version this overcast build documents and recommends. */
-export const RECOMMENDED_TINYCLOUD = "0.3.8";
+export const RECOMMENDED_TINYCLOUD = "0.3.12";
 
 function parseSemver(s: string): [number, number, number] | undefined {
   const m = s.match(/(\d+)\.(\d+)\.(\d+)/);
@@ -529,7 +532,7 @@ export const doctorVerb: VerbSpec = {
 
     // tinycloud CLI (default sense backend). Honor OVERCAST_TINYCLOUD_CMD so a
     // custom path/wrapper is the one actually checked. Parse the version to flag
-    // installs older than the face/index minimum and recommend the latest
+    // installs older than the supported floor and recommend the latest
     // documented tinycloud build when an older-but-compatible CLI is present.
     const [tcCmd, ...tcLead] = tinycloudBase();
     const tc = await execCapture(tcCmd, [...tcLead, "--version"], { timeoutMs: 15_000 }).catch(() => ({ code: 1, stdout: "", stderr: "" }));
@@ -543,7 +546,7 @@ export const doctorVerb: VerbSpec = {
         tc.code !== 0
           ? `tinycloud CLI not on PATH (install latest: \`npm i -g @cloudglue/tinycloud@${RECOMMENDED_TINYCLOUD}\` or \`tinycloud install --latest\`)`
           : tcVer
-            ? `${tcVer.join(".")}${tcOld ? ` (face/index verbs need ≥ ${MIN_TINYCLOUD} — run \`tinycloud update\`)` : tcBehind ? ` (update recommended: latest tested ${RECOMMENDED_TINYCLOUD}; run \`tinycloud update\`)` : ""}`
+            ? `${tcVer.join(".")}${tcOld ? ` (overcast needs ≥ ${MIN_TINYCLOUD} for inline watch/listen transcripts — run \`tinycloud update\`)` : tcBehind ? ` (update recommended: latest tested ${RECOMMENDED_TINYCLOUD}; run \`tinycloud update\`)` : ""}`
             : "CLI available",
     });
 
@@ -828,7 +831,7 @@ export const doctorVerb: VerbSpec = {
       );
     }
     if (tcOld) {
-      warnings.push(`tinycloud is older than ${MIN_TINYCLOUD} — the face + index verbs need ≥ ${MIN_TINYCLOUD} (run \`tinycloud update\`)`);
+      warnings.push(`tinycloud is older than ${MIN_TINYCLOUD} — watch/listen need ≥ ${MIN_TINYCLOUD} for inline verbatim transcripts (\`watch.speech.v1\`), face/index need ≥ 0.3.4 (run \`tinycloud update\`)`);
     } else if (tcBehind) {
       warnings.push(`tinycloud ${tcVer?.join(".")} is older than the recommended ${RECOMMENDED_TINYCLOUD} — run \`tinycloud update\` to pick up the latest face validation and reliability behavior`);
     }

--- a/test/e2e/cases/phase2_listen_speech.sh
+++ b/test/e2e/cases/phase2_listen_speech.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Phase 2 e2e (offline): the DEFAULT listen path against a fake tinycloud —
-# regression coverage for tinycloud ≥ 0.3.10, whose `watch --speech-only`
-# envelope stopped inlining speech (data.segments: [] for audio/short sources).
-# listen must (a) pull the VERBATIM words through the public `caption` verb,
-# (b) never silently store the watch SUMMARY as the transcript, and (c) never
-# push --diarize/--lang onto `watch` (the real CLI rejects both with exit 1).
-# Fixture: test/fixtures/fake-tinycloud-speech.sh (watch → summary-only
+# tinycloud ≥ 0.3.12 (the floor) inlines VERBATIM speech in the watch envelope
+# (segments[].speech), so listen maps it in ONE call. listen must (a) store the
+# verbatim words, deduping the boundary cue the CLI repeats across segments,
+# (b) never silently store the watch SUMMARY as the transcript, (c) never push
+# --diarize/--lang onto `watch` (the real CLI rejects both with exit 1), and
+# (d) keep the legacy caption-verb fallback working for a pre-0.3.12 envelope
+# (segments: []). Fixture: test/fixtures/fake-tinycloud-speech.sh
+# (watch → 0.3.12 speech envelope, FAKE_TC_WATCH=nospeech → 0.3.10 summary-only
 # envelope, caption → verbatim cues, FAKE_TC_CAPTION=fail → caption outage).
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,11 +30,13 @@ if [ ! -f "$wav" ]; then
   return 0 2>/dev/null || exit 0
 fi
 
-# 1) default listen: transcript = caption's verbatim cues, NOT the watch summary
+# 1) default listen (0.3.12 envelope): transcript = the inline verbatim speech,
+# single call — transcript_source=caption here means the two-call workaround
+# came back
 out="$(OVERCAST_TINYCLOUD_CMD="$FAKE_TC" $OVERCAST listen "$wav" --json --case "$casedir" 2>/dev/null)"
 save_json "phase2_listen_speech" "$out" >/dev/null
 assert_eq "listen_speech.state" "ready" "$(jq -r '.state // "ready"' <<<"$out")" "default listen ready"
-assert_eq "listen_speech.source" "caption" "$(jq -r '.meta.transcript_source' <<<"$out")" "transcript came from caption cues"
+assert_eq "listen_speech.source" "segments" "$(jq -r '.meta.transcript_source' <<<"$out")" "transcript came from the inline watch speech"
 tr_text="$(jq -r '.payload.transcript' <<<"$out")"
 case "$tr_text" in
   *"We'll walk through the streets"*) ok "listen_speech.verbatim" "transcript holds the verbatim speech" ;;
@@ -42,7 +46,8 @@ case "$tr_text" in
   *"visitor describes"*) fail "listen_speech.no_summary" "the watch SUMMARY leaked into the transcript: $tr_text" ;;
   *) ok "listen_speech.no_summary" "watch summary did not pose as the transcript" ;;
 esac
-assert_eq "listen_speech.segments" "2" "$(jq -r '.payload.segments|length' <<<"$out")" "cue-anchored segments"
+# the boundary cue repeated in the next segment's speech[] is stored once
+assert_eq "listen_speech.segments" "2" "$(jq -r '.payload.segments|length' <<<"$out")" "cue-anchored segments (boundary repeat deduped)"
 assert_eq "listen_speech.anchor" "[0,1.2]" "$(jq -c '.payload.segments[0].at' <<<"$out")" "segment carries [start,end]"
 
 # 2) --diarize rides the caption pass (watch REJECTS --diarize — the fixture
@@ -52,8 +57,20 @@ save_json "phase2_listen_speech_diarize" "$dout" >/dev/null
 assert_eq "listen_speech.diarize_state" "ready" "$(jq -r '.state // "ready"' <<<"$dout")" "--diarize did not hit watch (ready)"
 assert_eq "listen_speech.diarize_speaker" "1" "$(jq -r '.payload.segments[0].speaker' <<<"$dout")" "speaker label lifted from diarized cues"
 
-# 3) caption outage: the summary may stand in ONLY with an explicit marker
-fout="$(FAKE_TC_CAPTION=fail OVERCAST_TINYCLOUD_CMD="$FAKE_TC" $OVERCAST listen "$wav" --json --case "$casedir" 2>/dev/null)"
+# 3) legacy pre-0.3.12 envelope (segments: []): the caption verb still supplies
+# the verbatim cues
+lout="$(FAKE_TC_WATCH=nospeech OVERCAST_TINYCLOUD_CMD="$FAKE_TC" $OVERCAST listen "$wav" --json --case "$casedir" 2>/dev/null)"
+save_json "phase2_listen_speech_legacy" "$lout" >/dev/null
+assert_eq "listen_speech.legacy_state" "ready" "$(jq -r '.state // "ready"' <<<"$lout")" "legacy envelope still yields a ready record"
+assert_eq "listen_speech.legacy_source" "caption" "$(jq -r '.meta.transcript_source' <<<"$lout")" "legacy fallback pulled the caption cues"
+case "$(jq -r '.payload.transcript' <<<"$lout")" in
+  *"We'll walk through the streets"*) ok "listen_speech.legacy_verbatim" "legacy fallback transcript is verbatim" ;;
+  *) fail "listen_speech.legacy_verbatim" "legacy fallback transcript missing verbatim cues" ;;
+esac
+
+# 4) caption outage on a legacy envelope: the summary may stand in ONLY with an
+# explicit marker
+fout="$(FAKE_TC_WATCH=nospeech FAKE_TC_CAPTION=fail OVERCAST_TINYCLOUD_CMD="$FAKE_TC" $OVERCAST listen "$wav" --json --case "$casedir" 2>/dev/null)"
 save_json "phase2_listen_speech_fallback" "$fout" >/dev/null
 assert_eq "listen_speech.fallback_state" "ready" "$(jq -r '.state // "ready"' <<<"$fout")" "caption outage still yields a ready record"
 assert_eq "listen_speech.fallback_source" "summary" "$(jq -r '.meta.transcript_source' <<<"$fout")" "summary fallback is marked transcript_source=summary"

--- a/test/e2e/cases/phase2_listenlive.sh
+++ b/test/e2e/cases/phase2_listenlive.sh
@@ -31,12 +31,20 @@ out="$($OVERCAST listen "$clip" --json --case "$casedir" 2>"$SMOKE_DIR/phase2_li
 save_json "phase2_listenlive" "$out" >/dev/null
 assert_eq "listenlive.verb" "listen" "$(jq -r .verb <<<"$out")" "listen verb"
 assert_eq "listenlive.state" "ready" "$(jq -r '.state // "ready"' <<<"$out")" "listen ready (real Cloudglue)"
-# Regression (tinycloud ≥0.3.10): the transcript must be the verbatim caption
-# cues / inline speech segments — never the watch SUMMARY (which the mapper
-# marks transcript_source=summary + payload.warning when it has nothing else).
+# The transcript must exist and be the verbatim speech — tinycloud ≥ 0.3.12
+# (the floor) inlines it in the watch envelope (transcript_source=segments,
+# single call); "caption" = the legacy pre-0.3.12 fallback still ran. Never the
+# watch SUMMARY (which the mapper marks transcript_source=summary +
+# payload.warning when it has nothing else).
+tlen="$(jq -r '.payload.transcript | length' <<<"$out")"
+[ "${tlen:-0}" -gt 0 ] \
+  && ok "listenlive.transcript" "transcript non-empty (len $tlen)" \
+  || fail "listenlive.transcript" "empty transcript from a real speech clip"
 src="$(jq -r '.meta.transcript_source // empty' <<<"$out")"
-if [ "$src" = "caption" ] || [ "$src" = "segments" ]; then
-  ok "listenlive.verbatim" "transcript is verbatim speech (transcript_source=$src)"
+if [ "$src" = "segments" ]; then
+  ok "listenlive.verbatim" "transcript is the inline watch speech (transcript_source=segments)"
+elif [ "$src" = "caption" ]; then
+  fail "listenlive.verbatim" "transcript_source=caption — the tinycloud on PATH is pre-0.3.12 (envelope shipped no inline speech); install the floor version"
 else
   fail "listenlive.verbatim" "transcript_source='$src' — summary/none posing as the transcript"
 fi

--- a/test/e2e/live/cases/10_watch.sh
+++ b/test/e2e/live/cases/10_watch.sh
@@ -20,3 +20,20 @@ assert_eq "$C.provider" "tinycloud" "$(echo "$out" | jq -r '.meta.provider')" "m
 cond "the watch record is persisted to the case store and is queryable"
 recs="$(oc "$CASE" case records --verb watch --json | jq '.payload.count')"
 assert_eq "$C.persisted" "1" "$recs" "one watch record persisted"
+
+# tinycloud ≥ 0.3.12 (the floor) inlines verbatim speech in the watch envelope
+# (segments[].speech) — a watch over a SPEECH clip must populate
+# payload.transcript from the envelope alone, no caption second call.
+if have_media "$VIDEO_SPEECH_SRC"; then
+  SPEECH_CLIP="$SMOKE_DIR/watch_speech20.mp4"; clip_av 20 "$VIDEO_SPEECH_SRC" "$SPEECH_CLIP"
+  CASE2=$(case_dir watch_speech)
+  cond "watch on a speech clip inlines the verbatim transcript (tinycloud ≥ 0.3.12)"
+  sout="$(OC_TIMEOUT=300 oc "$CASE2" watch "$SPEECH_CLIP" --json)"
+  assert_eq "$C.speech.state" "ready" "$(echo "$sout" | jq -r '.state')" "speech watch ready"
+  stlen="$(echo "$sout" | jq -r '.payload.transcript | length')"
+  [ "${stlen:-0}" -gt 0 ] \
+    && ok "$C.speech.transcript" "watch transcript non-empty from the envelope (len $stlen)" \
+    || fail "$C.speech.transcript" "empty watch transcript on a speech clip — inline segments[].speech missing (pre-0.3.12 tinycloud on PATH?)"
+else
+  skip "$C.speech" "no OC_VIDEO_SPEECH — watch transcript check skipped"
+fi

--- a/test/e2e/live/cases/11_listen.sh
+++ b/test/e2e/live/cases/11_listen.sh
@@ -20,16 +20,19 @@ if require_cred "$C.cloudglue" CLOUDGLUE_API_KEY "skipping"; then
   assert_eq "$C.cg.verb" "listen" "$(echo "$out" | jq -r '.verb')" "record.verb is listen"
   assert_eq "$C.cg.state" "ready" "$(echo "$out" | jq -r '.state')" "state is ready"
   assert_eq "$C.cg.segments_array" "array" "$(echo "$out" | jq -r '.payload.segments|type')" "payload.segments is an array"
-  echo "$out" | jq -e 'has("payload") and (.payload|has("transcript"))' >/dev/null 2>&1 \
-    && ok "$C.cg.transcript_field" "transcript field present (len $(echo "$out"|jq -r '.payload.transcript|length'))" \
-    || fail "$C.cg.transcript_field" "no transcript field"
-  # Regression (tinycloud ≥0.3.10): `watch --speech-only` stopped inlining
-  # speech segments, and listen silently stored the LLM SUMMARY as the
-  # transcript. The transcript must come from the verbatim caption cues —
-  # a marked summary fallback here means the speech path is broken again.
+  tlen="$(echo "$out" | jq -r '.payload.transcript | length')"
+  [ "${tlen:-0}" -gt 0 ] \
+    && ok "$C.cg.transcript_field" "transcript present and non-empty (len $tlen)" \
+    || fail "$C.cg.transcript_field" "empty/missing transcript from a real speech clip"
+  # tinycloud ≥ 0.3.12 (the floor) inlines the verbatim speech in the watch
+  # envelope — listen maps it in ONE call (transcript_source=segments).
+  # "caption" = the legacy pre-0.3.12 two-call fallback ran (old CLI on PATH);
+  # a marked summary fallback means the speech path is broken again.
   src="$(echo "$out" | jq -r '.meta.transcript_source // empty')"
-  if [ "$src" = "caption" ] || [ "$src" = "segments" ]; then
-    ok "$C.cg.verbatim" "transcript is verbatim speech (transcript_source=$src)"
+  if [ "$src" = "segments" ]; then
+    ok "$C.cg.verbatim" "transcript is the inline watch speech (transcript_source=segments)"
+  elif [ "$src" = "caption" ]; then
+    fail "$C.cg.verbatim" "transcript_source=caption — the tinycloud on PATH is pre-0.3.12 (envelope shipped no inline speech); install the floor version"
   else
     fail "$C.cg.verbatim" "transcript_source='$src' — summary/none posing as the transcript"
   fi

--- a/test/fixtures/fake-tinycloud-speech.sh
+++ b/test/fixtures/fake-tinycloud-speech.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 # Fixture tinycloud for the listen DEFAULT path (bound via OVERCAST_TINYCLOUD_CMD):
-# `watch` answers with a tinycloud ≥0.3.10-shaped envelope — summary only, NO
-# inline speech segments — and `caption` answers with the verbatim cues, so the
-# two-step watch→caption transcript wiring is exercised offline.
-#   FAKE_TC_CAPTION=fail  → caption exits non-zero (tests the summary fallback path)
-#   FAKE_TC_CAPTION=hang  → caption blocks (tests that an abort REJECTS, never a summary)
-#   FAKE_TC_WATCH=pending → watch answers a pending async envelope (with a summary)
+# `watch` answers a tinycloud ≥0.3.12-shaped envelope — VERBATIM speech inlined
+# as segments[].speech (string arrays; a boundary cue repeats in the next
+# segment, like the real CLI) — so the single-call watch transcript wiring is
+# exercised offline. `caption` answers the verbatim cues for the --diarize pass
+# and the legacy (<0.3.12) fallback.
+#   FAKE_TC_WATCH=nospeech → watch answers a 0.3.10/0.3.11-shaped envelope
+#                            (summary only, segments: []) — tests the legacy
+#                            caption-verb fallback path
+#   FAKE_TC_WATCH=pending  → watch answers a pending async envelope (with a summary)
+#   FAKE_TC_CAPTION=fail   → caption exits non-zero (tests the summary fallback path)
+#   FAKE_TC_CAPTION=hang   → caption blocks (tests that an abort REJECTS, never a summary)
 #   FAKE_TC_DIARIZED=off    → caption honors --diarize but answers diarized:false
 #                             with "Word: …"-shaped SPEECH (diarization unavailable —
 #                             tests that no phantom speaker is lifted)
@@ -16,7 +21,7 @@ set -euo pipefail
 sub="${1:-}"
 case "$sub" in
   watch)
-    # strict like the real CLI (0.3.10): watch takes neither --diarize nor
+    # strict like the real CLI (0.3.12): watch takes neither --diarize nor
     # --lang — regressing to pushing listen flags onto watch must fail loudly.
     for a in "$@"; do
       case "$a" in
@@ -29,8 +34,22 @@ case "$sub" in
 JSON
       exit 0
     fi
-    cat <<'JSON'
+    if [ "${FAKE_TC_WATCH:-}" = "nospeech" ]; then
+      # 0.3.10/0.3.11: watch stopped inlining speech (segments: [] for audio /
+      # short sources) — listen must fall back to the caption verb.
+      cat <<'JSON'
 {"tinycloud":"1","kind":"watch","status":"ready","data":{"title":"Zurich walk","summary":"A visitor describes exploring Zurich for the first time.","duration_seconds":5,"segmentation":null,"segments":[]}}
+JSON
+      exit 0
+    fi
+    # 0.3.12 (watch.speech.v1): verbatim cues ride segments[].speech; a cue
+    # touching the segment boundary is repeated in the NEXT segment's array —
+    # the mapper must dedupe it, never store it twice.
+    cat <<'JSON'
+{"tinycloud":"1","kind":"watch","status":"ready","data":{"title":"Zurich walk","summary":"A visitor describes exploring Zurich for the first time.","duration_seconds":5,"segmentation":"uniform:20","segments":[
+  {"index":1,"start_time":0,"end_time":1.2,"description":"We'll walk through the streets","summary":null,"thumbnail_url":null,"speech":["We'll walk through the streets"]},
+  {"index":2,"start_time":1.2,"end_time":2.5,"description":"of Zurich.","summary":null,"thumbnail_url":null,"speech":["We'll walk through the streets","of Zurich."]}
+]}}
 JSON
     ;;
   caption)

--- a/test/unit/face-index.test.ts
+++ b/test/unit/face-index.test.ts
@@ -40,7 +40,7 @@ import { faceVerb } from "../../src/verbs/face.ts";
 import { imageVerb } from "../../src/verbs/image.ts";
 import { indexVerb } from "../../src/verbs/index.ts";
 import { askVerb, briefVerb } from "../../src/verbs/read.ts";
-import { doctorVerb, RECOMMENDED_TINYCLOUD } from "../../src/verbs/setup.ts";
+import { doctorVerb, MIN_TINYCLOUD } from "../../src/verbs/setup.ts";
 import { caseVerb } from "../../src/verbs/case.ts";
 import { pageCommand } from "../../src/render.ts";
 
@@ -1215,14 +1215,16 @@ test("doctor warns about missing tinycloud even when watch/listen are custom-bou
   }
 });
 
-test("doctor warns when tinycloud is below the recommended version", async () => {
+test("doctor warns when tinycloud is below the supported floor", async () => {
   const cdir = mkdtempSync(join(tmpdir(), "oc-doctor-tcver-"));
   try {
     const c = openCase(cdir); c.ensure();
+    // the fixture reports 0.3.4 — below the 0.3.12 floor (inline watch/listen
+    // transcripts), so doctor must flag it with the update hint
     const [rec] = await doctorVerb.run({ input: undefined, rest: [], opts: {}, case: c, profile: defaultProfile(), home: cdir });
     const warnings = (rec.payload as Record<string, unknown>).warnings as string[];
     assert.equal(rec.state, "error");
-    assert.ok(warnings.some((w) => w.includes(`recommended ${RECOMMENDED_TINYCLOUD}`) && /tinycloud update/.test(w)), `expected a tinycloud update warning; got ${JSON.stringify(warnings)}`);
+    assert.ok(warnings.some((w) => w.includes(`older than ${MIN_TINYCLOUD}`) && /tinycloud update/.test(w)), `expected a tinycloud update warning; got ${JSON.stringify(warnings)}`);
   } finally {
     rmSync(cdir, { recursive: true, force: true });
   }

--- a/test/unit/senses.test.ts
+++ b/test/unit/senses.test.ts
@@ -217,6 +217,39 @@ test("listen: an abort during the caption pass REJECTS — never a ready summary
   );
 });
 
+test("listen boundary dedupe is per-adjacent-segment: repeats after a gap survive, multi-cue overlaps drop once", async () => {
+  // seg2 repeats BOTH of seg1's straddling cues (dropped once each); seg3 is
+  // speechless (clears the dedupe state); seg4 legitimately repeats seg1's
+  // first utterance and must survive — the global-lastText regression dropped it.
+  const dir = mkdtempSync(join(tmpdir(), "oc-listengap-"));
+  try {
+    const json = JSON.stringify({
+      status: "ready",
+      data: {
+        summary: "sum",
+        segments: [
+          { index: 1, start_time: 0, end_time: 10, speech: ["Yeah.", "Can I ask you something?"] },
+          { index: 2, start_time: 10, end_time: 20, speech: ["Yeah.", "Can I ask you something?", "Sure."] },
+          { index: 3, start_time: 20, end_time: 30, speech: [] },
+          { index: 4, start_time: 30, end_time: 40, speech: ["Yeah."] },
+        ],
+      },
+    });
+    const script = join(dir, "listen.sh");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+    const rec = await runListen("talk.wav", { run: `bash ${script} {{input}}` });
+    assert.equal(rec.state, "ready");
+    const p = rec.payload as Record<string, unknown>;
+    const texts = (p.segments as Array<Record<string, unknown>>).map((s) => s.text);
+    assert.deepEqual(texts, ["Yeah.", "Can I ask you something?", "Sure.", "Yeah."]);
+    assert.equal(p.transcript, "Yeah.\nCan I ask you something?\nSure.\nYeah.");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("runListen maps a speech envelope to audio.analysis (via fixture provider)", async () => {
   chmodSync(FAKE_LISTEN, 0o755);
   const rec = await runListen("call.m4a", { run: `bash ${FAKE_LISTEN} {{input}}` });

--- a/test/unit/senses.test.ts
+++ b/test/unit/senses.test.ts
@@ -60,19 +60,42 @@ async function withFakeTinycloud(fn: () => Promise<void>, extraEnv: Record<strin
   }
 }
 
-test("listen default path takes the VERBATIM caption cues, not the watch summary", async () => {
+test("listen default path maps the VERBATIM inline watch speech (single call, ≥0.3.12)", async () => {
   await withFakeTinycloud(async () => {
     const rec = await runListen("talk.wav");
     assert.equal(rec.state, "ready");
     const p = rec.payload as Record<string, unknown>;
     assert.match(p.transcript as string, /We'll walk through the streets/);
+    assert.match(p.transcript as string, /of Zurich\./);
     assert.ok(!(p.transcript as string).includes("visitor describes"), "summary leaked into transcript");
     const segs = p.segments as Array<Record<string, unknown>>;
+    // the boundary cue repeated in the second segment's speech[] is deduped
     assert.equal(segs.length, 2);
     assert.deepEqual(segs[0].at, [0, 1.2]);
-    assert.equal(rec.meta?.transcript_source, "caption");
+    assert.deepEqual(segs[1].at, [1.2, 2.5]);
+    // envelope speech is the source — a "caption" here means the two-call
+    // workaround came back
+    assert.equal(rec.meta?.transcript_source, "segments");
     assert.equal("warning" in p, false);
   });
+});
+
+test("listen falls back to the caption verb on a pre-0.3.12 envelope (segments: [])", async () => {
+  await withFakeTinycloud(
+    async () => {
+      const rec = await runListen("talk.wav");
+      assert.equal(rec.state, "ready");
+      const p = rec.payload as Record<string, unknown>;
+      assert.match(p.transcript as string, /We'll walk through the streets/);
+      assert.ok(!(p.transcript as string).includes("visitor describes"), "summary leaked into transcript");
+      const segs = p.segments as Array<Record<string, unknown>>;
+      assert.equal(segs.length, 2);
+      assert.deepEqual(segs[0].at, [0, 1.2]);
+      assert.equal(rec.meta?.transcript_source, "caption");
+      assert.equal("warning" in p, false);
+    },
+    { FAKE_TC_WATCH: "nospeech" },
+  );
 });
 
 test("listen default path --diarize rides the caption pass and lifts speaker labels", async () => {
@@ -91,12 +114,29 @@ test("listen default path --diarize rides the caption pass and lifts speaker lab
 test("listen falls back to the summary ONLY with an explicit marker + warning", async () => {
   await withFakeTinycloud(
     async () => {
+      // no inline speech (pre-0.3.12 envelope) AND a caption outage — the
+      // summary may stand in only when it is marked as such
       const rec = await runListen("talk.wav");
       assert.equal(rec.state, "ready");
       const p = rec.payload as Record<string, unknown>;
       assert.match(p.transcript as string, /visitor describes exploring Zurich/);
       assert.equal(rec.meta?.transcript_source, "summary");
       assert.match(p.warning as string, /SUMMARY of the audio, not the spoken words/);
+    },
+    { FAKE_TC_WATCH: "nospeech", FAKE_TC_CAPTION: "fail" },
+  );
+});
+
+test("listen --diarize with a caption outage keeps the verbatim envelope speech + warns", async () => {
+  await withFakeTinycloud(
+    async () => {
+      const rec = await runListen("talk.wav", { diarize: true });
+      assert.equal(rec.state, "ready");
+      const p = rec.payload as Record<string, unknown>;
+      // the undiarized inline speech stays — never the summary
+      assert.match(p.transcript as string, /We'll walk through the streets/);
+      assert.equal(rec.meta?.transcript_source, "segments");
+      assert.match(p.warning as string, /diarization was unavailable/);
     },
     { FAKE_TC_CAPTION: "fail" },
   );
@@ -125,7 +165,7 @@ test("listen: a binding pinned to the STOCK template still takes the default pat
     assert.equal(rec.state, "ready");
     const p = rec.payload as Record<string, unknown>;
     assert.match(p.transcript as string, /We'll walk through the streets/);
-    assert.equal(rec.meta?.transcript_source, "caption");
+    assert.equal(rec.meta?.transcript_source, "segments");
   });
 });
 
@@ -167,12 +207,13 @@ test("listen: an abort during the caption pass REJECTS — never a ready summary
   await withFakeTinycloud(
     async () => {
       const ac = new AbortController();
+      // a pre-0.3.12 envelope (no inline speech) forces the caption pass
       const pending = runListen("talk.wav", { signal: ac.signal });
       // watch (instant fixture) finishes first; the abort lands mid-caption.
       setTimeout(() => ac.abort(), 400);
       await assert.rejects(pending);
     },
-    { FAKE_TC_CAPTION: "hang" },
+    { FAKE_TC_WATCH: "nospeech", FAKE_TC_CAPTION: "hang" },
   );
 });
 

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -81,6 +81,33 @@ test("runWatch maps a ≥0.3.12 envelope's inline segments[].speech into transcr
   }
 });
 
+test("runWatch boundary dedupe is per-adjacent-segment: repeats after a gap survive", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchgap-"));
+  try {
+    // mirrors the listen-side case: a speechless segment clears the dedupe
+    // state, so a genuinely repeated utterance later in the video is kept.
+    const json = JSON.stringify({
+      status: "ready",
+      data: {
+        title: "clip",
+        summary: "sum",
+        segments: [
+          { index: 1, start_time: 0, end_time: 10, speech: ["Yeah."] },
+          { index: 2, start_time: 10, end_time: 20, speech: [] },
+          { index: 3, start_time: 20, end_time: 30, speech: ["Yeah."] },
+        ],
+      },
+    });
+    const script = join(dir, "watch.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    assert.equal(String((rec.payload as Record<string, unknown>).transcript), "[0] Yeah.\n[20] Yeah.");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("runWatch fills transcript from tinycloud's speech.vtt sidecar", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-watchvtt-"));
   try {

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -44,6 +44,43 @@ test("runWatch maps a real tinycloud envelope to the loose record (via fixture p
   assert.equal(rec.meta?.title, detailed.title);
 });
 
+test("runWatch maps a ≥0.3.12 envelope's inline segments[].speech into transcript (deduped)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchspeech-"));
+  try {
+    // shaped like a real 0.3.12 capture: verbatim cues ride speech[] per
+    // segment, and a cue touching the segment boundary appears in BOTH
+    // neighboring segments — the transcript must carry it once.
+    const json = JSON.stringify({
+      status: "ready",
+      data: {
+        title: "Podcast clip",
+        summary: "Two men talk in a studio.",
+        duration_seconds: 30,
+        segments: [
+          { index: 1, start_time: 0, end_time: 20, description: "Podcast Interview", summary: "Scene prose.", speech: ["Are there a lot of birth fears?"] },
+          { index: 2, start_time: 20, end_time: 30, description: "Podcast Discussion", summary: "More scene prose.", speech: ["Are there a lot of birth fears?", "Can I ask you something?"] },
+        ],
+      },
+    });
+    const script = join(dir, "watch.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    assert.equal(rec.state, "ready");
+    const p = rec.payload as Record<string, unknown>;
+    const transcript = String(p.transcript);
+    assert.ok(transcript.length > 0, "transcript populated from the watch envelope alone");
+    assert.match(transcript, /\[0\] Are there a lot of birth fears\?/);
+    assert.match(transcript, /\[20\] Can I ask you something\?/);
+    // the boundary-duplicated cue appears exactly once
+    assert.equal(transcript.match(/birth fears/g)?.length, 1);
+    // scene prose never leaks into the transcript
+    assert.ok(!transcript.includes("Scene prose"), "segment summary leaked into transcript");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("runWatch fills transcript from tinycloud's speech.vtt sidecar", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-watchvtt-"));
   try {


### PR DESCRIPTION
## What

tinycloud **0.3.12** (feature `watch.speech.v1`) restored verbatim speech in the watch envelope — `segments[].speech`, now an **array of cue strings** per segment — so the watch→caption two-call listen workaround introduced in #111 is no longer the default path. This PR makes 0.3.12 the supported floor and maps transcripts straight off the envelope.

### CLI

- **listen** — the default path maps the inline envelope speech directly (`transcript_source: "segments"`, ONE tinycloud call). The public `caption` verb remains for exactly two gaps: `--diarize` (watch has no diarize flag) and the fallback for pre-0.3.12 envelopes that ship `segments: []`. A diarize request whose caption pass fails keeps the verbatim envelope speech and stamps a `payload.warning` instead of degrading to the summary; the summary-as-transcript guard (explicit `transcript_source=summary` + warning) is unchanged.
- **watch** — `transcriptFromSegments` handles the `speech[]` arrays and the `start_time` field, and **dedupes the boundary-straddling cue** the real CLI repeats into BOTH neighboring segments (verified against live 0.3.12 envelopes). Full-describe watch records now carry `[start]`-anchored transcripts from the envelope alone — no dependency on the local `speech.vtt` cache sidecar.
- **floor** — `MIN_TINYCLOUD = RECOMMENDED_TINYCLOUD = "0.3.12"`; `doctor`'s below-floor warning names the inline-transcript requirement (face/index still ≥ 0.3.4). Install hints point at `@cloudglue/tinycloud@0.3.12`.

### VS Code extension

No change needed — the extension is a thin client of the CLI (every sense is one `overcast <verb>` spawn) and already renders `payload.transcript`; it inherits the single-call transcript automatically. Swept its code + docs for workaround references: none.

### Tests

- `fake-tinycloud-speech.sh` emits a 0.3.12-shaped envelope by default (boundary-duplicate cue included); `FAKE_TC_WATCH=nospeech` keeps the legacy 0.3.10/0.3.11 path covered.
- Units: single-call mapping (a `caption` source = the workaround came back), boundary dedupe, legacy caption fallback, diarize-outage warning, watch 0.3.12 envelope → non-empty deduped transcript, doctor floor warning.
- Offline e2e: `phase2_listen_speech.sh` reworked around the four paths (0.3.12 single-call / diarize / legacy caption / summary-only-with-marker).
- Live e2e: `10_watch.sh` gains a speech-clip case asserting `payload.transcript` is non-empty from the envelope; `11_listen.sh` + `phase2_listenlive.sh` now REQUIRE non-empty transcript with `transcript_source=segments` (a `caption` result fails loudly as "pre-0.3.12 tinycloud on PATH").

### Docs

README, CLAUDE.md, `docs/providers.md`, `skill-gen.ts` + regenerated `skills/` all state the 0.3.12 floor (skills regen is drift-free).

## Testing

- `npm run typecheck`, **1155 unit**, **336 offline e2e**, `shellcheck -S warning` — all green.
- **Live against real Cloudglue on tinycloud 0.3.12**: `overcast listen` → `transcript_source=segments`, verbatim transcript, one call; `overcast watch` → `[0]`/`[20]`-anchored transcript with the boundary cue stored once; `overcast doctor` → `tinycloud 0.3.12` clean, no warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default watch/listen transcript pipeline and raises the tinycloud minimum (older CLIs are flagged and use caption fallback), but behavior is heavily tested and legacy envelopes remain supported.
> 
> **Overview**
> Raises the supported **tinycloud floor to 0.3.12** (`watch.speech.v1`) and documents **0.3.12** as the recommended install everywhere (`setup.ts`, README, skills, `doctor`).
> 
> **Transcript path:** `watch` and `listen` now map verbatim speech from the watch envelope’s **`segments[].speech` string arrays** in a **single `watch` call**, with `transcript_source: "segments"`. Shared **`segmentSpeechCues`** in `envelope.ts` handles legacy single-string fields and **dedupes boundary-straddling cues** repeated in adjacent segments (speechless segments reset dedupe so real repeats after a gap are kept).
> 
> **`caption` is no longer the default** — it runs only for **`listen --diarize`**, **empty inline speech** (0.3.10/0.3.11 `segments: []`), or when diarization fails (undiarized envelope speech + `payload.warning`). Summary-as-transcript guards are unchanged.
> 
> Tests and the fake tinycloud fixture cover 0.3.12 single-call, legacy caption fallback, boundary dedupe, and live e2e now expect **`segments`** (not `caption`) on current tinycloud.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5095bbccca93bbf83b26871d750b92dc912ecba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->