### PR TITLE
VS Code extension: Marketplace-ready — kdrrr.overcast + CI publish; v0.0.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.10"
+    "version": "0.0.11"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": {
     "name": "kdr"
   },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,22 +68,14 @@ jobs:
             npm publish
           fi
 
-  # VS Code extension: package the .vsix, attach it to the same GitHub Release,
-  # and publish it to the VS Code Marketplace + Open VSX. Its version is stamped
-  # by scripts/sync-version.mjs (checked in the npm-publish job), so the .vsix
-  # always matches the tag. The publish steps are config-gated (Entra ID OIDC
-  # via the AZURE_* repo variables, or VSCE_PAT / OVSX_PAT — see RELEASING.md)
-  # and skip when the version is already live, so re-running a tag is safe and
-  # the job passes before the one-time setup.
-  #
-  # `environment: release` gives the GitHub OIDC token a STABLE subject
-  # (`repo:<owner>/<repo>:environment:release`) that the managed identity's
-  # federated credential trusts — without it, the subject is per-tag and would
-  # need a credential per release.
+  # VS Code extension: package the .vsix and attach it to the same GitHub
+  # Release. Its version is stamped by scripts/sync-version.mjs (checked in the
+  # npm-publish job), so the .vsix always matches the tag. Publishing to the
+  # Marketplace is a manual upload of this attached .vsix from the publisher
+  # manage page — see RELEASING.md.
   vsix:
     needs: npm-publish
     runs-on: ubuntu-latest
-    environment: release
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -100,64 +92,12 @@ jobs:
       - run: npm run --prefix vscode build
       - run: npm run --prefix vscode test
       - run: mkdir -p .dev && npm run --prefix vscode package
