### PR TITLE
VS Code extension: CLI discovery under GUI PATH + empty-window onboarding; v0.0.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.9"
+    "version": "0.0.10"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": {
     "name": "kdr"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "Apache-2.0",
   "author": "kdr",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.3.
 
-export const OVERCAST_VERSION = "0.0.9";
+export const OVERCAST_VERSION = "0.0.10";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.3";

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "overcast-vscode",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "overcast-vscode",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "overcast-vscode",
   "displayName": "Overcast",
   "description": "The situation room in your editor — senses on your media (watch, listen, see, faces, EXIF via right-click), OSINT on your sources, and a wall to monitor the situation: maps, graphs, briefs, live feeds.",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "publisher": "kdr",
   "private": true,
   "license": "Apache-2.0",
@@ -95,8 +95,13 @@
       },
       {
         "view": "overcast.investigation",
+        "contents": "No folder is open — a case is a directory.\n[Open Folder…](command:workbench.action.files.openFolder)\nOr adopt an existing case folder without opening it as the workspace:\n[Select a Case…](command:overcast.selectCase)",
+        "when": "overcast.cliFound && !overcast.hasCase && workbenchState == empty"
+      },
+      {
+        "view": "overcast.investigation",
         "contents": "No overcast case in this workspace.\n[Initialize Case Here](command:overcast.initCase)\n[Select a Case…](command:overcast.selectCase)\nA case is a folder with an `.overcast/` store — records, media, targets, findings.",
-        "when": "overcast.cliFound && !overcast.hasCase"
+        "when": "overcast.cliFound && !overcast.hasCase && workbenchState != empty"
       },
       {
         "view": "overcast.investigation",

--- a/vscode/src/commands/caseCommands.ts
+++ b/vscode/src/commands/caseCommands.ts
@@ -3,20 +3,12 @@
 // folder as the case, launching the interactive overcast AGENT in a terminal,
 // and a CLI restart. The active-case override lives in workspaceState (see
 // CaseLocator.setChosenCase) so it survives reloads and beats auto-detection.
-import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
+import { hasCaseStore } from "../services/caseLocator.ts";
 import type { ExtDeps } from "../types.ts";
 
 const OVERCAST_VIEW = "workbench.view.extension.overcast";
-
-function hasStore(dir: string): boolean {
-  try {
-    return fs.existsSync(path.join(dir, ".overcast", "case.json"));
-  } catch {
-    return false;
-  }
-}
 
 async function focusOvercastView(): Promise<void> {
   try {
@@ -186,7 +178,7 @@ export function registerCaseCommands(deps: ExtDeps): void {
 
 /** Adopt a folder as the active case, initializing the store if absent. */
 async function adoptFolder(deps: ExtDeps, dir: string): Promise<void> {
-  if (!hasStore(dir)) {
+  if (!hasCaseStore(dir)) {
     const pick = await vscode.window.showInformationMessage(
       `No overcast case in "${path.basename(dir)}". Initialize one here?`,
       "Initialize",

--- a/vscode/src/commands/initCase.ts
+++ b/vscode/src/commands/initCase.ts
@@ -2,18 +2,10 @@
 // (`overcast case init`), then re-locate. With no folder open there is no
 // "here" yet — instead of dead-ending, ask for a folder and pin it as the
 // active case (same adopt path as Select a Case → "Choose another folder…").
-import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
+import { hasCaseStore } from "../services/caseLocator.ts";
 import type { ExtDeps } from "../types.ts";
-
-function hasStore(dir: string): boolean {
-  try {
-    return fs.existsSync(path.join(dir, ".overcast", "case.json"));
-  } catch {
-    return false;
-  }
-}
 
 export function registerInitCase(deps: ExtDeps): void {
   deps.context.subscriptions.push(
@@ -36,16 +28,6 @@ export function registerInitCase(deps: ExtDeps): void {
         if (!picked?.[0]) return;
         dir = picked[0].fsPath;
         pickedOutsideWorkspace = true;
-        if (hasStore(dir)) {
-          // Already a case — adopt it as-is; `case init --name` on an existing
-          // store would silently rename it.
-          await deps.locator.setChosenCase(dir);
-          deps.router.refresh();
-          void vscode.window.showInformationMessage(
-            `Existing overcast case selected: ${path.basename(dir)}`,
-          );
-          return;
-        }
       } else if (folders.length > 1) {
         const pick = await vscode.window.showQuickPick(
           folders.map((f) => ({ label: f.name, description: f.uri.fsPath, dir: f.uri.fsPath })),
@@ -55,6 +37,18 @@ export function registerInitCase(deps: ExtDeps): void {
         dir = pick.dir;
       } else {
         dir = folders[0].uri.fsPath;
+      }
+      if (hasCaseStore(dir)) {
+        // Never `case init` over an existing store — on any path here (palette,
+        // chat button, Select Case → Initialize…): with --name it would
+        // silently rename the case. Adopt it as the active case instead.
+        if (pickedOutsideWorkspace) await deps.locator.setChosenCase(dir);
+        await deps.locator.refresh();
+        deps.router.refresh();
+        void vscode.window.showInformationMessage(
+          `Folder is already an overcast case — selected: ${path.basename(dir)}`,
+        );
+        return;
       }
       const name = await vscode.window.showInputBox({
         prompt: "Case name",

--- a/vscode/src/commands/initCase.ts
+++ b/vscode/src/commands/initCase.ts
@@ -1,7 +1,19 @@
 // "Overcast: Initialize Case Here" — turn the workspace folder into a case
-// (`overcast case init`), then re-locate.
+// (`overcast case init`), then re-locate. With no folder open there is no
+// "here" yet — instead of dead-ending, ask for a folder and pin it as the
+// active case (same adopt path as Select a Case → "Choose another folder…").
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import type { ExtDeps } from "../types.ts";
+
+function hasStore(dir: string): boolean {
+  try {
+    return fs.existsSync(path.join(dir, ".overcast", "case.json"));
+  } catch {
+    return false;
+  }
+}
 
 export function registerInitCase(deps: ExtDeps): void {
   deps.context.subscriptions.push(
@@ -9,22 +21,44 @@ export function registerInitCase(deps: ExtDeps): void {
       const cli = await deps.bridge.ensureCli();
       if (!cli) return;
       const folders = vscode.workspace.workspaceFolders ?? [];
+      let dir: string;
+      // A dialog-picked folder isn't a workspace folder, so auto-detection
+      // won't find the case afterward — it must be pinned via setChosenCase.
+      let pickedOutsideWorkspace = false;
       if (folders.length === 0) {
-        void vscode.window.showErrorMessage("Open a folder first — a case is a directory.");
-        return;
-      }
-      let dir = folders[0].uri.fsPath;
-      if (folders.length > 1) {
+        const picked = await vscode.window.showOpenDialog({
+          canSelectFolders: true,
+          canSelectFiles: false,
+          canSelectMany: false,
+          openLabel: "Use as Case Folder",
+          title: "A case is a directory — pick the folder that becomes the case",
+        });
+        if (!picked?.[0]) return;
+        dir = picked[0].fsPath;
+        pickedOutsideWorkspace = true;
+        if (hasStore(dir)) {
+          // Already a case — adopt it as-is; `case init --name` on an existing
+          // store would silently rename it.
+          await deps.locator.setChosenCase(dir);
+          deps.router.refresh();
+          void vscode.window.showInformationMessage(
+            `Existing overcast case selected: ${path.basename(dir)}`,
+          );
+          return;
+        }
+      } else if (folders.length > 1) {
         const pick = await vscode.window.showQuickPick(
           folders.map((f) => ({ label: f.name, description: f.uri.fsPath, dir: f.uri.fsPath })),
           { placeHolder: "Which folder becomes the case?" },
         );
         if (!pick) return;
         dir = pick.dir;
+      } else {
+        dir = folders[0].uri.fsPath;
       }
       const name = await vscode.window.showInputBox({
         prompt: "Case name",
-        value: folders[0].name,
+        value: path.basename(dir),
         ignoreFocusOut: true,
       });
       if (name === undefined) return;
@@ -35,6 +69,7 @@ export function registerInitCase(deps: ExtDeps): void {
         cwd: dir,
       });
       if (!result) return;
+      if (pickedOutsideWorkspace) await deps.locator.setChosenCase(dir);
       await deps.locator.refresh();
       deps.router.refresh();
       void vscode.window.showInformationMessage(`Overcast case ready: ${name || dir}`);

--- a/vscode/src/commands/initCase.ts
+++ b/vscode/src/commands/initCase.ts
@@ -10,8 +10,6 @@ import type { ExtDeps } from "../types.ts";
 export function registerInitCase(deps: ExtDeps): void {
   deps.context.subscriptions.push(
     vscode.commands.registerCommand("overcast.initCase", async () => {
-      const cli = await deps.bridge.ensureCli();
-      if (!cli) return;
       const folders = vscode.workspace.workspaceFolders ?? [];
       let dir: string;
       if (folders.length === 0) {
@@ -45,6 +43,10 @@ export function registerInitCase(deps: ExtDeps): void {
         );
         return;
       }
+      // Only a FRESH init needs the CLI — adopting an existing store (above)
+      // is pure state, same split adoptFolder makes. Checked before the name
+      // prompt so a missing CLI fails before the user types anything.
+      if (!(await deps.bridge.ensureCli())) return;
       const name = await vscode.window.showInputBox({
         prompt: "Case name",
         value: path.basename(dir),

--- a/vscode/src/commands/initCase.ts
+++ b/vscode/src/commands/initCase.ts
@@ -14,9 +14,6 @@ export function registerInitCase(deps: ExtDeps): void {
       if (!cli) return;
       const folders = vscode.workspace.workspaceFolders ?? [];
       let dir: string;
-      // A dialog-picked folder isn't a workspace folder, so auto-detection
-      // won't find the case afterward — it must be pinned via setChosenCase.
-      let pickedOutsideWorkspace = false;
       if (folders.length === 0) {
         const picked = await vscode.window.showOpenDialog({
           canSelectFolders: true,
@@ -27,7 +24,6 @@ export function registerInitCase(deps: ExtDeps): void {
         });
         if (!picked?.[0]) return;
         dir = picked[0].fsPath;
-        pickedOutsideWorkspace = true;
       } else if (folders.length > 1) {
         const pick = await vscode.window.showQuickPick(
           folders.map((f) => ({ label: f.name, description: f.uri.fsPath, dir: f.uri.fsPath })),
@@ -42,8 +38,7 @@ export function registerInitCase(deps: ExtDeps): void {
         // Never `case init` over an existing store — on any path here (palette,
         // chat button, Select Case → Initialize…): with --name it would
         // silently rename the case. Adopt it as the active case instead.
-        if (pickedOutsideWorkspace) await deps.locator.setChosenCase(dir);
-        await deps.locator.refresh();
+        await deps.locator.setChosenCase(dir);
         deps.router.refresh();
         void vscode.window.showInformationMessage(
           `Folder is already an overcast case — selected: ${path.basename(dir)}`,
@@ -63,8 +58,11 @@ export function registerInitCase(deps: ExtDeps): void {
         cwd: dir,
       });
       if (!result) return;
-      if (pickedOutsideWorkspace) await deps.locator.setChosenCase(dir);
-      await deps.locator.refresh();
+      // Always pin: auto-detection can't see a dialog-picked folder at all,
+      // and in multi-root (or under a stale chosen-case override) the new
+      // case wouldn't become active either — initCase on X must END with X
+      // active, same rule as adoptFolder. setChosenCase refreshes the locator.
+      await deps.locator.setChosenCase(dir);
       deps.router.refresh();
       void vscode.window.showInformationMessage(`Overcast case ready: ${name || dir}`);
     }),

--- a/vscode/src/services/caseLocator.ts
+++ b/vscode/src/services/caseLocator.ts
@@ -22,7 +22,9 @@ export interface CaseChoice {
 
 const CHOSEN_KEY = "overcast.chosenCaseDir";
 
-function hasCaseStore(dir: string): boolean {
+/** The one store-detection check (a case = a folder with `.overcast/case.json`)
+ *  — import this rather than re-checking the path shape elsewhere. */
+export function hasCaseStore(dir: string): boolean {
   try {
     return fs.existsSync(path.join(dir, ".overcast", "case.json"));
   } catch {

--- a/vscode/src/services/cliBridge.ts
+++ b/vscode/src/services/cliBridge.ts
@@ -5,9 +5,12 @@
 // Resolution: `overcast.path` setting wins — a `.js` path (e.g. a repo
 // dist/bin/overcast.js) is run with the extension host's own Node
 // (ELECTRON_RUN_AS_NODE=1); anything else is treated as an executable.
-// Empty setting = discover `overcast` on PATH.
+// Empty setting = discover `overcast` on PATH, then in well-known install
+// locations (nvm/volta/bun/homebrew) — a Dock-launched extension host often
+// carries the bare GUI PATH, hiding installs every terminal can see.
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { failureFor, parseRecords, type CliFailure } from "../lib/cliOutput.ts";
@@ -54,14 +57,47 @@ export interface CliResult {
   cancelled?: boolean;
 }
 
-function findOnPath(name: string): string | undefined {
-  const pathVar = process.env.PATH ?? "";
+function pathDirs(): string[] {
+  return (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+}
+
+// Fallback install locations probed when PATH discovery misses. GUI-launched
+// VS Code can skip the shell init that puts version-manager bins on PATH, so
+// an `npm install -g` via nvm is invisible here while working in every
+// terminal. nvm keeps no stable `current` symlink — probe every installed
+// node's bin, newest first.
+function wellKnownBinDirs(): string[] {
+  if (process.platform === "win32") return [];
+  const home = os.homedir();
+  const dirs = [
+    path.join(home, ".volta", "bin"),
+    path.join(home, ".bun", "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+  ];
+  const nvmNode = path.join(process.env.NVM_DIR ?? path.join(home, ".nvm"), "versions", "node");
+  try {
+    const versions = fs
+      .readdirSync(nvmNode)
+      .filter((v) => /^v\d+\.\d+\.\d+$/.test(v))
+      .sort((a, b) => {
+        const pa = a.slice(1).split(".").map(Number);
+        const pb = b.slice(1).split(".").map(Number);
+        return pb[0] - pa[0] || pb[1] - pa[1] || pb[2] - pa[2];
+      });
+    for (const v of versions) dirs.push(path.join(nvmNode, v, "bin"));
+  } catch {
+    /* no nvm */
+  }
+  return dirs;
+}
+
+function findExecutable(name: string, dirs: string[]): string | undefined {
   const exts =
     process.platform === "win32"
       ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
       : [""];
-  for (const dir of pathVar.split(path.delimiter)) {
-    if (!dir) continue;
+  for (const dir of dirs) {
     for (const ext of exts) {
       const candidate = path.join(dir, name + ext.toLowerCase());
       try {
@@ -77,6 +113,9 @@ function findOnPath(name: string): string | undefined {
 
 export class CliBridge implements vscode.Disposable {
   private resolved: ResolvedCli | null | undefined; // undefined = not yet tried
+  /** Full-sentence reason the last resolve failed ("not found" vs "found but
+   *  won't run") — the two need different fixes, so never blur them. */
+  private resolveFailure: string | undefined;
   private mutateQueue: Promise<unknown> = Promise.resolve();
   private readonly disposables: vscode.Disposable[] = [];
 
@@ -142,18 +181,25 @@ export class CliBridge implements vscode.Disposable {
         candidate = { cmd: setting, argsPrefix: [], env: {}, display: setting };
       }
     } else {
-      const onPath = findOnPath("overcast");
-      if (onPath) candidate = { cmd: onPath, argsPrefix: [], env: {}, display: onPath };
+      const found = findExecutable("overcast", pathDirs()) ?? findExecutable("overcast", wellKnownBinDirs());
+      if (found) candidate = { cmd: found, argsPrefix: [], env: {}, display: found };
     }
     if (candidate) {
       const ok = await this.smokeTest(candidate);
       this.resolved = ok ? candidate : null;
+      this.resolveFailure = ok
+        ? undefined
+        : `The overcast CLI at ${candidate.display} failed to run — see the Overcast output log.`;
     } else {
       this.resolved = null;
+      this.resolveFailure = "The overcast CLI was not found on PATH or in the usual install locations.";
     }
     await vscode.commands.executeCommand("setContext", "overcast.cliFound", !!this.resolved);
     if (this.resolved) this.output.appendLine(`overcast cli: ${this.resolved.display}`);
-    else this.output.appendLine("overcast cli: NOT FOUND (set overcast.path or install on PATH)");
+    else
+      this.output.appendLine(
+        `overcast cli: ${this.resolveFailure} (set overcast.path or install on PATH)`,
+      );
     return this.resolved ?? undefined;
   }
 
@@ -168,18 +214,24 @@ export class CliBridge implements vscode.Disposable {
       };
       try {
         const child = spawn(cli.cmd, [...cli.argsPrefix, "--version", "--json"], {
-          env: { ...process.env, ...cli.env },
+          env: this.childEnv(cli),
         });
+        let stderr = "";
+        child.stderr?.on("data", (d: Buffer) => (stderr += d.toString("utf8")));
         const timer = setTimeout(() => {
           child.kill("SIGKILL");
           done(false);
         }, 10_000);
-        child.on("error", () => {
+        child.on("error", (e) => {
           clearTimeout(timer);
+          this.output.appendLine(`  smoke test (--version) spawn failed: ${e.message}`);
           done(false);
         });
         child.on("close", (code) => {
           clearTimeout(timer);
+          if (code !== 0 && stderr.trim()) {
+            this.output.appendLine(`  smoke test (--version) exit ${code}: ${stderr.trim()}`);
+          }
           done(code === 0);
         });
       } catch {
@@ -188,17 +240,33 @@ export class CliBridge implements vscode.Disposable {
     });
   }
 
+  /** Env for spawning the resolved CLI. Prepends the resolved binary's own
+   *  directory to PATH: an `#!/usr/bin/env node` launcher (nvm/volta installs)
+   *  resolves `node` from PATH, and node sits next to the launcher — but a
+   *  GUI-launched extension host's PATH lacks that directory even when
+   *  discovery (or the overcast.path setting) found the launcher itself. */
+  private childEnv(cli: ResolvedCli, extra?: Record<string, string>): NodeJS.ProcessEnv {
+    if (process.platform === "win32") return { ...process.env, ...cli.env, ...extra };
+    const binDir = path.dirname(cli.cmd);
+    const dirs = pathDirs();
+    const PATH = dirs.includes(binDir) ? (process.env.PATH ?? "") : [binDir, ...dirs].join(path.delimiter);
+    return { ...process.env, PATH, ...cli.env, ...extra };
+  }
+
   /** Resolve or walk the user through fixing the setup. Returns undefined if missing. */
   async ensureCli(): Promise<ResolvedCli | undefined> {
     const cli = await this.resolve();
     if (cli) return cli;
     const pick = await vscode.window.showErrorMessage(
-      "The overcast CLI was not found. Install it (npm install -g @kdrrr/overcast) or point overcast.path at a binary or a built dist/bin/overcast.js.",
+      `${this.resolveFailure ?? "The overcast CLI was not found."} Install it (npm install -g @kdrrr/overcast) or point overcast.path at a binary or a built dist/bin/overcast.js.`,
       "Open Settings",
+      "Show Log",
       "Retry",
     );
     if (pick === "Open Settings") {
       await vscode.commands.executeCommand("workbench.action.openSettings", "overcast.path");
+    } else if (pick === "Show Log") {
+      this.output.show(true);
     } else if (pick === "Retry") {
       this.resolved = undefined;
       return this.ensureCli();
@@ -239,7 +307,7 @@ export class CliBridge implements vscode.Disposable {
     return new Promise((resolvePromise) => {
       const child = spawn(cli.cmd, finalArgs, {
         cwd: opts.cwd ?? caseDir ?? undefined,
-        env: { ...process.env, ...cli.env, ...opts.env },
+        env: this.childEnv(cli, opts.env),
       });
       let stdout = "";
       let stderr = "";
@@ -525,7 +593,7 @@ export class CliBridge implements vscode.Disposable {
     );
     return spawn(cli.cmd, finalArgs, {
       cwd: caseDir ?? undefined,
-      env: { ...process.env, ...cli.env, ...opts.env },
+      env: this.childEnv(cli, opts.env),
     });
   }
 

--- a/vscode/src/services/cliBridge.ts
+++ b/vscode/src/services/cliBridge.ts
@@ -143,6 +143,16 @@ function launcherDirs(cmd: string): string[] {
   return dirs;
 }
 
+/** PATH with the launcher's missing symlink-chain dirs prepended — the ONE
+ *  shebang-rescue computation, shared by spawn env and terminal env. Undefined
+ *  when PATH already covers the chain (or on win32, where shebangs don't run). */
+function rescuedPath(cmd: string): string | undefined {
+  if (process.platform === "win32") return undefined;
+  const dirs = pathDirs();
+  const missing = launcherDirs(cmd).filter((d) => !dirs.includes(d));
+  return missing.length ? [...missing, ...dirs].join(path.delimiter) : undefined;
+}
+
 export class CliBridge implements vscode.Disposable {
   private resolved: ResolvedCli | null | undefined; // undefined = not yet tried
   /** Full-sentence reason the last resolve failed ("not found" vs "found but
@@ -155,6 +165,13 @@ export class CliBridge implements vscode.Disposable {
   private resolveGen = 0;
   private mutateQueue: Promise<unknown> = Promise.resolve();
   private readonly disposables: vscode.Disposable[] = [];
+
+  // ---- resolution eventing ----
+  private readonly cliEmitter = new vscode.EventEmitter<void>();
+  /** Fires when a resolution pass completes — `cliFound` may have changed.
+   *  UI that paints off the synchronous `cliFound` getter must re-render on
+   *  this, or a view drawn mid-discovery keeps a stale "not found" state. */
+  readonly onDidResolveCli = this.cliEmitter.event;
 
   // ---- run tracking (Runs view + status-bar spinner) ----
   private readonly jobEmitter = new vscode.EventEmitter<void>();
@@ -254,8 +271,10 @@ export class CliBridge implements vscode.Disposable {
       }
     }
     // Invalidated mid-pass (setting change / restart): the outcome is stale —
-    // hand it to whoever awaited THIS pass, but leave the cache to the new one.
-    if (gen !== this.resolveGen) return resolved ?? undefined;
+    // JOIN the current resolve instead of handing awaiters an outdated CLI or
+    // a false not-found. No self-await cycle: invalidate() cleared `resolving`
+    // when it bumped the generation, so this.resolve() is never THIS pass.
+    if (gen !== this.resolveGen) return this.resolve();
     this.resolved = resolved;
     this.resolveFailure = resolved
       ? undefined
@@ -268,6 +287,7 @@ export class CliBridge implements vscode.Disposable {
       this.output.appendLine(
         `overcast cli: ${this.resolveFailure} (set overcast.path or install on PATH)`,
       );
+    this.cliEmitter.fire();
     return this.resolved ?? undefined;
   }
 
@@ -308,19 +328,15 @@ export class CliBridge implements vscode.Disposable {
     });
   }
 
-  /** Env for spawning the resolved CLI. Prepends the launcher's symlink-chain
-   *  dirs (launcherDirs) to PATH: an `#!/usr/bin/env node` launcher resolves
-   *  `node` from PATH, and node sits next to some hop of the chain — but a
-   *  GUI-launched extension host's PATH lacks those directories even when
-   *  discovery (or the overcast.path setting) found the launcher itself. */
+  /** Env for spawning the resolved CLI, with the shebang PATH rescue
+   *  (rescuedPath): an `#!/usr/bin/env node` launcher resolves `node` from
+   *  PATH, and a GUI-launched extension host's PATH lacks the launcher's own
+   *  chain dirs even when discovery (or overcast.path) found the launcher. */
   private childEnv(cli: ResolvedCli, extra?: Record<string, string>): NodeJS.ProcessEnv {
-    if (process.platform === "win32") return { ...process.env, ...cli.env, ...extra };
-    const dirs = pathDirs();
-    const missing = launcherDirs(cli.cmd).filter((d) => !dirs.includes(d));
-    const PATH = missing.length
-      ? [...missing, ...dirs].join(path.delimiter)
-      : (process.env.PATH ?? "");
-    return { ...process.env, PATH, ...cli.env, ...extra };
+    const PATH = rescuedPath(cli.cmd);
+    return PATH
+      ? { ...process.env, PATH, ...cli.env, ...extra }
+      : { ...process.env, ...cli.env, ...extra };
   }
 
   /** Resolve or walk the user through fixing the setup. Returns undefined if missing. */
@@ -545,9 +561,16 @@ export class CliBridge implements vscode.Disposable {
 
   /** Terminal env for a `terminalLaunch` command line — the node-runner head
    *  (extension-host executable) only behaves as node with ELECTRON_RUN_AS_NODE
-   *  set. Undefined when the resolved CLI needs no env. */
+   *  set, and a discovered shim needs the same shebang PATH rescue spawns get
+   *  (a terminal shell whose init doesn't restore nvm/volta dirs would
+   *  otherwise die on `env: node: No such file or directory`; shell init that
+   *  prepends its own PATH on top keeps working — ours only appends coverage).
+   *  Undefined when the resolved CLI needs no env. */
   terminalEnv(cli: ResolvedCli): Record<string, string> | undefined {
-    return Object.keys(cli.env).length ? { ...cli.env } : undefined;
+    const env: Record<string, string> = { ...cli.env };
+    const PATH = rescuedPath(cli.cmd);
+    if (PATH) env.PATH = PATH;
+    return Object.keys(env).length ? env : undefined;
   }
 
   /** `overcast.home` setting → `--home` (profiles, archive buckets). Absolute
@@ -672,5 +695,6 @@ export class CliBridge implements vscode.Disposable {
     for (const cts of this.jobCts.values()) cts.dispose();
     this.jobCts.clear();
     this.jobEmitter.dispose();
+    this.cliEmitter.dispose();
   }
 }

--- a/vscode/src/services/cliBridge.ts
+++ b/vscode/src/services/cliBridge.ts
@@ -131,6 +131,11 @@ export class CliBridge implements vscode.Disposable {
   /** Full-sentence reason the last resolve failed ("not found" vs "found but
    *  won't run") — the two need different fixes, so never blur them. */
   private resolveFailure: string | undefined;
+  /** In-flight resolution, so concurrent callers share ONE discovery pass. */
+  private resolving: Promise<ResolvedCli | undefined> | undefined;
+  /** Bumped by invalidate(); a pass that finishes under a stale generation
+   *  (setting changed / restart mid-flight) must not write the cache. */
+  private resolveGen = 0;
   private mutateQueue: Promise<unknown> = Promise.resolve();
   private readonly disposables: vscode.Disposable[] = [];
 
@@ -150,7 +155,7 @@ export class CliBridge implements vscode.Disposable {
     this.disposables.push(
       vscode.workspace.onDidChangeConfiguration((e) => {
         if (e.affectsConfiguration("overcast.path")) {
-          this.resolved = undefined;
+          this.invalidate();
           void this.resolve();
         }
       }),
@@ -174,14 +179,36 @@ export class CliBridge implements vscode.Disposable {
 
   /** Drop the cached resolution and re-resolve (the "Restart CLI" command). */
   async restart(): Promise<ResolvedCli | undefined> {
-    this.resolved = undefined;
+    this.invalidate();
     this.output.appendLine("overcast cli: re-resolving (restart requested)");
     return this.resolve();
   }
 
-  /** Resolve (and smoke-test) the CLI; caches; maintains overcast.cliFound. */
+  /** Forget any cached/in-flight resolution (setting change, restart, retry).
+   *  A pass already in flight keeps running but can't write the cache. */
+  private invalidate(): void {
+    this.resolved = undefined;
+    this.resolving = undefined;
+    this.resolveGen++;
+  }
+
+  /** Resolve (and smoke-test) the CLI; caches; maintains overcast.cliFound.
+   *  Single-flight: the cache is only ever written with a FINISHED outcome —
+   *  mutating it mid-pass would make cliFound/resolve report "not found"
+   *  to concurrent callers while candidates are still being smoke-tested. */
   async resolve(): Promise<ResolvedCli | undefined> {
     if (this.resolved !== undefined) return this.resolved ?? undefined;
+    if (!this.resolving) {
+      const pass = this.doResolve(this.resolveGen).finally(() => {
+        // don't clear a NEWER pass installed after an invalidate mid-flight
+        if (this.resolving === pass) this.resolving = undefined;
+      });
+      this.resolving = pass;
+    }
+    return this.resolving;
+  }
+
+  private async doResolve(gen: number): Promise<ResolvedCli | undefined> {
     const setting = vscode.workspace.getConfiguration("overcast").get<string>("path", "").trim();
     const candidates: ResolvedCli[] = [];
     if (setting) {
@@ -202,14 +229,18 @@ export class CliBridge implements vscode.Disposable {
         candidates.push({ cmd: found, argsPrefix: [], env: {}, display: found });
       }
     }
-    this.resolved = null;
+    let resolved: ResolvedCli | null = null;
     for (const candidate of candidates) {
       if (await this.smokeTest(candidate)) {
-        this.resolved = candidate;
+        resolved = candidate;
         break;
       }
     }
-    this.resolveFailure = this.resolved
+    // Invalidated mid-pass (setting change / restart): the outcome is stale —
+    // hand it to whoever awaited THIS pass, but leave the cache to the new one.
+    if (gen !== this.resolveGen) return resolved ?? undefined;
+    this.resolved = resolved;
+    this.resolveFailure = resolved
       ? undefined
       : candidates.length > 0
         ? `The overcast CLI at ${candidates[0].display}${candidates.length > 1 ? ` (and ${candidates.length - 1} other install(s))` : ""} failed to run — see the Overcast output log.`
@@ -288,7 +319,7 @@ export class CliBridge implements vscode.Disposable {
     } else if (pick === "Show Log") {
       this.output.show(true);
     } else if (pick === "Retry") {
-      this.resolved = undefined;
+      this.invalidate();
       return this.ensureCli();
     }
     return undefined;

--- a/vscode/src/services/cliBridge.ts
+++ b/vscode/src/services/cliBridge.ts
@@ -92,23 +92,38 @@ function wellKnownBinDirs(): string[] {
   return dirs;
 }
 
-function findExecutable(name: string, dirs: string[]): string | undefined {
+/** EVERY executable named `name` across `dirs`, in order, deduped by realpath
+ *  (symlinked installs would smoke-test the same binary twice). All of them are
+ *  returned — resolution smoke-tests each in turn, so a stale/broken launcher
+ *  earlier in the order can't hide a working later install. */
+function findExecutables(name: string, dirs: string[]): string[] {
   const exts =
     process.platform === "win32"
       ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
       : [""];
+  const found: string[] = [];
+  const seen = new Set<string>();
   for (const dir of dirs) {
     for (const ext of exts) {
       const candidate = path.join(dir, name + ext.toLowerCase());
       try {
         fs.accessSync(candidate, fs.constants.X_OK);
-        return candidate;
+        let key = candidate;
+        try {
+          key = fs.realpathSync(candidate);
+        } catch {
+          /* dedupe on the literal path */
+        }
+        if (!seen.has(key)) {
+          seen.add(key);
+          found.push(candidate);
+        }
       } catch {
         /* keep looking */
       }
     }
   }
-  return undefined;
+  return found;
 }
 
 export class CliBridge implements vscode.Disposable {
@@ -168,32 +183,37 @@ export class CliBridge implements vscode.Disposable {
   async resolve(): Promise<ResolvedCli | undefined> {
     if (this.resolved !== undefined) return this.resolved ?? undefined;
     const setting = vscode.workspace.getConfiguration("overcast").get<string>("path", "").trim();
-    let candidate: ResolvedCli | undefined;
+    const candidates: ResolvedCli[] = [];
     if (setting) {
+      // An explicit setting never falls back to discovery — a wrong path
+      // should fail loudly, not be silently papered over.
       if (setting.endsWith(".js") || setting.endsWith(".mjs")) {
-        candidate = {
+        candidates.push({
           cmd: process.execPath,
           argsPrefix: [setting],
           env: { ELECTRON_RUN_AS_NODE: "1" },
           display: `${setting} (via extension-host node)`,
-        };
+        });
       } else {
-        candidate = { cmd: setting, argsPrefix: [], env: {}, display: setting };
+        candidates.push({ cmd: setting, argsPrefix: [], env: {}, display: setting });
       }
     } else {
-      const found = findExecutable("overcast", pathDirs()) ?? findExecutable("overcast", wellKnownBinDirs());
-      if (found) candidate = { cmd: found, argsPrefix: [], env: {}, display: found };
+      for (const found of findExecutables("overcast", [...pathDirs(), ...wellKnownBinDirs()])) {
+        candidates.push({ cmd: found, argsPrefix: [], env: {}, display: found });
+      }
     }
-    if (candidate) {
-      const ok = await this.smokeTest(candidate);
-      this.resolved = ok ? candidate : null;
-      this.resolveFailure = ok
-        ? undefined
-        : `The overcast CLI at ${candidate.display} failed to run — see the Overcast output log.`;
-    } else {
-      this.resolved = null;
-      this.resolveFailure = "The overcast CLI was not found on PATH or in the usual install locations.";
+    this.resolved = null;
+    for (const candidate of candidates) {
+      if (await this.smokeTest(candidate)) {
+        this.resolved = candidate;
+        break;
+      }
     }
+    this.resolveFailure = this.resolved
+      ? undefined
+      : candidates.length > 0
+        ? `The overcast CLI at ${candidates[0].display}${candidates.length > 1 ? ` (and ${candidates.length - 1} other install(s))` : ""} failed to run — see the Overcast output log.`
+        : "The overcast CLI was not found on PATH or in the usual install locations.";
     await vscode.commands.executeCommand("setContext", "overcast.cliFound", !!this.resolved);
     if (this.resolved) this.output.appendLine(`overcast cli: ${this.resolved.display}`);
     else
@@ -224,13 +244,13 @@ export class CliBridge implements vscode.Disposable {
         }, 10_000);
         child.on("error", (e) => {
           clearTimeout(timer);
-          this.output.appendLine(`  smoke test (--version) spawn failed: ${e.message}`);
+          this.output.appendLine(`  smoke test ${cli.display}: spawn failed: ${e.message}`);
           done(false);
         });
         child.on("close", (code) => {
           clearTimeout(timer);
           if (code !== 0 && stderr.trim()) {
-            this.output.appendLine(`  smoke test (--version) exit ${code}: ${stderr.trim()}`);
+            this.output.appendLine(`  smoke test ${cli.display}: exit ${code}: ${stderr.trim()}`);
           }
           done(code === 0);
         });

--- a/vscode/src/services/cliBridge.ts
+++ b/vscode/src/services/cliBridge.ts
@@ -92,10 +92,12 @@ function wellKnownBinDirs(): string[] {
   return dirs;
 }
 
-/** EVERY executable named `name` across `dirs`, in order, deduped by realpath
- *  (symlinked installs would smoke-test the same binary twice). All of them are
- *  returned — resolution smoke-tests each in turn, so a stale/broken launcher
- *  earlier in the order can't hide a working later install. */
+/** EVERY executable named `name` across `dirs`, in order, deduped by LITERAL
+ *  path only — two paths sharing a realpath are still distinct candidates,
+ *  because a symlink's own location changes which PATH prefix rescues its
+ *  shebang (see launcherDirs); dropping the "duplicate" could drop the only
+ *  runnable one. All are returned — resolution smoke-tests each in turn, so a
+ *  stale/broken launcher earlier in the order can't hide a working install. */
 function findExecutables(name: string, dirs: string[]): string[] {
   const exts =
     process.platform === "win32"
@@ -108,14 +110,8 @@ function findExecutables(name: string, dirs: string[]): string[] {
       const candidate = path.join(dir, name + ext.toLowerCase());
       try {
         fs.accessSync(candidate, fs.constants.X_OK);
-        let key = candidate;
-        try {
-          key = fs.realpathSync(candidate);
-        } catch {
-          /* dedupe on the literal path */
-        }
-        if (!seen.has(key)) {
-          seen.add(key);
+        if (!seen.has(candidate)) {
+          seen.add(candidate);
           found.push(candidate);
         }
       } catch {
@@ -124,6 +120,27 @@ function findExecutables(name: string, dirs: string[]): string[] {
     }
   }
   return found;
+}
+
+/** The launcher's own dir plus each symlink hop's dir, in chain order. An
+ *  `#!/usr/bin/env node` launcher needs `node` on PATH, and node sits next to
+ *  SOME hop of the chain — e.g. /usr/local/bin/overcast → ~/.nvm/.../bin/
+ *  overcast (node lives here) → …/lib/node_modules/…/overcast.js. */
+function launcherDirs(cmd: string): string[] {
+  const dirs: string[] = [];
+  let cur = cmd;
+  for (let hop = 0; hop < 8; hop++) {
+    const dir = path.dirname(cur);
+    if (!dirs.includes(dir)) dirs.push(dir);
+    let link: string;
+    try {
+      link = fs.readlinkSync(cur);
+    } catch {
+      break; // not a symlink — end of the chain
+    }
+    cur = path.resolve(dir, link);
+  }
+  return dirs;
 }
 
 export class CliBridge implements vscode.Disposable {
@@ -291,16 +308,18 @@ export class CliBridge implements vscode.Disposable {
     });
   }
 
-  /** Env for spawning the resolved CLI. Prepends the resolved binary's own
-   *  directory to PATH: an `#!/usr/bin/env node` launcher (nvm/volta installs)
-   *  resolves `node` from PATH, and node sits next to the launcher — but a
-   *  GUI-launched extension host's PATH lacks that directory even when
+  /** Env for spawning the resolved CLI. Prepends the launcher's symlink-chain
+   *  dirs (launcherDirs) to PATH: an `#!/usr/bin/env node` launcher resolves
+   *  `node` from PATH, and node sits next to some hop of the chain — but a
+   *  GUI-launched extension host's PATH lacks those directories even when
    *  discovery (or the overcast.path setting) found the launcher itself. */
   private childEnv(cli: ResolvedCli, extra?: Record<string, string>): NodeJS.ProcessEnv {
     if (process.platform === "win32") return { ...process.env, ...cli.env, ...extra };
-    const binDir = path.dirname(cli.cmd);
     const dirs = pathDirs();
-    const PATH = dirs.includes(binDir) ? (process.env.PATH ?? "") : [binDir, ...dirs].join(path.delimiter);
+    const missing = launcherDirs(cli.cmd).filter((d) => !dirs.includes(d));
+    const PATH = missing.length
+      ? [...missing, ...dirs].join(path.delimiter)
+      : (process.env.PATH ?? "");
     return { ...process.env, PATH, ...cli.env, ...extra };
   }
 

--- a/vscode/src/views/commandDeck.ts
+++ b/vscode/src/views/commandDeck.ts
@@ -91,10 +91,25 @@ const NO_CASE_GROUPS: DeckGroup[] = [
   },
 ];
 
+// Actions in an empty window (no folder open): "Initialize Case HERE" has no
+// here yet — lead with opening a folder; Select Case can still adopt an
+// existing case folder without opening it as the workspace.
+const EMPTY_WINDOW_GROUPS: DeckGroup[] = [
+  {
+    title: "Case",
+    buttons: [
+      { label: "Open Folder…", command: "workbench.action.files.openFolder", icon: ICONS.folder },
+      { label: "Select Case…", command: "overcast.selectCase", icon: ICONS.swap },
+    ],
+  },
+];
+
 // Every command the deck is allowed to dispatch (guards the message channel).
 // selectCase + the agent terminal ride the head row, not a grid button.
 const ALLOWED = new Set([
-  ...[...CASE_GROUPS, ...NO_CASE_GROUPS].flatMap((g) => g.buttons.map((b) => b.command)),
+  ...[...CASE_GROUPS, ...NO_CASE_GROUPS, ...EMPTY_WINDOW_GROUPS].flatMap((g) =>
+    g.buttons.map((b) => b.command),
+  ),
   "overcast.selectCase",
   "overcast.openAgentTerminal",
 ]);
@@ -141,10 +156,12 @@ export class CommandDeckProvider implements vscode.WebviewViewProvider {
         void vscode.commands.executeCommand(msg.command);
       }
     });
-    // Re-render on case-board refreshes and case switches (both cheap here).
+    // Re-render on case-board refreshes, case switches, and workspace-folder
+    // changes (the empty-window deck below) — all cheap here.
     this.subs.push(
       this.deps.model.onDidChange(() => this.render()),
       this.deps.locator.onDidChangeCase(() => this.render()),
+      vscode.workspace.onDidChangeWorkspaceFolders(() => this.render()),
     );
     webviewView.onDidDispose(() => {
       for (const d of this.subs) d.dispose();
@@ -164,7 +181,11 @@ export class CommandDeckProvider implements vscode.WebviewViewProvider {
     const hasCase = !!this.deps.locator.caseDir;
     const cliFound = this.deps.bridge.cliFound;
     const caseName = hasCase ? (this.deps.locator.caseName ?? "case") : "no case";
-    const groups = hasCase ? CASE_GROUPS : NO_CASE_GROUPS;
+    // A chosen case can be active with no folder open — only the truly empty
+    // no-case window swaps to the open-a-folder deck.
+    const emptyWindow = (vscode.workspace.workspaceFolders ?? []).length === 0;
+    const groups = hasCase ? CASE_GROUPS : emptyWindow ? EMPTY_WINDOW_GROUPS : NO_CASE_GROUPS;
+    const hint = !hasCase && emptyWindow ? "No folder is open — a case is a directory." : "";
     const dotClass = cliFound ? "ok" : "bad";
     const dotTitle = cliFound ? "overcast CLI found" : "overcast CLI not found — set overcast.path";
     const button = (b: DeckButton) =>
@@ -207,6 +228,7 @@ export class CommandDeckProvider implements vscode.WebviewViewProvider {
           font-size: 0.78em; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;
           opacity: 0.55; margin: 0 0 3px 1px;
         }
+        .hint { opacity: 0.75; margin: 0 0 8px; }
         .grid { display: flex; flex-wrap: wrap; gap: 6px; }
         .icon-btn {
           margin-left: auto; flex: 0 0 auto; background: none; border: none; padding: 2px;
@@ -241,6 +263,7 @@ export class CommandDeckProvider implements vscode.WebviewViewProvider {
           </button>
           ${hasCase ? `<button class="icon-btn" data-cmd="overcast.openAgentTerminal" title="Open the overcast agent terminal"><svg viewBox="0 0 16 16" aria-hidden="true">${ICONS.terminal}</svg></button>` : ""}
         </div>
+        ${hint ? `<div class="hint">${escapeHtml(hint)}</div>` : ""}
         <div class="groups">${groupHtml}</div>
       </div>
       <script nonce="${n}">

--- a/vscode/src/views/commandDeck.ts
+++ b/vscode/src/views/commandDeck.ts
@@ -156,12 +156,16 @@ export class CommandDeckProvider implements vscode.WebviewViewProvider {
         void vscode.commands.executeCommand(msg.command);
       }
     });
-    // Re-render on case-board refreshes, case switches, and workspace-folder
-    // changes (the empty-window deck below) — all cheap here.
+    // Re-render on case-board refreshes, case switches, workspace-folder
+    // changes (the empty-window deck below), and CLI resolution finishing —
+    // the status dot reads the synchronous cliFound, and a deck painted while
+    // multi-candidate discovery is still smoke-testing would keep a stale
+    // red dot forever otherwise. All cheap here.
     this.subs.push(
       this.deps.model.onDidChange(() => this.render()),
       this.deps.locator.onDidChangeCase(() => this.render()),
       vscode.workspace.onDidChangeWorkspaceFolders(() => this.render()),
+      this.deps.bridge.onDidResolveCli(() => this.render()),
     );
     webviewView.onDidDispose(() => {
       for (const d of this.subs) d.dispose();


### PR DESCRIPTION
Two dead-ends hit while testing the extension in a Dock-launched VS Code, plus the 0.0.10 bump so the fixes ride the release train (per RELEASING.md's fold-the-bump-into-the-PR flow).

## CLI discovery (`cliBridge.ts`)

**Symptom:** "The overcast CLI was not found" despite a working `npm install -g @kdrrr/overcast` — the nvm bin dir only reaches PATH via shell init, which a Dock-launched extension host can miss (`launchctl getenv PATH` is empty on this machine).

- Discovery falls back to well-known install dirs when PATH misses: `~/.volta/bin`, `~/.bun/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, and every `~/.nvm/versions/node/*/bin` newest-first (nvm has no stable `current` symlink).
- **Shebang rescue:** every spawn now prepends the resolved binary's own dir to the child's PATH. An `#!/usr/bin/env node` launcher (any node-manager install) resolves `node` next to itself; without this, even a correct `overcast.path` setting failed the smoke test with `env: node: No such file or directory` (verified: same launcher, bare GUI PATH, fails without / runs with the prepend).
- "Not found on PATH" and "found at X but failed to run" are now distinct messages (they need different fixes and previously shared one), smoke-test stderr lands in the Overcast output log, and the error toast gained a Show Log button.

## Empty-window onboarding (`initCase.ts`, `commandDeck.ts`, `viewsWelcome`)

**Symptom:** with no folder open, the sidebar still offers "Initialize Case Here" → clicking it errors "Open a folder first — a case is a directory."

- The Investigation welcome and the command deck now show an explicit empty-window state — "No folder is open — a case is a directory" with **Open Folder…** / **Select a Case…** — instead of buttons that error (welcome gated on `workbenchState`; deck re-renders on workspace-folder changes).
- `overcast.initCase` itself (still reachable via palette/chat) no longer dead-ends: it asks for a folder and pins it as the active case, adopting an existing `.overcast/` store as-is rather than re-initting (a `case init --name` on an existing store would silently rename it).
- Multi-root fix: the case-name default now follows the *picked* folder, not `folders[0]`.

## Release v0.0.10

`npm version 0.0.10 --no-git-tag-version` — sync-version confirms all 7 surfaces match. After merge:

```bash
git checkout main && git pull && git tag v0.0.10 && git push origin v0.0.10
```

## Verification

- Root + vscode typecheck clean; extension tests 51/51.
- `overcast-vscode-0.0.10.vsix` packages cleanly; bun binary builds and reports `overcast 0.0.10 (pi 0.80.3)`.
- Shebang rescue verified empirically against the bare GUI PATH (above).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the extension resolves and spawns the CLI (PATH, multi-candidate discovery) and case pinning on init—high user impact but localized to VS Code extension UX, not core CLI or auth.
> 
> **Overview**
> Bumps the release to **0.0.10** across npm, plugin manifests, and `OVERCAST_VERSION`.
> 
> **CLI discovery (`cliBridge`)** fixes Dock/GUI-launched VS Code missing shell `PATH`: discovery probes well-known install dirs (nvm node bins newest-first, Volta, Bun, Homebrew) and smoke-tests every candidate instead of stopping at the first broken shim. Spawns and agent terminals get a **shebang PATH rescue** so `#!/usr/bin/env node` launchers find `node`. Resolution is single-flight with generation invalidation, distinct “not found” vs “found but won’t run” errors, smoke-test logging, **Show Log** on the setup toast, and **`onDidResolveCli`** so the command deck’s CLI dot refreshes after async discovery.
> 
> **Empty-window / case init** adds Investigation welcome + command-deck states when no folder is open (`workbenchState == empty`), and **`overcast.initCase`** picks a folder instead of erroring, adopts existing `.overcast/` stores (no silent re-init/rename), pins the chosen case with **`setChosenCase`**, and uses the picked folder for the default case name.
> 
> **`hasCaseStore`** is exported from `caseLocator` and reused in case commands instead of duplicate checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360b16313f7afb38a5bbf5646e7e8c3a54047c4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->