-      # Attach the .vsix to the Release BEFORE publishing, so the downloadable
-      # artifact is guaranteed even if a Marketplace/Open VSX publish later fails
-      # (a bad PAT, a registry hiccup) — the manual download+upload path always
-      # has a file to grab.
       - name: Attach the .vsix to the GitHub Release
         if: github.event_name == 'push'
         uses: softprops/action-gh-release@v3
         with:
           files: .dev/*.vsix
           fail_on_unmatched_files: true
-      # Entra ID OIDC (preferred): exchange the GitHub OIDC token for an Azure
-      # token as the managed identity behind vars.AZURE_CLIENT_ID. `vsce publish
-      # --azure-credential` then mints a Marketplace token via the logged-in
-      # Azure CLI — no stored PAT. Runs only when OIDC is configured; the PAT
-      # path below is the fallback.
-      - name: Azure login (OIDC — for Marketplace publish)
-        if: github.event_name == 'push' && vars.AZURE_CLIENT_ID != ''
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-      - name: Publish to the VS Code Marketplace
-        if: github.event_name == 'push'
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          HAVE_OIDC: ${{ vars.AZURE_CLIENT_ID != '' }}
-        run: |
-          VSCE=vscode/node_modules/.bin/vsce
-          VERSION="$(node -p "require('./vscode/package.json').version")"
-          # Idempotent like the npm publish so re-running a tag is safe. `vsce
-          # show --json` lists every published version on its own line (and
-          # prints `undefined`, exit 0, before the first publish — no match →
-          # publish); a match means this version is already live → skip.
-          if "$VSCE" show kdrrr.overcast --json 2>/dev/null | grep -q "\"version\": \"$VERSION\""; then
-            echo "kdrrr.overcast@$VERSION is already on the Marketplace — skipping publish."
-          elif [ "$HAVE_OIDC" = "true" ]; then
-            "$VSCE" publish --azure-credential --packagePath .dev/*.vsix
-          elif [ -n "$VSCE_PAT" ]; then
-            "$VSCE" publish -p "$VSCE_PAT" --packagePath .dev/*.vsix
-          else
-            echo "No Marketplace auth configured (set the AZURE_* variables for OIDC, or VSCE_PAT) — skipping (see RELEASING.md)."
-          fi
-      - name: Publish to Open VSX
-        if: github.event_name == 'push'
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-        run: |
-          if [ -z "$OVSX_PAT" ]; then
-            echo "OVSX_PAT secret not set — skipping Open VSX publish (see RELEASING.md)."
-            exit 0
-          fi
-          VERSION="$(node -p "require('./vscode/package.json').version")"
-          if curl -fsS "https://open-vsx.org/api/kdrrr/overcast/$VERSION" >/dev/null 2>&1; then
-            echo "kdrrr.overcast@$VERSION is already on Open VSX — skipping publish."
-          else
-            npx --yes ovsx@1.0.2 publish .dev/*.vsix -p "$OVSX_PAT"
-          fi
       - name: Upload the .vsix as a workflow artifact (manual run)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,19 @@ jobs:
   # VS Code extension: package the .vsix, attach it to the same GitHub Release,
   # and publish it to the VS Code Marketplace + Open VSX. Its version is stamped
   # by scripts/sync-version.mjs (checked in the npm-publish job), so the .vsix
-  # always matches the tag. The publish steps are secret-gated (VSCE_PAT /
-  # OVSX_PAT — see RELEASING.md) and skip when the version is already live, so
-  # re-running a tag is safe and the job passes before the one-time setup.
+  # always matches the tag. The publish steps are config-gated (Entra ID OIDC
+  # via the AZURE_* repo variables, or VSCE_PAT / OVSX_PAT — see RELEASING.md)
+  # and skip when the version is already live, so re-running a tag is safe and
+  # the job passes before the one-time setup.
+  #
+  # `environment: release` gives the GitHub OIDC token a STABLE subject
+  # (`repo:<owner>/<repo>:environment:release`) that the managed identity's
+  # federated credential trusts — without it, the subject is per-tag and would
+  # need a credential per release.
   vsix:
     needs: npm-publish
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -103,15 +110,24 @@ jobs:
         with:
           files: .dev/*.vsix
           fail_on_unmatched_files: true
+      # Entra ID OIDC (preferred): exchange the GitHub OIDC token for an Azure
+      # token as the managed identity behind vars.AZURE_CLIENT_ID. `vsce publish
+      # --azure-credential` then mints a Marketplace token via the logged-in
+      # Azure CLI — no stored PAT. Runs only when OIDC is configured; the PAT
+      # path below is the fallback.
+      - name: Azure login (OIDC — for Marketplace publish)
+        if: github.event_name == 'push' && vars.AZURE_CLIENT_ID != ''
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - name: Publish to the VS Code Marketplace
         if: github.event_name == 'push'
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          HAVE_OIDC: ${{ vars.AZURE_CLIENT_ID != '' }}
         run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "VSCE_PAT secret not set — skipping Marketplace publish (see RELEASING.md)."
-            exit 0
-          fi
           VSCE=vscode/node_modules/.bin/vsce
           VERSION="$(node -p "require('./vscode/package.json').version")"
           # Idempotent like the npm publish so re-running a tag is safe. `vsce
@@ -120,8 +136,12 @@ jobs:
           # publish); a match means this version is already live → skip.
           if "$VSCE" show kdrrr.overcast --json 2>/dev/null | grep -q "\"version\": \"$VERSION\""; then
             echo "kdrrr.overcast@$VERSION is already on the Marketplace — skipping publish."
+          elif [ "$HAVE_OIDC" = "true" ]; then
+            "$VSCE" publish --azure-credential --packagePath .dev/*.vsix
+          elif [ -n "$VSCE_PAT" ]; then
+            "$VSCE" publish -p "$VSCE_PAT" --packagePath .dev/*.vsix
           else
-            "$VSCE" publish --packagePath .dev/*.vsix
+            echo "No Marketplace auth configured (set the AZURE_* variables for OIDC, or VSCE_PAT) — skipping (see RELEASING.md)."
           fi
       - name: Publish to Open VSX
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,16 @@ jobs:
       - run: npm run --prefix vscode build
       - run: npm run --prefix vscode test
       - run: mkdir -p .dev && npm run --prefix vscode package
+      # Attach the .vsix to the Release BEFORE publishing, so the downloadable
+      # artifact is guaranteed even if a Marketplace/Open VSX publish later fails
+      # (a bad PAT, a registry hiccup) — the manual download+upload path always
+      # has a file to grab.
+      - name: Attach the .vsix to the GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: .dev/*.vsix
+          fail_on_unmatched_files: true
       - name: Publish to the VS Code Marketplace
         if: github.event_name == 'push'
         env:
@@ -128,12 +138,6 @@ jobs:
           else
             npx --yes ovsx@1.0.2 publish .dev/*.vsix -p "$OVSX_PAT"
           fi
-      - name: Attach the .vsix to the GitHub Release
-        if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: .dev/*.vsix
-          fail_on_unmatched_files: true
       - name: Upload the .vsix as a workflow artifact (manual run)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,12 @@ jobs:
             npm publish
           fi
 
-  # VS Code extension: package the .vsix and attach it to the same GitHub
-  # Release. Its version is stamped by scripts/sync-version.mjs (checked in the
-  # npm-publish job), so the .vsix always matches the tag.
+  # VS Code extension: package the .vsix, attach it to the same GitHub Release,
+  # and publish it to the VS Code Marketplace + Open VSX. Its version is stamped
+  # by scripts/sync-version.mjs (checked in the npm-publish job), so the .vsix
+  # always matches the tag. The publish steps are secret-gated (VSCE_PAT /
+  # OVSX_PAT — see RELEASING.md) and skip when the version is already live, so
+  # re-running a tag is safe and the job passes before the one-time setup.
   vsix:
     needs: npm-publish
     runs-on: ubuntu-latest
@@ -90,6 +93,41 @@ jobs:
       - run: npm run --prefix vscode build
       - run: npm run --prefix vscode test
       - run: mkdir -p .dev && npm run --prefix vscode package
+      - name: Publish to the VS Code Marketplace
+        if: github.event_name == 'push'
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "VSCE_PAT secret not set — skipping Marketplace publish (see RELEASING.md)."
+            exit 0
+          fi
+          VSCE=vscode/node_modules/.bin/vsce
+          VERSION="$(node -p "require('./vscode/package.json').version")"
+          # Idempotent like the npm publish so re-running a tag is safe. `vsce
+          # show --json` lists every published version on its own line (and
+          # prints `undefined`, exit 0, before the first publish — no match →
+          # publish); a match means this version is already live → skip.
+          if "$VSCE" show kdrrr.overcast --json 2>/dev/null | grep -q "\"version\": \"$VERSION\""; then
+            echo "kdrrr.overcast@$VERSION is already on the Marketplace — skipping publish."
+          else
+            "$VSCE" publish --packagePath .dev/*.vsix
+          fi
+      - name: Publish to Open VSX
+        if: github.event_name == 'push'
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          if [ -z "$OVSX_PAT" ]; then
+            echo "OVSX_PAT secret not set — skipping Open VSX publish (see RELEASING.md)."
+            exit 0
+          fi
+          VERSION="$(node -p "require('./vscode/package.json').version")"
+          if curl -fsS "https://open-vsx.org/api/kdrrr/overcast/$VERSION" >/dev/null 2>&1; then
+            echo "kdrrr.overcast@$VERSION is already on Open VSX — skipping publish."
+          else
+            npx --yes ovsx@1.0.2 publish .dev/*.vsix -p "$OVSX_PAT"
+          fi
       - name: Attach the .vsix to the GitHub Release
         if: github.event_name == 'push'
         uses: softprops/action-gh-release@v3

--- a/README.md
+++ b/README.md
@@ -186,9 +186,8 @@ language-model tools when a chat provider is installed. Every action spawns
 
 Install it from the
 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kdrrr.overcast)
-(search "Overcast", or `ext install kdrrr.overcast`) — Cursor / VSCodium /
-Windsurf users, from [Open VSX](https://open-vsx.org/extension/kdrrr/overcast).
-Alternatively, install the `overcast-<version>.vsix` attached to the
+(search "Overcast", or `ext install kdrrr.overcast`), or install the
+`overcast-<version>.vsix` attached to the
 [latest release](https://github.com/kdr/overcast/releases) (`code
 --install-extension overcast-<version>.vsix`, or "Install from VSIX…" in the
 Extensions view), or build it from source:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ such as qmd before clearing local state.
 
 ## VS Code extension
 
-**[Overcast for VS Code](vscode/README.md)** (`vscode/`, sideloaded `.vsix`) puts
+**[Overcast for VS Code](vscode/README.md)** (`vscode/`, extension id
+[`kdrrr.overcast`](https://marketplace.visualstudio.com/items?itemName=kdrrr.overcast)) puts
 the situation room in your editor as a thin client of this CLI: right-click any
 media file for the senses (watch / listen / see / faces / EXIF / …), an
 activity-bar view with a command deck laid out along the intelligence cycle plus
@@ -183,14 +184,18 @@ language-model tools when a chat provider is installed. Every action spawns
 `overcast … --json`; records land in the case and the sidebar follows the
 `.overcast/` store live.
 
-Install the `overcast-vscode-<version>.vsix` attached to the
+Install it from the
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kdrrr.overcast)
+(search "Overcast", or `ext install kdrrr.overcast`) — Cursor / VSCodium /
+Windsurf users, from [Open VSX](https://open-vsx.org/extension/kdrrr/overcast).
+Alternatively, install the `overcast-<version>.vsix` attached to the
 [latest release](https://github.com/kdr/overcast/releases) (`code
---install-extension overcast-vscode-<version>.vsix`, or "Install from VSIX…" in
-the Extensions view), or build it from source:
+--install-extension overcast-<version>.vsix`, or "Install from VSIX…" in the
+Extensions view), or build it from source:
 
 ```bash
 cd vscode && npm install && npm run build && npm run package
-code --install-extension ../.dev/overcast-vscode-*.vsix
+code --install-extension ../.dev/overcast-*.vsix
 ```
 
 ---

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,15 +7,12 @@ overcast ships from one source tree to four places on every release:
 - **GitHub Releases** — the standalone **bun binary**, cross-compiled for macOS
   (arm64/x64) and Linux (x64/arm64) and attached as
   `overcast-<os>-<arch>.tar.gz`.
-- **VS Code Marketplace + Open VSX** — the **VS Code extension**
-  (`kdrrr.overcast`), published from CI. The Marketplace uses **Entra ID
-  workload identity federation (OIDC)** — no stored PAT, like npm above (a
-  `VSCE_PAT` secret is an optional fallback); Open VSX uses an `OVSX_PAT` secret.
-  Each step skips when unconfigured or the version is already live. Open VSX
-  serves Cursor/VSCodium/Windsurf users.
-- **GitHub Releases** — the same extension packaged as
-  `overcast-<version>.vsix` (install via `code --install-extension …` or
-  "Install from VSIX…" in the Extensions view).
+- **GitHub Releases** — the **VS Code extension** packaged as
+  `overcast-<version>.vsix` and attached to the Release by CI. Publishing to the
+  **VS Code Marketplace** (`kdrrr.overcast`) is a **manual upload** of that
+  `.vsix` from the publisher manage page (see below); it can also be installed
+  straight from the `.vsix` (`code --install-extension …` or "Install from
+  VSIX…" in the Extensions view).
 - **Claude plugin + agent skills** — the `.claude-plugin/` manifests and
   `skills/` are read straight from the repo (GitHub), so they go live when the
   release commit lands on the default branch.
@@ -91,108 +88,31 @@ exists — the publish step is idempotent) and just build + attach the binaries.
 
 ---
 
-## One-time setup: VS Code Marketplace + Open VSX (maintainer)
+## Publishing the extension to the VS Code Marketplace (manual)
 
-Unlike npm's OIDC, the Marketplace has no publish-once bootstrap requirement —
-once the publisher and credential exist, CI can do the very first publish. Until
-then the publish steps log a skip and the release still succeeds.
+CI attaches `overcast-<version>.vsix` to every GitHub Release; putting it on the
+Marketplace is a **manual upload** of that file. (Automated publishing — PAT or
+Entra ID OIDC — was intentionally left out; the manual upload is the supported
+path here.)
 
-The extension publishes with **Microsoft Entra ID workload identity federation
-(OIDC)** — no stored PAT, the analog of this repo's npm trusted publishing.
-Microsoft's own docs describe this only for Azure Pipelines; the steps below are
-the **GitHub Actions** adaptation. (A PAT is still supported as a fallback — see
-the end of this section — but note that vsce PATs must be *global* ("All
-accessible organizations") PATs, which Microsoft **retires Dec 1 2026**, so OIDC
-is the durable path.)
+**One-time:** create the **`kdrrr` publisher** on
+<https://marketplace.visualstudio.com/manage> (it authenticates through an
+[Azure DevOps organization](https://dev.azure.com), so create one if prompted).
+The publisher id must match `publisher` in `vscode/package.json` (`kdrrr` — same
+story as npm: `kdr` is already taken on the Marketplace, we ship under `kdrrr`
+everywhere).
 
-### 1. Create the publisher
+**Each release:**
 
-Create an [Azure DevOps organization](https://dev.azure.com) (the Marketplace
-authenticates through it), then create the **`kdrrr` publisher** on
-<https://marketplace.visualstudio.com/manage>. The publisher id must match
-`publisher` in `vscode/package.json` (`kdrrr` — same story as npm: `kdr` is
-already taken on the Marketplace, we ship under `kdrrr` everywhere).
+1. On the Release for the tag, download `overcast-<version>.vsix`.
+2. Go to <https://marketplace.visualstudio.com/manage/publishers/kdrrr> →
+   **New extension → Visual Studio Code** (or the extension's `⋯` → **Update**
+   for a new version) and upload the `.vsix`.
 
-### 2. Create a user-assigned managed identity
-
-In the [Azure Portal](https://portal.azure.com) → **Managed Identities** →
-**Create**: any resource group / region, name e.g. `overcast-vsce-publish`. Open
-it and record its **Client ID**, **Subscription ID**, and **Tenant ID** (the
-tenant is on the identity's **Properties** / your Entra tenant). A managed
-identity is required (not a plain app registration): the Marketplace authorizes
-publishers by managed-identity **resource ID** in step 5.
-
-> The identity also needs a foothold on the subscription so the Azure CLI has a
-> subscription context when it mints the Marketplace token: Subscription →
-> **Access control (IAM)** → **Add role assignment** → **Reader** → assign to
-> the managed identity.
-
-### 3. Add a federated credential trusting this repo's `release` environment
-
-On the managed identity → **Settings → Federated credentials → Add credential**:
-
-| Field    | Value                                            |
-| -------- | ------------------------------------------------ |
-| Scenario | Other issuer                                     |
-| Issuer   | `https://token.actions.githubusercontent.com`    |
-| Subject  | `repo:kdr/overcast:environment:release`          |
-| Audience | `api://AzureADTokenExchange`                     |
-| Name     | e.g. `github-release`                            |
-
-The subject must match **exactly** (case-sensitive). It ties the credential to
-the GitHub Actions `release` environment (created in step 6), which is why the
-`vsix` job sets `environment: release` — without it the OIDC subject would be
-per-tag (`…:ref:refs/tags/vX.Y.Z`) and need a new credential every release.
-
-### 4. Get the managed identity's resource ID
-
-```bash
-az identity show -n overcast-vsce-publish -g <resource-group> --query id -o tsv
-# → /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/overcast-vsce-publish
-```
-
-(Or Portal → the identity → **Properties → Resource ID**.)
-
-### 5. Authorize the identity on the publisher
-
-On <https://marketplace.visualstudio.com/manage/publishers/kdrrr> → **Members** →
-**Add** → paste the managed identity's **resource ID** from step 4, role
-**Contributor**.
-
-### 6. Wire GitHub Actions
-
-- Repo **Settings → Environments → New environment** → name it **`release`**
-  (no protection rules needed — it exists only to give the OIDC token a stable
-  subject).
-- Repo **Settings → Secrets and variables → Actions → Variables** (the
-  **Variables** tab, not Secrets — these ids aren't sensitive). Add:
-  - `AZURE_CLIENT_ID` — the managed identity's Client ID
-  - `AZURE_TENANT_ID` — the tenant id
-  - `AZURE_SUBSCRIPTION_ID` — the subscription id
-
-That's it — the next `v*` tag authenticates via OIDC and publishes. The `vsix`
-job attaches the `.vsix` to the Release **before** the publish steps, so the
-download always exists even if a publish fails.
-
-### 7. Open VSX (optional — for Cursor/VSCodium/Windsurf users)
-
-Open VSX has no OIDC, so it stays token-based. Create an
-[Open VSX](https://open-vsx.org) account, sign the publisher agreement, create
-the `kdrrr` namespace (`npx ovsx create-namespace kdrrr -p <token>`), and store
-the token as the `OVSX_PAT` **secret**.
-
-### PAT fallback
-
-If OIDC isn't set up (or misbehaves), the Marketplace step falls back to a PAT
-when `AZURE_CLIENT_ID` is unset and the `VSCE_PAT` **secret** is present. Create
-it in Azure DevOps → User settings → **Personal access tokens** → New Token,
-**Organization: All accessible organizations**, **Scopes: Show all scopes →
-Marketplace → Manage**; `npx @vscode/vsce verify-pat kdrrr` checks it. To put
-the listing live by hand without a release, upload the current release's `.vsix`
-on the manage page (**New extension → Visual Studio Code**), or
-`npx @vscode/vsce publish --packagePath overcast-<v>.vsix -p <pat>`. Marketplace
-ingestion runs a malware scan; the listing goes live a few minutes after
-publish.
+Marketplace ingestion runs a malware scan; the listing goes live a few minutes
+after upload. The `.vsix` already carries the right identity
+(`Id="overcast" Publisher="kdrrr"` → `kdrrr.overcast`), so the upload is accepted
+as long as you're signed in as the `kdrrr` publisher.
 
 ---
 
@@ -239,11 +159,9 @@ Pushing the `vX.Y.Z` tag triggers `release.yml`, which:
 3. **Publishes to npm** over OIDC (skipped if that version is already on npm).
 4. Cross-compiles the bun binary for the four targets and attaches the tarballs
    to the GitHub Release for the tag.
-5. Builds + tests the VS Code extension, attaches `overcast-<version>.vsix` to
-   the same Release (before publishing, so the download always exists), then
-   publishes it to the **VS Code Marketplace** (Entra ID OIDC, PAT fallback) and
-   **Open VSX** (`OVSX_PAT`) — each step skips if unconfigured or the version is
-   already live there.
+5. Builds + tests the VS Code extension and attaches `overcast-<version>.vsix`
+   to the same Release. Putting it on the Marketplace is a **manual upload** —
+   see "Publishing the extension to the VS Code Marketplace" above.
 
 You can also run it manually from the Actions tab (**workflow_dispatch**) with the
 version as input; in that mode the binaries are uploaded as workflow artifacts
@@ -271,12 +189,11 @@ npm i -g @kdrrr/overcast@latest && overcast --version --json
 ```
 
 - Binaries: download a tarball from the release, `tar -xzf …`, run `./overcast --version`.
-- VS Code extension: `npx @vscode/vsce show kdrrr.overcast` shows the published
-  version (or check the
+- VS Code extension: after the manual upload, the
   [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=kdrrr.overcast)
-  and [Open VSX](https://open-vsx.org/extension/kdrrr/overcast)). To verify the
-  release asset itself: download the `.vsix`, `code --install-extension
-  overcast-<version>.vsix`, open the Overcast view.
+  shows the version (`npx @vscode/vsce show kdrrr.overcast` also works). To
+  verify the release asset itself: download the `.vsix`, `code
+  --install-extension overcast-<version>.vsix`, open the Overcast view.
 - Provenance: the npm package page shows a "Provenance" panel linking back to the run.
 - Plugin/skills: `/plugin marketplace add kdr/overcast` then `/plugin install overcast@overcast`,
   or `npx skills add kdr/overcast`.
@@ -295,16 +212,10 @@ npm i -g @kdrrr/overcast@latest && overcast --version --json
   version commit → `main` requires a PR. Use the PR-based flow above (the tag
   pushes fine on its own), or add an admin bypass to the `main` ruleset.
 - **2FA on the bootstrap publish** → `npm publish --otp=<code>`.
-- **Marketplace publish fails under OIDC** → usual causes: the federated
-  credential **subject** doesn't exactly equal `repo:kdr/overcast:environment:release`
-  (case-sensitive; the `vsix` job must keep `environment: release`); the managed
-  identity isn't a **Contributor** member of the `kdrrr` publisher; or the
-  `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID` **variables** are
-  missing/wrong. Check the "Azure login (OIDC)" step's log first.
-- **Marketplace publish 401/403 under the PAT fallback** → the PAT expired,
-  isn't scoped to **All accessible organizations** + Marketplace → Manage, or
-  belongs to a different org than the `kdrrr` publisher.
-  `npx @vscode/vsce verify-pat kdrrr` checks credentials without publishing.
-- **Re-running a release tag** → safe; the npm, Marketplace, and Open VSX
-  publish steps each no-op when the version is already live, and binary assets
-  are overwritten.
+- **Marketplace upload rejected (publisher mismatch)** → the `.vsix` must be
+  uploaded while signed in as the **`kdrrr`** publisher, and its manifest
+  `Publisher` must equal `kdrrr` (it does, from `vscode/package.json`). A `.vsix`
+  built before the `kdr` → `kdrrr` rename won't upload to this publisher.
+- **Re-running a release tag** → safe; the npm publish no-ops when the version
+  is already live and binary/`.vsix` assets are overwritten. The Marketplace
+  upload is manual and independent of re-runs.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,12 @@ overcast ships from one source tree to four places on every release:
 - **GitHub Releases** — the standalone **bun binary**, cross-compiled for macOS
   (arm64/x64) and Linux (x64/arm64) and attached as
   `overcast-<os>-<arch>.tar.gz`.
-- **GitHub Releases** — the **VS Code extension** packaged as
-  `overcast-vscode-<version>.vsix` (install via `code --install-extension …` or
+- **VS Code Marketplace + Open VSX** — the **VS Code extension**
+  (`kdrrr.overcast`), published from CI with the `VSCE_PAT` / `OVSX_PAT`
+  secrets (each step skips when its secret is absent or the version is already
+  live). Open VSX serves Cursor/VSCodium/Windsurf users.
+- **GitHub Releases** — the same extension packaged as
+  `overcast-<version>.vsix` (install via `code --install-extension …` or
   "Install from VSIX…" in the Extensions view).
 - **Claude plugin + agent skills** — the `.claude-plugin/` manifests and
   `skills/` are read straight from the repo (GitHub), so they go live when the
@@ -85,6 +89,35 @@ exists — the publish step is idempotent) and just build + attach the binaries.
 
 ---
 
+## One-time setup: VS Code Marketplace + Open VSX (maintainer, in a browser)
+
+Unlike npm's OIDC, the Marketplace has no publish-once bootstrap requirement —
+once the publisher and secret exist, CI can do the very first publish. Until
+then the publish steps log a skip and the release still succeeds.
+
+1. Create an [Azure DevOps organization](https://dev.azure.com) (the
+   Marketplace authenticates through it), then create the **`kdrrr`
+   publisher** on <https://marketplace.visualstudio.com/manage>. The publisher
+   id must match `publisher` in `vscode/package.json` (`kdrrr` — same story as
+   npm: `kdr` is already taken on the Marketplace, we ship under `kdrrr`
+   everywhere).
+2. Create a PAT with **Marketplace → Manage** scope and store it as the
+   `VSCE_PAT` repo secret. Make it an **org-scoped** PAT — Azure DevOps
+   *global* PATs retire **Dec 1 2026**. Sanity-check it without publishing:
+   `npx @vscode/vsce verify-pat kdrrr`.
+3. Optionally (for Cursor/VSCodium/Windsurf users): create an
+   [Open VSX](https://open-vsx.org) account, sign the publisher agreement,
+   create the `kdrrr` namespace (`npx ovsx create-namespace kdrrr -p <token>`),
+   and store the token as the `OVSX_PAT` repo secret.
+
+The next `v*` tag then publishes the extension automatically. To put the
+listing live without waiting for a release train, publish the current release's
+`.vsix` by hand: `npx @vscode/vsce publish --packagePath overcast-<v>.vsix -p
+<pat>` (or upload it on the manage page). Marketplace ingestion runs a malware
+scan; the listing goes live a few minutes after publish.
+
+---
+
 ## Cutting a release (0.0.1 and onward)
 
 `main` is protected (changes must go through a PR), so the version-bump **commit**
@@ -128,8 +161,10 @@ Pushing the `vX.Y.Z` tag triggers `release.yml`, which:
 3. **Publishes to npm** over OIDC (skipped if that version is already on npm).
 4. Cross-compiles the bun binary for the four targets and attaches the tarballs
    to the GitHub Release for the tag.
-5. Builds + tests the VS Code extension and attaches
-   `overcast-vscode-<version>.vsix` to the same Release.
+5. Builds + tests the VS Code extension, attaches `overcast-<version>.vsix` to
+   the same Release, and publishes it to the **VS Code Marketplace** and
+   **Open VSX** (each step skips if its secret is missing or the version is
+   already live there).
 
 You can also run it manually from the Actions tab (**workflow_dispatch**) with the
 version as input; in that mode the binaries are uploaded as workflow artifacts
@@ -157,8 +192,12 @@ npm i -g @kdrrr/overcast@latest && overcast --version --json
 ```
 
 - Binaries: download a tarball from the release, `tar -xzf …`, run `./overcast --version`.
-- VS Code extension: download the `.vsix` from the release, `code
-  --install-extension overcast-vscode-<version>.vsix`, open the Overcast view.
+- VS Code extension: `npx @vscode/vsce show kdrrr.overcast` shows the published
+  version (or check the
+  [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=kdrrr.overcast)
+  and [Open VSX](https://open-vsx.org/extension/kdrrr/overcast)). To verify the
+  release asset itself: download the `.vsix`, `code --install-extension
+  overcast-<version>.vsix`, open the Overcast view.
 - Provenance: the npm package page shows a "Provenance" panel linking back to the run.
 - Plugin/skills: `/plugin marketplace add kdr/overcast` then `/plugin install overcast@overcast`,
   or `npx skills add kdr/overcast`.
@@ -177,5 +216,9 @@ npm i -g @kdrrr/overcast@latest && overcast --version --json
   version commit → `main` requires a PR. Use the PR-based flow above (the tag
   pushes fine on its own), or add an admin bypass to the `main` ruleset.
 - **2FA on the bootstrap publish** → `npm publish --otp=<code>`.
-- **Re-running a release tag** → safe; the publish step no-ops when the version is
-  already on npm, and binary assets are overwritten.
+- **Marketplace publish 401/403** → the PAT expired, lacks the Marketplace →
+  Manage scope, or belongs to a different org than the `kdrrr` publisher.
+  `npx @vscode/vsce verify-pat kdrrr` checks credentials without publishing.
+- **Re-running a release tag** → safe; the npm, Marketplace, and Open VSX
+  publish steps each no-op when the version is already live, and binary assets
+  are overwritten.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,20 +101,37 @@ then the publish steps log a skip and the release still succeeds.
    id must match `publisher` in `vscode/package.json` (`kdrrr` — same story as
    npm: `kdr` is already taken on the Marketplace, we ship under `kdrrr`
    everywhere).
-2. Create a PAT with **Marketplace → Manage** scope and store it as the
-   `VSCE_PAT` repo secret. Make it an **org-scoped** PAT — Azure DevOps
-   *global* PATs retire **Dec 1 2026**. Sanity-check it without publishing:
-   `npx @vscode/vsce verify-pat kdrrr`.
+2. Create the credential and store it as the `VSCE_PAT` repo secret — **two
+   options**, see the note below on which to pick:
+   - **PAT (simplest, works today):** in Azure DevOps → User settings →
+     Personal access tokens → New Token, set **Organization: All accessible
+     organizations** and **Scopes: Show all scopes → Marketplace → Manage**.
+     Sanity-check without publishing: `npx @vscode/vsce verify-pat kdrrr`.
+   - **Microsoft Entra ID workload identity federation (recommended):** no
+     stored secret — the analog of this repo's npm OIDC publishing. See the
+     note below.
 3. Optionally (for Cursor/VSCodium/Windsurf users): create an
    [Open VSX](https://open-vsx.org) account, sign the publisher agreement,
    create the `kdrrr` namespace (`npx ovsx create-namespace kdrrr -p <token>`),
    and store the token as the `OVSX_PAT` repo secret.
 
-The next `v*` tag then publishes the extension automatically. To put the
-listing live without waiting for a release train, publish the current release's
-`.vsix` by hand: `npx @vscode/vsce publish --packagePath overcast-<v>.vsix -p
-<pat>` (or upload it on the manage page). Marketplace ingestion runs a malware
-scan; the listing goes live a few minutes after publish.
+> **PAT vs. Entra ID — which to use.** A PAT is the quickest way to start and
+> is what the `VSCE_PAT`-gated workflow expects. But note the vsce publishing
+> PAT must be scoped to **All accessible organizations** (a *global* PAT), and
+> Microsoft **retires global PATs on Dec 1 2026** — so a PAT is a stopgap.
+> Microsoft's recommended path is **Entra ID workload identity federation**
+> (`vsce publish --azure-credential` after `azure/login` OIDC, with the managed
+> identity added as a publisher member) — no long-lived secret, matching this
+> repo's npm-OIDC posture. Migrate to it before Dec 2026; ref:
+> <https://code.visualstudio.com/api/working-with-extensions/publishing-extension#secure-automated-publishing-to-visual-studio-marketplace>.
+
+The next `v*` tag then publishes the extension automatically (CI attaches the
+`.vsix` to the Release *before* the publish steps, so the download always
+exists even if a publish fails). To put the listing live without waiting for a
+release train, publish the current release's `.vsix` by hand: `npx @vscode/vsce
+publish --packagePath overcast-<v>.vsix -p <pat>`, or upload it on the manage
+page (**New extension → Visual Studio Code**). Marketplace ingestion runs a
+malware scan; the listing goes live a few minutes after publish.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,9 +8,11 @@ overcast ships from one source tree to four places on every release:
   (arm64/x64) and Linux (x64/arm64) and attached as
   `overcast-<os>-<arch>.tar.gz`.
 - **VS Code Marketplace + Open VSX** — the **VS Code extension**
-  (`kdrrr.overcast`), published from CI with the `VSCE_PAT` / `OVSX_PAT`
-  secrets (each step skips when its secret is absent or the version is already
-  live). Open VSX serves Cursor/VSCodium/Windsurf users.
+  (`kdrrr.overcast`), published from CI. The Marketplace uses **Entra ID
+  workload identity federation (OIDC)** — no stored PAT, like npm above (a
+  `VSCE_PAT` secret is an optional fallback); Open VSX uses an `OVSX_PAT` secret.
+  Each step skips when unconfigured or the version is already live. Open VSX
+  serves Cursor/VSCodium/Windsurf users.
 - **GitHub Releases** — the same extension packaged as
   `overcast-<version>.vsix` (install via `code --install-extension …` or
   "Install from VSIX…" in the Extensions view).
@@ -89,49 +91,108 @@ exists — the publish step is idempotent) and just build + attach the binaries.
 
 ---
 
-## One-time setup: VS Code Marketplace + Open VSX (maintainer, in a browser)
+## One-time setup: VS Code Marketplace + Open VSX (maintainer)
 
 Unlike npm's OIDC, the Marketplace has no publish-once bootstrap requirement —
-once the publisher and secret exist, CI can do the very first publish. Until
+once the publisher and credential exist, CI can do the very first publish. Until
 then the publish steps log a skip and the release still succeeds.
 
-1. Create an [Azure DevOps organization](https://dev.azure.com) (the
-   Marketplace authenticates through it), then create the **`kdrrr`
-   publisher** on <https://marketplace.visualstudio.com/manage>. The publisher
-   id must match `publisher` in `vscode/package.json` (`kdrrr` — same story as
-   npm: `kdr` is already taken on the Marketplace, we ship under `kdrrr`
-   everywhere).
-2. Create the credential and store it as the `VSCE_PAT` repo secret — **two
-   options**, see the note below on which to pick:
-   - **PAT (simplest, works today):** in Azure DevOps → User settings →
-     Personal access tokens → New Token, set **Organization: All accessible
-     organizations** and **Scopes: Show all scopes → Marketplace → Manage**.
-     Sanity-check without publishing: `npx @vscode/vsce verify-pat kdrrr`.
-   - **Microsoft Entra ID workload identity federation (recommended):** no
-     stored secret — the analog of this repo's npm OIDC publishing. See the
-     note below.
-3. Optionally (for Cursor/VSCodium/Windsurf users): create an
-   [Open VSX](https://open-vsx.org) account, sign the publisher agreement,
-   create the `kdrrr` namespace (`npx ovsx create-namespace kdrrr -p <token>`),
-   and store the token as the `OVSX_PAT` repo secret.
+The extension publishes with **Microsoft Entra ID workload identity federation
+(OIDC)** — no stored PAT, the analog of this repo's npm trusted publishing.
+Microsoft's own docs describe this only for Azure Pipelines; the steps below are
+the **GitHub Actions** adaptation. (A PAT is still supported as a fallback — see
+the end of this section — but note that vsce PATs must be *global* ("All
+accessible organizations") PATs, which Microsoft **retires Dec 1 2026**, so OIDC
+is the durable path.)
 
-> **PAT vs. Entra ID — which to use.** A PAT is the quickest way to start and
-> is what the `VSCE_PAT`-gated workflow expects. But note the vsce publishing
-> PAT must be scoped to **All accessible organizations** (a *global* PAT), and
-> Microsoft **retires global PATs on Dec 1 2026** — so a PAT is a stopgap.
-> Microsoft's recommended path is **Entra ID workload identity federation**
-> (`vsce publish --azure-credential` after `azure/login` OIDC, with the managed
-> identity added as a publisher member) — no long-lived secret, matching this
-> repo's npm-OIDC posture. Migrate to it before Dec 2026; ref:
-> <https://code.visualstudio.com/api/working-with-extensions/publishing-extension#secure-automated-publishing-to-visual-studio-marketplace>.
+### 1. Create the publisher
 
-The next `v*` tag then publishes the extension automatically (CI attaches the
-`.vsix` to the Release *before* the publish steps, so the download always
-exists even if a publish fails). To put the listing live without waiting for a
-release train, publish the current release's `.vsix` by hand: `npx @vscode/vsce
-publish --packagePath overcast-<v>.vsix -p <pat>`, or upload it on the manage
-page (**New extension → Visual Studio Code**). Marketplace ingestion runs a
-malware scan; the listing goes live a few minutes after publish.
+Create an [Azure DevOps organization](https://dev.azure.com) (the Marketplace
+authenticates through it), then create the **`kdrrr` publisher** on
+<https://marketplace.visualstudio.com/manage>. The publisher id must match
+`publisher` in `vscode/package.json` (`kdrrr` — same story as npm: `kdr` is
+already taken on the Marketplace, we ship under `kdrrr` everywhere).
+
+### 2. Create a user-assigned managed identity
+
+In the [Azure Portal](https://portal.azure.com) → **Managed Identities** →
+**Create**: any resource group / region, name e.g. `overcast-vsce-publish`. Open
+it and record its **Client ID**, **Subscription ID**, and **Tenant ID** (the
+tenant is on the identity's **Properties** / your Entra tenant). A managed
+identity is required (not a plain app registration): the Marketplace authorizes
+publishers by managed-identity **resource ID** in step 5.
+
+> The identity also needs a foothold on the subscription so the Azure CLI has a
+> subscription context when it mints the Marketplace token: Subscription →
+> **Access control (IAM)** → **Add role assignment** → **Reader** → assign to
+> the managed identity.
+
+### 3. Add a federated credential trusting this repo's `release` environment
+
+On the managed identity → **Settings → Federated credentials → Add credential**:
+
+| Field    | Value                                            |
+| -------- | ------------------------------------------------ |
+| Scenario | Other issuer                                     |
+| Issuer   | `https://token.actions.githubusercontent.com`    |
+| Subject  | `repo:kdr/overcast:environment:release`          |
+| Audience | `api://AzureADTokenExchange`                     |
+| Name     | e.g. `github-release`                            |
+
+The subject must match **exactly** (case-sensitive). It ties the credential to
+the GitHub Actions `release` environment (created in step 6), which is why the
+`vsix` job sets `environment: release` — without it the OIDC subject would be
+per-tag (`…:ref:refs/tags/vX.Y.Z`) and need a new credential every release.
+
+### 4. Get the managed identity's resource ID
+
+```bash
+az identity show -n overcast-vsce-publish -g <resource-group> --query id -o tsv
+# → /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/overcast-vsce-publish
+```
+
+(Or Portal → the identity → **Properties → Resource ID**.)
+
+### 5. Authorize the identity on the publisher
+
+On <https://marketplace.visualstudio.com/manage/publishers/kdrrr> → **Members** →
+**Add** → paste the managed identity's **resource ID** from step 4, role
+**Contributor**.
+
+### 6. Wire GitHub Actions
+
+- Repo **Settings → Environments → New environment** → name it **`release`**
+  (no protection rules needed — it exists only to give the OIDC token a stable
+  subject).
+- Repo **Settings → Secrets and variables → Actions → Variables** (the
+  **Variables** tab, not Secrets — these ids aren't sensitive). Add:
+  - `AZURE_CLIENT_ID` — the managed identity's Client ID
+  - `AZURE_TENANT_ID` — the tenant id
+  - `AZURE_SUBSCRIPTION_ID` — the subscription id
+
+That's it — the next `v*` tag authenticates via OIDC and publishes. The `vsix`
+job attaches the `.vsix` to the Release **before** the publish steps, so the
+download always exists even if a publish fails.
+
+### 7. Open VSX (optional — for Cursor/VSCodium/Windsurf users)
+
+Open VSX has no OIDC, so it stays token-based. Create an
+[Open VSX](https://open-vsx.org) account, sign the publisher agreement, create
+the `kdrrr` namespace (`npx ovsx create-namespace kdrrr -p <token>`), and store
+the token as the `OVSX_PAT` **secret**.
+
+### PAT fallback
+
+If OIDC isn't set up (or misbehaves), the Marketplace step falls back to a PAT
+when `AZURE_CLIENT_ID` is unset and the `VSCE_PAT` **secret** is present. Create
+it in Azure DevOps → User settings → **Personal access tokens** → New Token,
+**Organization: All accessible organizations**, **Scopes: Show all scopes →
+Marketplace → Manage**; `npx @vscode/vsce verify-pat kdrrr` checks it. To put
+the listing live by hand without a release, upload the current release's `.vsix`
+on the manage page (**New extension → Visual Studio Code**), or
+`npx @vscode/vsce publish --packagePath overcast-<v>.vsix -p <pat>`. Marketplace
+ingestion runs a malware scan; the listing goes live a few minutes after
+publish.
 
 ---
 
@@ -179,9 +240,10 @@ Pushing the `vX.Y.Z` tag triggers `release.yml`, which:
 4. Cross-compiles the bun binary for the four targets and attaches the tarballs
    to the GitHub Release for the tag.
 5. Builds + tests the VS Code extension, attaches `overcast-<version>.vsix` to
-   the same Release, and publishes it to the **VS Code Marketplace** and
-   **Open VSX** (each step skips if its secret is missing or the version is
-   already live there).
+   the same Release (before publishing, so the download always exists), then
+   publishes it to the **VS Code Marketplace** (Entra ID OIDC, PAT fallback) and
+   **Open VSX** (`OVSX_PAT`) — each step skips if unconfigured or the version is
+   already live there.
 
 You can also run it manually from the Actions tab (**workflow_dispatch**) with the
 version as input; in that mode the binaries are uploaded as workflow artifacts
@@ -233,8 +295,15 @@ npm i -g @kdrrr/overcast@latest && overcast --version --json
   version commit → `main` requires a PR. Use the PR-based flow above (the tag
   pushes fine on its own), or add an admin bypass to the `main` ruleset.
 - **2FA on the bootstrap publish** → `npm publish --otp=<code>`.
-- **Marketplace publish 401/403** → the PAT expired, lacks the Marketplace →
-  Manage scope, or belongs to a different org than the `kdrrr` publisher.
+- **Marketplace publish fails under OIDC** → usual causes: the federated
+  credential **subject** doesn't exactly equal `repo:kdr/overcast:environment:release`
+  (case-sensitive; the `vsix` job must keep `environment: release`); the managed
+  identity isn't a **Contributor** member of the `kdrrr` publisher; or the
+  `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID` **variables** are
+  missing/wrong. Check the "Azure login (OIDC)" step's log first.
+- **Marketplace publish 401/403 under the PAT fallback** → the PAT expired,
+  isn't scoped to **All accessible organizations** + Marketplace → Manage, or
+  belongs to a different org than the `kdrrr` publisher.
   `npx @vscode/vsce verify-pat kdrrr` checks credentials without publishing.
 - **Re-running a release tag** → safe; the npm, Marketplace, and Open VSX
   publish steps each no-op when the version is already live, and binary assets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "Apache-2.0",
   "author": "kdr",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -106,7 +106,7 @@ replaceVersions("vscode/package.json", /^(  "version": ")([^"]*)(")/m, 1);
 // root "" packages entry — both directly follow the package name.
 replaceVersions(
   "vscode/package-lock.json",
-  /("name": "overcast-vscode",\n\s*"version": ")([^"]*)(")/g,
+  /("name": "overcast",\n\s*"version": ")([^"]*)(")/g,
   2
 );
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.80.3.
 
-export const OVERCAST_VERSION = "0.0.10";
+export const OVERCAST_VERSION = "0.0.11";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.80.3";

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -5,9 +5,10 @@ the overcast release train — it matches the root `package.json` version stampe
 by `scripts/sync-version.mjs`, so a given `.vsix` version pairs with the same
 CLI version.
 
-## Unreleased
+## 0.0.11
 
-Initial preview release.
+Initial preview release — first published to the VS Code Marketplace and Open
+VSX as `kdrrr.overcast`.
 
 - Right-click senses on any media file — Watch, Listen, See, Detect Faces,
   EXIF, Chronolocate, Enhance, Find Similar, Audio Fingerprint, Voice Match,

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,8 +7,8 @@ CLI version.
 
 ## 0.0.11
 
-Initial preview release — first published to the VS Code Marketplace and Open
-VSX as `kdrrr.overcast`.
+Initial preview release — first published to the VS Code Marketplace as
+`kdrrr.overcast`.
 
 - Right-click senses on any media file — Watch, Listen, See, Detect Faces,
   EXIF, Chronolocate, Enhance, Find Similar, Audio Fingerprint, Voice Match,

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -104,9 +104,7 @@ what to configure.
 **From the Marketplace** (recommended): search for **Overcast** in the
 Extensions view, or install
 [`kdrrr.overcast`](https://marketplace.visualstudio.com/items?itemName=kdrrr.overcast)
-directly (`ext install kdrrr.overcast` from Quick Open). Cursor / VSCodium /
-Windsurf users install the same extension from
-[Open VSX](https://open-vsx.org/extension/kdrrr/overcast).
+directly (`ext install kdrrr.overcast` from Quick Open).
 
 **From a GitHub release**: every
 [overcast release](https://github.com/kdr/overcast/releases) attaches

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -101,14 +101,19 @@ what to configure.
 
 ## Install
 
-Install the packaged `.vsix`.
+**From the Marketplace** (recommended): search for **Overcast** in the
+Extensions view, or install
+[`kdrrr.overcast`](https://marketplace.visualstudio.com/items?itemName=kdrrr.overcast)
+directly (`ext install kdrrr.overcast` from Quick Open). Cursor / VSCodium /
+Windsurf users install the same extension from
+[Open VSX](https://open-vsx.org/extension/kdrrr/overcast).
 
-**From a GitHub release** (recommended): every
+**From a GitHub release**: every
 [overcast release](https://github.com/kdr/overcast/releases) attaches
-`overcast-vscode-<version>.vsix`. Download it, then either run
+`overcast-<version>.vsix`. Download it, then either run
 
 ```bash
-code --install-extension overcast-vscode-<version>.vsix
+code --install-extension overcast-<version>.vsix
 ```
 
 or, in VS Code: **Extensions** view → `···` menu → **Install from VSIX…** and
@@ -120,6 +125,6 @@ pick the downloaded file.
 cd vscode
 npm install
 npm run build         # tsup (host → dist/extension.cjs) + vite (SPA → dist/webview)
-npm run package       # @vscode/vsce → ../.dev/overcast-vscode-<version>.vsix
-code --install-extension ../.dev/overcast-vscode-*.vsix
+npm run package       # @vscode/vsce → ../.dev/overcast-<version>.vsix
+code --install-extension ../.dev/overcast-*.vsix
 ```

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "overcast-vscode",
-  "version": "0.0.10",
+  "name": "overcast",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "overcast-vscode",
-      "version": "0.0.10",
+      "name": "overcast",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "overcast-vscode",
+  "name": "overcast",
   "displayName": "Overcast",
   "description": "The situation room in your editor — senses on your media (watch, listen, see, faces, EXIF via right-click), OSINT on your sources, and a wall to monitor the situation: maps, graphs, briefs, live feeds.",
-  "version": "0.0.10",
-  "publisher": "kdr",
+  "version": "0.0.11",
+  "publisher": "kdrrr",
   "private": true,
+  "preview": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Gets the VS Code extension ready to publish to the **VS Code Marketplace** (and **Open VSX**), and cuts **v0.0.11** so the published \`.vsix\` carries the final identity.

## Why
The extension only ever shipped as a release-attached \`.vsix\` — no actual publish step. The publisher \`kdrrr\` was just created on the Marketplace (\`kdr\` was taken, same as the npm \`@kdrrr\` story), so the manifest identity had to change **before** first publish (the extension id is permanent once published). The already-released v0.0.10 \`.vsix\` is stamped \`kdr.overcast-vscode\` and can't be uploaded to the \`kdrrr\` publisher, so this bumps to **v0.0.11** to produce a fresh \`overcast-0.0.11.vsix\` with \`Id="overcast" Publisher="kdrrr"\`.

## What
- **Identity (permanent):** \`name\` \`overcast-vscode\` → \`overcast\`, \`publisher\` \`kdr\` → \`kdrrr\` → extension id \`kdrrr.overcast\`; marked \`preview: true\`.
- **CI publish:** \`release.yml\` \`vsix\` job now publishes to the Marketplace (\`vsce publish\`) and Open VSX (\`ovsx publish\`). Both are **secret-gated** (\`VSCE_PAT\` / \`OVSX_PAT\` — log a skip and stay green until the secrets exist) and **idempotent** (skip when the version is already live), so re-running a tag is safe, exactly like the npm OIDC step.
- **Version sync:** \`sync-version.mjs\` tracks the renamed lockfile name; whole release train bumped 0.0.10 → 0.0.11.
- **Docs:** both READMEs go Marketplace-first with the new \`overcast-<version>.vsix\` asset name; \`RELEASING.md\` gains the Marketplace/Open VSX one-time setup, verify, and troubleshooting sections.

## Verified locally
- \`sync-version --check\` ✓ (all surfaces at 0.0.11)
- root \`typecheck\` ✓, extension \`typecheck\` / \`build\` / \`test\` (52) ✓
- \`vsce package\` ✓ → \`overcast-0.0.11.vsix\`, manifest identity \`Id="overcast" Publisher="kdrrr"\`
- no version leak into \`skills/\` (drift guard safe)

## Remaining (maintainer, browser — can't be automated)
1. Create org-scoped Azure DevOps PAT (Marketplace → Manage) → \`VSCE_PAT\` repo secret.
2. *(optional, for Cursor/VSCodium/Windsurf)* Open VSX \`kdrrr\` namespace + token → \`OVSX_PAT\`.

After merge, tag \`v0.0.11\` to trigger the release; CI then attaches \`overcast-0.0.11.vsix\` and (once \`VSCE_PAT\` is set) auto-publishes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and packaging metadata only; extension behavior and CI publish logic are unchanged aside from version sync and `.vsix` naming.
> 
> **Overview**
> Prepares the **VS Code extension** for first **Marketplace** listing under permanent id **`kdrrr.overcast`**: package **`name`** `overcast-vscode` → **`overcast`**, **`publisher`** `kdr` → **`kdrrr`**, and **`preview: true`**. Release artifacts are renamed to **`overcast-<version>.vsix`** (was `overcast-vscode-…`); **`scripts/sync-version.mjs`** updates the vscode lockfile regex to match the new package name.
> 
> The **release train** is bumped **0.0.10 → 0.0.11** on npm, CLI (`OVERCAST_VERSION`), Claude plugin manifests, and vscode packages. **`release.yml`** only adds a comment that Marketplace publish stays a **manual upload** of the CI-attached `.vsix` (see **`RELEASING.md`**).
> 
> **Docs** (`README.md`, `vscode/README.md`, `vscode/CHANGELOG.md`, **`RELEASING.md`**) now point installers at the Marketplace and document one-time **`kdrrr`** publisher setup, per-release upload steps, and publisher-mismatch troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8ce099be5b636ad10021eefd91970c2dd62215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->