### PR TITLE
Open-source hardening: security fixes + OSS scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Report a problem with a verb, provider, source, or the CLI/TUI
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Please **do not paste real targets, PII,
+        credentials, API keys, or case data** into this issue — redact anything
+        sensitive. Security vulnerabilities should go through
+        [SECURITY.md](../blob/main/SECURITY.md), not a public issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: Running `overcast watch clip.mp4` returned ... but I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact command(s). Redact any real paths/targets.
+      render: shell
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area?
+      description: The verb, source, or surface involved.
+      options:
+        - "Sense verb (watch / listen / see / face / etc.)"
+        - "OSINT source (scan / capture / monitor)"
+        - "Inspect/report (view / brief / map / graph / wall / situation)"
+        - "Provider setup / doctor / profiles"
+        - "Case / state (init / setup / target / finding / archive)"
+        - "pi extension / TUI / slash commands"
+        - "VS Code extension"
+        - "Build / install / packaging"
+        - "Other / not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: overcast doctor output
+      description: "Paste `overcast doctor` output (it reports tool/credential *presence* only — no key values)."
+      render: text
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: overcast version
+      description: Output of `overcast --version`.
+      placeholder: "0.0.10"
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: OS + Node version
+      placeholder: "macOS 15.5 / Node 22.5.0 (or 'bun binary')"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I redacted real targets, PII, credentials, and case data from this report.
+          required: true
+        - label: This is not a security vulnerability (those go through SECURITY.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/kdr/overcast/security/advisories/new
+    about: Please report vulnerabilities privately via GitHub Security Advisories — not as a public issue. See SECURITY.md.
+  - name: 💬 Questions & discussion
+    url: https://github.com/kdr/overcast/discussions
+    about: Ask a question, share a workflow, or propose an idea before filing an issue.
+  - name: 📖 Documentation
+    url: https://github.com/kdr/overcast#readme
+    about: README, docs/flows.md, and docs/providers.md cover setup, flows, and provider authoring.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest a new verb, provider/source, or improvement
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! For questions or open-ended discussion, prefer
+        [Discussions](../../discussions). New OSINT sources that reach personal
+        data must be **opt-in and never a default** — see
+        [RESPONSIBLE_USE.md](../blob/main/RESPONSIBLE_USE.md).
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem or use case?
+      description: What are you trying to do that overcast doesn't support well today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? A new verb, a source/provider, a flag, a report view?
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of change is this?
+      options:
+        - "New sense verb / capability"
+        - "New OSINT source or provider"
+        - "New inspect/report surface"
+        - "Improvement to an existing verb"
+        - "Developer experience / docs"
+        - "Other"
+    validations:
+      required: true
+  - type: checkboxes
+    id: responsible
+    attributes:
+      label: Responsible use
+      description: Only if this involves an OSINT source reaching personal data.
+      options:
+        - label: If this source reaches PII/biometrics, I understand it must be opt-in, non-default, and documented with its legal constraints.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- Thanks for contributing to overcast! Please fill this out so review is quick. -->
+
+## What & why
+
+<!-- What does this change do, and what problem does it solve? Link any issue: Fixes #123 -->
+
+## How was it verified?
+
+<!-- Which commands/tests did you run? For provider/record changes, mention the fixture/verb you exercised. -->
+
+## Checklist
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes (and `npm run test:e2e` if providers/records changed)
+- [ ] Regenerated `skills/` (`overcast skills generate`) if the verb registry changed
+- [ ] Did **not** bump the pinned `@earendil-works/*` versions (that's a separate, reviewed change)
+- [ ] Documented any new env var / provider in `.env.example` and the README
+- [ ] Commits are signed off (`git commit -s`) per the [DCO](../blob/main/CONTRIBUTING.md#sign-off-dco)
+
+## For new OSINT sources reaching personal data
+
+- [ ] N/A — not a PII-reaching source
+- [ ] The source is **opt-in and never a default binding**
+- [ ] It's documented in [`RESPONSIBLE_USE.md`](../blob/main/RESPONSIBLE_USE.md) with its legal constraints (ToS, DPPA/FCRA/biometric law as applicable)
+
+## Security-sensitive code
+
+- [ ] N/A
+- [ ] New outbound fetches go through the SSRF guard (`assertFetchHostAllowed`)
+- [ ] New `spawn`s pass arguments as an argv array (no `shell: true`); untrusted inputs are treated as hostile
+- [ ] New user-facing output that can contain provider data goes through `redactSecrets`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: codeql
+
+# Static analysis (SAST) for JavaScript/TypeScript. Complements Dependabot
+# (dependency updates) with source-level security scanning. Results land in the
+# repo's Security > Code scanning tab.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # weekly, so newly-published CodeQL queries catch existing code
+    - cron: "27 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended adds higher-signal security queries beyond the
+          # default set; drop to `security-and-quality` if noise is too high.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+title: >-
+  overcast — senses (video/audio/image) + OSINT reach for any agent
+message: If you use overcast in your research or reporting, please cite it.
+type: software
+authors:
+  - name: "kdr"
+repository-code: "https://github.com/kdr/overcast"
+url: "https://github.com/kdr/overcast#readme"
+abstract: >-
+  overcast is a portable toolkit that gives an agent senses (video, audio, and
+  image understanding) and OSINT reach (search, capture, monitor, reverse-image
+  and reverse-face lookup, and public-records sources), organized around an
+  investigation case. It is built on top of the pi agent harness and ships as a
+  pi package, a standalone binary, and agent skills.
+keywords:
+  - osint
+  - video-analysis
+  - investigation
+  - agent
+  - cli
+  - perception
+license: Apache-2.0
+version: 0.0.10
+date-released: "2026-07-17"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,120 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Using this project's OSINT capabilities to surveil, dox, stalk, or harass any
+  person (see [RESPONSIBLE_USE.md](RESPONSIBLE_USE.md))
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**kdr@cloudglue.dev**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved for a specified period of time. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating these
+terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to overcast
+
+Thanks for your interest in improving overcast! This guide covers how to get set
+up, the conventions that keep the project coherent, and what we look for in a
+pull request. Please also read our [Code of Conduct](CODE_OF_CONDUCT.md) and
+[Responsible Use](RESPONSIBLE_USE.md) policy.
+
+## Ways to contribute
+
+- **Report a bug** or **request a feature** via
+  [issues](https://github.com/kdr/overcast/issues) (templates provided).
+- **Ask a question** or share an idea in
+  [Discussions](https://github.com/kdr/overcast/discussions).
+- **Report a security issue** privately — see [SECURITY.md](SECURITY.md). Do not
+  file security reports as public issues.
+- **Open a pull request** — small, focused PRs are easiest to review.
+
+## Development setup
+
+Prerequisites: **Node.js ≥ 22** (with npm), plus the runtime tools overcast
+shells out to when you exercise the relevant verbs — **FFmpeg/ffprobe**, and
+optionally **tinycloud**, **ExifTool**, **c2patool**, **yt-dlp**, and a
+**uv**-managed Python for the local visual/audio DBs. See the README
+"Prerequisites" section for the full list. `bun` is only needed to build the
+compiled binary.
+
+```bash
+git clone https://github.com/kdr/overcast.git
+cd overcast
+npm ci                 # install (postinstall brands the pi base)
+npm run build          # tsup (dev build) + web consoles
+npm run typecheck      # tsc --noEmit for src + web/chair + web/situation
+npm test               # unit tests (offline, fixtures — no creds/network)
+npm run dev -- --help  # run the CLI from source (tsx)
+```
+
+Offline end-to-end tests use fixture providers and need no credentials:
+
+```bash
+npm run test:e2e       # offline e2e (bash test/e2e/run.sh)
+```
+
+The **live** suite (`npm run test:e2e:live`) hits real backends and needs keys —
+see [`test/e2e/README.md`](test/e2e/README.md) and copy `.env.example` to `.env`
+first. Never commit a real `.env` (it's git-ignored).
+
+## Architecture invariants — please don't break these
+
+overcast is built **on top of [pi](https://github.com/earendil-works/pi)** and is
+organized around a single source of truth. [`CLAUDE.md`](CLAUDE.md) is the
+detailed architecture guide (written for AI agents but accurate for humans) — the
+invariants that matter most for contributors:
+
+1. **Don't fork pi.** Reuse pi's loop, TUI, sessions, base tools, and provider
+   layer. overcast attaches as a pi **package/extension**; net-new code is the
+   verbs, providers, and record store.
+2. **One verb spec → three surfaces.** Declare each verb **once** in
+   `src/registry/verbs.ts`; the CLI subcommand, the pi AgentTool, and the skill
+   doc are generated from it. `overcast commands --json` is the authoritative
+   registry — verify against it, not memory.
+3. **`skills/` is generated.** If you change the verb registry, regenerate with
+   `overcast skills generate` and commit the result. CI fails if `skills/` is out
+   of sync.
+4. **Pinned dependencies stay pinned.** `@earendil-works/pi-*` are fixed at
+   **exactly `0.80.3`**. Don't float them; a pi bump is a deliberate, reviewed
+   change (Dependabot is configured to ignore them).
+5. **The record is loose.** The output contract is
+   `{ id, verb, format, payload, media?, meta?, error?, state? }` and nothing
+   more. Map provider output to the record at the exec boundary; don't
+   reintroduce a rigid envelope.
+6. **BYO LLM.** Never hardcode the brain provider. Keep the *brain* provider and
+   the *sense* providers separate.
+7. **Providers are pluggable via manifests.** Add a source/sense by authoring a
+   `provider.json` manifest, not by hand-listing it — see
+   [`docs/providers.md`](docs/providers.md). ffmpeg is internal, not a provider.
+
+When in doubt, match the surrounding code and keep pi touch-points isolated in
+`src/extension/` and `src/registry/to-agent-tool.ts` so a pi bump has a small
+blast radius.
+
+## Security-sensitive code
+
+Some areas carry hardening that has regression tests
+(`test/unit/audit-hardening.test.ts`) — please keep them green and add cases when
+you touch:
+
+- **Outbound fetches** must go through `assertFetchHostAllowed` / the SSRF guard
+  (`src/media/fetch.ts`). Don't add a new `fetch`/`curl`/`yt-dlp` path that skips
+  it.
+- **Spawning binaries** must pass arguments as an **argv array** (never a shell
+  string; no `shell: true`). Assume filenames/URLs/refs are attacker-controlled.
+- **Anything user-facing** (records, reports, logs, consoles) that can contain
+  provider output must go through `redactSecrets`.
+- **Untrusted content** (scraped, media) is a prompt-injection vector — see
+  invariant #10 in CLAUDE.md.
+
+## Adding a new source or sense provider
+
+Providers live in the top-level `providers/` tree, each with a `provider.json`
+manifest that the catalog scans at runtime. A new **OSINT source that reaches
+PII** must be **opt-in and never a default binding**, and must be documented in
+[`RESPONSIBLE_USE.md`](RESPONSIBLE_USE.md) with its legal constraints. See
+[`docs/providers.md`](docs/providers.md) for the authoring walkthrough and
+`overcast provider create` to scaffold one.
+
+## Pull request checklist
+
+Before opening a PR, please make sure:
+
+- [ ] `npm run typecheck` passes.
+- [ ] `npm test` passes (and `npm run test:e2e` if you touched providers/records).
+- [ ] `skills/` is regenerated if you changed the verb registry.
+- [ ] You didn't bump the pinned `@earendil-works/*` versions.
+- [ ] New env vars/providers are documented in `.env.example` and the README.
+- [ ] New PII-reaching sources are opt-in and noted in `RESPONSIBLE_USE.md`.
+- [ ] Commits are signed off (see below).
+
+CI runs typecheck, unit tests, offline e2e, the `skills/`-in-sync check, the
+VS Code extension checks, and `shellcheck -S warning` on shell providers.
+
+## Sign-off (DCO)
+
+We use the [Developer Certificate of Origin](https://developercertificate.org/).
+Certify that you wrote (or have the right to submit) your contribution by adding a
+`Signed-off-by` line to each commit:
+
+```bash
+git commit -s -m "your message"
+```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+project's [Apache-2.0 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -27,10 +27,32 @@ another backend or your own script with no code changes.
 
 ---
 
+> ### ⚠️ Responsible use & security model
+>
+> overcast is a **dual-use** tool. Its OSINT sources can reach personal
+> information about real people (reverse-face and reverse-image search,
+> skip-trace / people-search, phone, property, and license-plate lookups). Use
+> it **only for lawful purposes against targets you are authorized to
+> investigate.** The high-sensitivity sources are opt-in and never enabled by
+> default, and each carries legal constraints (DPPA, not-an-FCRA-report,
+> biometric-privacy law, third-party ToS). Read
+> **[RESPONSIBLE_USE.md](RESPONSIBLE_USE.md)** before you point it at anyone.
+>
+> By design, overcast runs an agent with **no sandbox or permission system**
+> (inherited from [pi](https://github.com/earendil-works/pi)) over **untrusted
+> media and scraped web content**, which are prompt-injection vectors. Run
+> investigations in an environment you're willing to expose to the material you
+> collect. See **[SECURITY.md](SECURITY.md)** for the full trust model and how
+> to report a vulnerability.
+
+---
+
 ## Install
 
 ### Prerequisites
 
+- **Node.js ≥ 22** (with npm) — required to install and run overcast. The
+  compiled `bun` binary bundles its own runtime, but `npm i -g` needs Node 22+.
 - **FFmpeg** — `ffmpeg` + `ffprobe` on your `PATH` (the internal media toolkit
   for `enhance`, frame extraction, detection crops, and `view`).
   `brew install ffmpeg` · `apt install ffmpeg` · <https://ffmpeg.org/download.html>
@@ -781,3 +803,25 @@ overcast doctor            # preflight
 `npm pack` runs `npm run pack:check` first. Build with `npm run build` before
 packing; if the ignored `dist/` tree is missing or stale, the pack fails with a
 message showing the version or command-registry drift.
+
+---
+
+## Contributing & community
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — dev setup, the architecture
+  invariants, how to add a provider, and the PR checklist.
+- **[RESPONSIBLE_USE.md](RESPONSIBLE_USE.md)** — the dual-use / acceptable-use
+  policy and per-source legal notes. Read this before using the OSINT sources.
+- **[SECURITY.md](SECURITY.md)** — the trust model and how to report a
+  vulnerability (privately, via GitHub Security Advisories).
+- **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)** — how we treat each other.
+- **[SUPPORT.md](SUPPORT.md)** — where to get help.
+- Questions and ideas → [Discussions](https://github.com/kdr/overcast/discussions);
+  bugs and features → [Issues](https://github.com/kdr/overcast/issues/new/choose).
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE). Built on top of
+[pi](https://github.com/earendil-works/pi). You are responsible for how you use
+this tool and for complying with all applicable laws and the terms of any
+third-party services you configure — see [RESPONSIBLE_USE.md](RESPONSIBLE_USE.md).

--- a/RESPONSIBLE_USE.md
+++ b/RESPONSIBLE_USE.md
@@ -1,0 +1,75 @@
+# Responsible Use
+
+overcast gives an agent **senses** (video / audio / image understanding) and
+**OSINT reach** (search, capture, monitor, reverse-image/-face lookup,
+skip-trace and public-records sources). Those are powerful, general-purpose
+capabilities. Like a camera, a search engine, or a network scanner, they can be
+used for legitimate investigation and journalism — or misused to surveil,
+harass, dox, or stalk. This document sets the boundary we expect every user to
+stay inside.
+
+**By using overcast you agree to use it only for lawful purposes and only
+against targets you are authorized to investigate.**
+
+## Use it for
+
+- Security research, red-team / blue-team, and CTF work **on systems and
+  accounts you own or are explicitly authorized to test**.
+- Open-source intelligence for journalism, research, fact-checking, and
+  incident response, conducted lawfully and ethically.
+- Analyzing **your own** media, or media you have the right to analyze.
+- Missing-person, disaster-response, and public-safety work by people
+  authorized to do it.
+
+## Do not use it for
+
+- Stalking, harassment, doxxing, intimidation, or building profiles of private
+  individuals without a lawful basis.
+- Surveillance of people who have a reasonable expectation of privacy.
+- Circumventing the Terms of Service of any third-party platform or data source.
+- Any use prohibited by law in your jurisdiction or the target's — including
+  data-protection law (GDPR, CCPA, and equivalents), anti-stalking law,
+  computer-misuse law, and sector-specific restrictions (below).
+- Automated decisions about a person's eligibility for credit, employment,
+  housing, or insurance. overcast is **not** a consumer-reporting tool and its
+  output is **not** an FCRA report.
+
+## The high-sensitivity sources
+
+Several sources reach **personal information about real, identifiable people**.
+They are **opt-in and never enabled by default** — you must deliberately bind
+and invoke them — and each carries legal constraints you are responsible for:
+
+| Source | What it reaches | Your responsibility |
+| --- | --- | --- |
+| `facesearch` | Reverse **face** search across the web | ToS/privacy-gated; many jurisdictions regulate biometric processing (e.g. BIPA, GDPR Art. 9). Get a lawful basis. |
+| `person` | People-search / skip-trace (addresses, phones, relatives, age) | **Not** an FCRA consumer report — never use for credit/employment/housing/insurance decisions. |
+| `phone` | Reverse-phone / number OSINT | Public-footprint only; don't use to harass or for prohibited screening. |
+| `property` | Assessor / tax / recorder records | Public records, but re-purposing them to target a resident can still be unlawful harassment. |
+| `plate` | License-plate → vehicle spec | Registered-**owner** data is **DPPA-restricted** in the US; overcast ships **no default actor** for this and returns vehicle spec only. |
+| `username` | Account discovery across many sites | Aggregating someone's accounts can constitute stalking if used to target them. |
+| `lens`, `yandeximg` | Reverse-image search | Can de-anonymize people in photos; use lawfully. |
+| `shodan`, `dork` | Host/service recon, Google dorking | Recon only; do not use to access systems without authorization. |
+
+overcast also **captures and stores** third-party media and scraped content in a
+case folder. You are the data controller for anything you collect. Retain only
+what you need, secure it, and delete it when your lawful basis ends.
+
+## Third-party services and their terms
+
+Many sources call third-party APIs and scraping actors (Apify, Google/Yandex,
+Serper, Shodan, Cloudglue/tinycloud, fal, and others). You bring your own keys
+and you are bound by **their** terms of service and rate limits as well as the
+law. overcast does not grant you any right to a third party's data.
+
+## No warranty; you are responsible
+
+overcast is provided under the Apache-2.0 license, **without warranty of any
+kind**. OSINT results can be wrong, stale, or point at the wrong person —
+treat every result as a **lead, not proof** (many verbs deliberately stamp
+`payload.caveat` to reinforce this). You are solely responsible for how you use
+this tool and for complying with all applicable laws and terms. The authors and
+contributors accept no liability for misuse.
+
+If your intended use doesn't clearly fit "Use it for" above, that's a signal to
+stop and reconsider.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,87 @@
+# Security Policy
+
+Thanks for helping keep overcast and its users safe. overcast is an
+investigation toolkit that handles untrusted media and adversarial web content,
+so we take security seriously and welcome good-faith research.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report privately through **GitHub Security Advisories**:
+[**Report a vulnerability**](https://github.com/kdr/overcast/security/advisories/new)
+(the "Report a vulnerability" button under the repository's **Security** tab).
+This creates a private thread with the maintainers.
+
+Please include:
+
+- A description of the issue and its impact.
+- The version / commit (`overcast --version`) and your platform.
+- Reproduction steps or a proof-of-concept, and any relevant `overcast doctor`
+  output. **Redact real targets, PII, credentials, and case data** from
+  anything you attach.
+
+We aim to acknowledge a report within **5 business days** and to keep you
+updated as we investigate. We'll credit reporters who want it once a fix ships.
+This is a volunteer-maintained open-source project, so please allow reasonable
+time before any public disclosure — we'll work with you on timing.
+
+## Scope — what is a vulnerability vs. by-design behavior
+
+overcast is a local, single-operator tool that deliberately gives an agent broad
+capabilities. Some behavior that looks alarming is **intentional and
+documented**. Understanding the trust model helps you report real issues:
+
+**By design (not vulnerabilities):**
+
+- **No sandbox / no permission system.** overcast runs on top of
+  [pi](https://github.com/earendil-works/pi) and inherits its model: base tools
+  (`read`/`write`/`edit`/`bash`/…) and providers run with the operator's own
+  privileges. Treat the whole tool as running as you.
+- **Untrusted media and scraped content are prompt-injection vectors.** overcast
+  ingests adversarial video, audio, images, and web pages and feeds them to an
+  LLM. Malicious content may attempt to steer the agent. Run investigations in
+  an environment you're willing to expose to the material you're collecting.
+- **Exec providers run with your environment.** A provider bound via `exec:` or
+  installed with `provider install` is third-party code that runs as you and,
+  today, inherits your environment (including API keys). Only install providers
+  you trust — the same bar as installing an npm package or a shell plugin. See
+  [`docs/providers.md`](docs/providers.md).
+- **Local servers exist but are loopback + token-gated.** `situation serve` and
+  `/chair` bind to `127.0.0.1` by default and require a 256-bit bearer token.
+  Binding to a wider interface (`--bind`, `tailnet`, `OVERCAST_*_BIND`) is an
+  explicit operator choice; do it only on networks you trust.
+
+**In scope (please report):**
+
+- Path traversal / arbitrary file read or write outside the case directory
+  (e.g. via the `/media` route, static asset serving, archive/case refs, or
+  provider-install tarball extraction).
+- Auth bypass on the `situation` / `chair` local servers, token leakage, or
+  missing constant-time comparison.
+- SSRF beyond the documented residual — a way to reach internal/loopback/cloud-
+  metadata hosts that defeats `assertFetchHostAllowed`, or an outbound fetch path
+  that never consults it. (The DNS-rebinding TOCTOU on the media/screenshot fetch
+  path is a **known residual** — see the code comments in `src/media/fetch.ts`;
+  a novel, more reliable bypass is still worth reporting.)
+- Command / argument injection into a spawned binary (ffmpeg, yt-dlp, tinycloud,
+  etc.) from a filename, URL, ref, or scraped field.
+- Credential/API-key leakage into persisted records, exported reports, logs, or
+  the web consoles (the `redactSecrets` boundary in `src/env.ts` is meant to
+  prevent this — a bypass is in scope).
+- Any way for scraped/untrusted content to achieve code execution or escape the
+  case directory beyond the documented prompt-injection stance.
+
+## Supported versions
+
+overcast is pre-1.0 and ships from `main`. Security fixes land on the latest
+released version on npm (`@kdrrr/overcast`) and the `main` branch. Please test
+against the latest release before reporting.
+
+## Handling your own case data
+
+Cases can contain sensitive media and PII. overcast stores everything locally in
+the case's `.overcast/` folder — nothing is uploaded except what you send to the
+third-party providers you configure. Secure your case directories accordingly,
+and see [`RESPONSIBLE_USE.md`](RESPONSIBLE_USE.md) for your obligations as the
+data controller.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,38 @@
+# Support
+
+Thanks for using overcast! Here's how to get help.
+
+## First, self-diagnose
+
+Most setup problems are a missing prerequisite or an unbound provider. Run:
+
+```bash
+overcast doctor            # checks pi, providers, ffmpeg, and credentials
+overcast doctor --sources  # also checks source credentials
+overcast commands --json   # the authoritative list of verbs and flags
+overcast <verb> --help     # a man page for any verb
+```
+
+The [README](README.md), [`docs/flows.md`](docs/flows.md) (end-to-end flows), and
+[`docs/providers.md`](docs/providers.md) (provider setup and authoring) cover most
+questions.
+
+## Where to go
+
+| I want to… | Go to |
+| --- | --- |
+| Ask a question / share a workflow / propose an idea | [Discussions](https://github.com/kdr/overcast/discussions) |
+| Report a reproducible bug | [Issues](https://github.com/kdr/overcast/issues/new/choose) |
+| Request a feature | [Issues](https://github.com/kdr/overcast/issues/new/choose) |
+| **Report a security vulnerability** | [Security Advisories](https://github.com/kdr/overcast/security/advisories/new) — **not** a public issue (see [SECURITY.md](SECURITY.md)) |
+| Contribute code | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+## Before filing an issue
+
+- Update to the latest release (`npm i -g @kdrrr/overcast@latest`) and re-check.
+- Include your `overcast --version`, OS, Node version, and `overcast doctor`
+  output.
+- **Redact real targets, PII, credentials, and case data** from anything you
+  paste.
+
+This is a community-maintained open-source project — please be patient and kind.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# overcast documentation
+
+The front-door [README](../README.md) covers what overcast is, install, and the
+verb surface. This folder holds the deeper references.
+
+| Doc | What's in it |
+| --- | --- |
+| [flows.md](flows.md) | End-to-end investigation flows — how the verbs chain into real workflows (scan → capture → sense → ask/brief). |
+| [providers.md](providers.md) | The provider model in depth: binding senses/sources, the profile system, and **authoring your own provider** (manifests, `provider install`). |
+| [../RESPONSIBLE_USE.md](../RESPONSIBLE_USE.md) | Dual-use / acceptable-use policy and per-source legal constraints. |
+| [../SECURITY.md](../SECURITY.md) | Trust model and vulnerability disclosure. |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | Dev setup, architecture invariants, and the PR checklist. |
+| [../RELEASING.md](../RELEASING.md) | Release process and versioning. |
+| [../CLAUDE.md](../CLAUDE.md) | The architecture guide (written for AI agents, accurate for humans) — invariants, stack, and the full verb surface. |
+
+Authoritative, always-current references:
+
+```bash
+overcast commands --json   # the verb registry — the source of truth
+overcast <verb> --help     # a man page for any verb
+overcast doctor            # what's installed / configured
+```

--- a/providers/engines/screenshot/render.mjs
+++ b/providers/engines/screenshot/render.mjs
@@ -99,11 +99,14 @@ function parseLooseIPv4(host) {
 function isBlockedIPv4(ip) {
   const a = (ip >>> 24) & 0xff;
   const b = (ip >>> 16) & 0xff;
+  const c = (ip >>> 8) & 0xff;
   if (a === 127 || a === 10 || a === 0) return true;
   if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254
   if (a === 192 && b === 168) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
   if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF protocol assignments
+  if (a >= 224) return true; // multicast 224/4 + reserved 240/4 (incl. broadcast)
   return false;
 }
 

--- a/providers/senses/exif/exif.sh
+++ b/providers/senses/exif/exif.sh
@@ -39,6 +39,9 @@ while [ "$#" -gt 0 ]; do case "$1" in
 esac; done
 need_exiftool
 [ -f "$input" ] || { jq -nc --arg i "$input" '{verb:"exif",format:"json",payload:{error:("file not found: "+$i)},error:"file not found",state:"error"}'; exit 0; }
+# A relative path beginning with '-' would be parsed by exiftool as an option
+# (e.g. -tagsFromFile / -w); prefix ./ so it stays a positional file operand.
+case "$input" in -*) input="./$input" ;; esac
 
 # -n = numeric values (signed decimal GPS via the Composite group), -json = one
 # object per file. Capture exiftool's exit status so a genuine failure (corrupt/

--- a/providers/senses/verify/verify.sh
+++ b/providers/senses/verify/verify.sh
@@ -45,6 +45,9 @@ while [ "$#" -gt 0 ]; do case "$1" in
 esac; done
 need_c2patool
 [ -f "$input" ] || { jq -nc --arg i "$input" '{verb:"verify",format:"json",payload:{error:("file not found: "+$i)},error:"file not found",state:"error"}'; exit 0; }
+# A relative path beginning with '-' would be parsed by c2patool as an option;
+# prefix ./ so it stays a positional file operand.
+case "$input" in -*) input="./$input" ;; esac
 
 errf="$(mktemp)"
 out="$("${C2PATOOL_CMD[@]}" "$input" 2>"$errf")"; code=$?

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,7 +2,11 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const SECRET_NAME_RE = /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASS|CREDENTIAL|AUTH)(?:_|$)/i;
-const SECRET_VALUE_RE = /\b(?:apify_api_[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{16,}|gh[opsu]_[A-Za-z0-9_]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,})\b/g;
+// High-precision provider key prefixes: redact a bare secret VALUE even when it
+// appears inline (e.g. embedded in a URL query string in provider stderr), where
+// the name-based `KEY=…` line redaction below can't see it. Prefixes only — no
+// generic hex/base64 (too many false positives on hashes/ids).
+const SECRET_VALUE_RE = /\b(?:apify_api_[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{16,}|gh[opsu]_[A-Za-z0-9_]{20,}|hf_[A-Za-z0-9]{20,}|AIza[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,})\b/g;
 const BASE_DOTENV_VALUES = new Map<string, string>();
 const OVERRIDE_DOTENV_VALUES = new Map<string, string>();
 

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -50,11 +50,14 @@ function parseLooseIPv4(host: string): number | null {
 function isBlockedIPv4(ip: number): boolean {
   const a = (ip >>> 24) & 0xff;
   const b = (ip >>> 16) & 0xff;
+  const c = (ip >>> 8) & 0xff;
   if (a === 127 || a === 10 || a === 0) return true; // loopback / private / this-host
   if (a === 169 && b === 254) return true; // link-local incl. cloud metadata 169.254.169.254
   if (a === 192 && b === 168) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
   if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF protocol assignments
+  if (a >= 224) return true; // multicast 224/4 + reserved 240/4 (incl. 255.255.255.255 broadcast)
   return false;
 }
 

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -643,8 +643,16 @@ function parseFindingsThresholds(raw: string): { thresholds: Record<string, numb
   return { thresholds, errors };
 }
 
-function quoteCommandArg(arg: string): string {
-  return /^[A-Za-z0-9_./:=@+-]+$/.test(arg) ? arg : JSON.stringify(arg);
+// Quote an argument for interpolation into the generated /bin/sh job script.
+// JSON.stringify (double quotes) is NOT sh-safe: `$(...)` and backticks still
+// execute inside a double-quoted string, so a case dir / --home / --profile
+// containing `$(cmd)` would run when the memory-index rebuild script executes.
+// Use POSIX single-quote escaping — everything between single quotes is literal;
+// an embedded single quote is closed, escaped, and reopened ('\''). The fast
+// path returns already-safe tokens verbatim so the stored command stays readable.
+export function quoteCommandArg(arg: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
 function incompletePlannedIndexes(setup: CaseSetup): SetupIndex[] {

--- a/src/verbs/provider-install.ts
+++ b/src/verbs/provider-install.ts
@@ -237,6 +237,27 @@ function stageSource(src: string): { staged: string; cleanup: () => void; error?
       cleanup();
       return { staged: "", cleanup: () => {}, error: `tarball has an unsafe member '${unsafe}' — refused (path traversal / absolute path)` };
     }
+    // Reject symlink/hardlink members BEFORE extraction. A symlink member
+    // (`d -> /outside`) followed by a regular member under it (`d/x`) can write
+    // THROUGH the symlink and escape the staging dir on tar builds that follow
+    // it — the post-extract hasUnsafePaths() scan runs too late to catch a file
+    // that already escaped. `-tv` prints the type char (l=symlink, h=hardlink)
+    // and the ` -> ` / ` link to ` notation across GNU and BSD tar. Packages
+    // already may not contain symlinks (hasUnsafePaths rejects them), so this
+    // only moves that check earlier to close the write-through window.
+    const vlist = spawnSync("tar", ["-tvzf", abs], { encoding: "utf8", timeout: 60_000 });
+    if (vlist.error || vlist.status !== 0) {
+      cleanup();
+      return { staged: "", cleanup: () => {}, error: `tar listing failed: ${(vlist.stderr || vlist.error?.message || "").slice(0, 200)}` };
+    }
+    const link = vlist.stdout
+      .split("\n")
+      .map((e) => e.trim())
+      .find((e) => e && (e[0] === "l" || e[0] === "h" || / -> | link to /.test(e)));
+    if (link) {
+      cleanup();
+      return { staged: "", cleanup: () => {}, error: `tarball has a link member '${link.slice(0, 120)}' — refused (symlink/hardlink escape)` };
+    }
     const res = spawnSync("tar", ["-xzf", abs, "-C", out], { encoding: "utf8", timeout: 60_000 });
     if (res.error || res.status !== 0) {
       cleanup();

--- a/src/verbs/provider-install.ts
+++ b/src/verbs/provider-install.ts
@@ -241,10 +241,13 @@ function stageSource(src: string): { staged: string; cleanup: () => void; error?
     // (`d -> /outside`) followed by a regular member under it (`d/x`) can write
     // THROUGH the symlink and escape the staging dir on tar builds that follow
     // it — the post-extract hasUnsafePaths() scan runs too late to catch a file
-    // that already escaped. `-tv` prints the type char (l=symlink, h=hardlink)
-    // and the ` -> ` / ` link to ` notation across GNU and BSD tar. Packages
-    // already may not contain symlinks (hasUnsafePaths rejects them), so this
-    // only moves that check earlier to close the write-through window.
+    // that already escaped. Discriminate on the TYPE CHAR (first column of
+    // `tar -tv`: l=symlink, h=hardlink) — authoritative across GNU and BSD tar.
+    // Do NOT match ` -> ` / ` link to ` in the line: those strings can appear in
+    // a regular file's NAME and would false-positive a valid package. Symlink
+    // detection (`l`) is the security-critical one; hasUnsafePaths rejects any
+    // symlink post-extract as a backstop, so this only closes the earlier
+    // write-through window.
     const vlist = spawnSync("tar", ["-tvzf", abs], { encoding: "utf8", timeout: 60_000 });
     if (vlist.error || vlist.status !== 0) {
       cleanup();
@@ -253,7 +256,7 @@ function stageSource(src: string): { staged: string; cleanup: () => void; error?
     const link = vlist.stdout
       .split("\n")
       .map((e) => e.trim())
-      .find((e) => e && (e[0] === "l" || e[0] === "h" || / -> | link to /.test(e)));
+      .find((e) => e[0] === "l" || e[0] === "h");
     if (link) {
       cleanup();
       return { staged: "", cleanup: () => {}, error: `tarball has a link member '${link.slice(0, 120)}' — refused (symlink/hardlink escape)` };

--- a/test/unit/audit-hardening.test.ts
+++ b/test/unit/audit-hardening.test.ts
@@ -12,6 +12,8 @@ import { readRecordsJSONL, newRecordId, makeRecord } from "../../src/record.ts";
 import { execCapture } from "../../src/providers/exec.ts";
 import { assertFetchHostAllowed, readBodyCapped, fetchMediaToCase } from "../../src/media/fetch.ts";
 import { writeFileAtomic } from "../../src/fs-atomic.ts";
+import { redactSecrets } from "../../src/env.ts";
+import { quoteCommandArg } from "../../src/verbs/case.ts";
 
 // --- C1: a torn JSONL line must not brick the whole store read ---------------
 
@@ -97,6 +99,17 @@ test("assertFetchHostAllowed blocks private/loopback/link-local host literals (C
 test("assertFetchHostAllowed allows public IP literals (no DNS)", async () => {
   const ok = ["https://8.8.8.8/x", "https://1.1.1.1/x", "https://172.32.0.1/x", "https://11.0.0.1/x", "https://[2001:db8::1]/x"];
   for (const u of ok) await assert.doesNotReject(assertFetchHostAllowed(u, { lookup: noLookup }), u);
+});
+
+test("assertFetchHostAllowed blocks multicast / reserved / broadcast / 192.0.0.0/24", async () => {
+  const blocked = [
+    "http://224.0.0.1/x", // multicast 224/4 lower
+    "http://239.255.255.250/x", // SSDP multicast
+    "http://240.0.0.1/x", // reserved 240/4
+    "http://255.255.255.255/x", // limited broadcast
+    "http://192.0.0.1/x", // 192.0.0.0/24 IETF protocol assignments
+  ];
+  for (const u of blocked) await assert.rejects(assertFetchHostAllowed(u, { lookup: noLookup }), /private\/loopback/, u);
 });
 
 test("assertFetchHostAllowed resolves a hostname and blocks a private DNS answer (rebinding)", async () => {
@@ -200,6 +213,42 @@ test("writeFileAtomic writes content and leaves no temp file (C2)", () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// --- quoteCommandArg: the memory-index job script must not be sh-injectable ---
+
+test("quoteCommandArg neutralizes $()/backtick/space so a case path can't inject", () => {
+  // a hostile case dir / --home / --profile carrying a command substitution
+  const payload = "/tmp/case$(touch /tmp/pwned)";
+  const q = quoteCommandArg(payload);
+  // single-quoted → everything literal; the `$(` is inside single quotes, inert
+  assert.equal(q, "'/tmp/case$(touch /tmp/pwned)'");
+  assert.ok(!/^"/.test(q), "must NOT use double quotes (which keep $()/backtick live)");
+  for (const bad of ["`id`", "a b", "$(id)", "x;y", "$HOME", "a'b"]) {
+    const out = quoteCommandArg(bad);
+    assert.ok(out.startsWith("'") && out.endsWith("'"), `${bad} → single-quoted`);
+  }
+  // an embedded single quote is closed/escaped/reopened, not left dangling
+  assert.equal(quoteCommandArg("a'b"), "'a'\\''b'");
+  // shell-safe tokens stay verbatim for a readable stored command line
+  assert.equal(quoteCommandArg("/abs/path.mp4"), "/abs/path.mp4");
+  assert.equal(quoteCommandArg("--json"), "--json");
+});
+
+// --- redactSecrets: added high-precision key prefixes are masked inline -------
+
+test("redactSecrets masks hf_/AIza/AKIA/xox tokens even inline in prose", () => {
+  const hf = "hf_" + "a".repeat(34);
+  const aiza = "AIza" + "B".repeat(35);
+  const akia = "AKIA" + "1234567890ABCDEF";
+  const slack = "xoxb-" + "1111111111-abcdefghij";
+  for (const secret of [hf, aiza, akia, slack]) {
+    const out = redactSecrets(`error fetching https://api.example/?key=${secret}&x=1`);
+    assert.ok(!out.includes(secret), `${secret.slice(0, 6)}… must be redacted`);
+    assert.ok(out.includes("[REDACTED]"));
+  }
+  // a plain word / short id is NOT redacted (no false positives)
+  assert.equal(redactSecrets("just a normal sentence with id 12345"), "just a normal sentence with id 12345");
 });
 
 // --- S1: every scripts/*.sh a skill instructs must ship in package.json -------

--- a/test/unit/provider-install.test.ts
+++ b/test/unit/provider-install.test.ts
@@ -316,6 +316,30 @@ test("install: refuses a tarball containing a symlink member (write-through esca
   rmSync(HOME, { recursive: true, force: true });
 });
 
+test("install: a regular file whose name contains ' -> ' is NOT misflagged as a link (Bugbot #118)", () => {
+  HOME = freshHome();
+  const work = mkdtempSync(join(tmpdir(), "oc-install-arrow-"));
+  const pkg = writeSourcePkg(work, "arrowpkg", "arrowtype");
+  // a regular file whose NAME contains the symlink/hardlink notation strings —
+  // the link check must key on the tar type char, not this text
+  writeFileSync(join(pkg, "a -> b link to c.txt"), "regular file, not a link");
+  const tgz = join(work, "arrow.tgz");
+  const made = spawnSync("tar", ["-czf", tgz, "-C", work, "arrowpkg"], { encoding: "utf8" });
+  // sanity: the odd name survived AND is listed as a regular file (type '-')
+  const vlist = spawnSync("tar", ["-tvzf", tgz], { encoding: "utf8" }).stdout || "";
+  const arrowLine = vlist.split("\n").find((l) => l.includes("a -> b link to c.txt"));
+  if (made.status !== 0 || !arrowLine || arrowLine.trim()[0] !== "-") {
+    rmSync(work, { recursive: true, force: true });
+    rmSync(HOME, { recursive: true, force: true });
+    return;
+  }
+  const r = rec(installProvider(tgz, { yes: true }));
+  assert.notEqual(r.state, "error", `must not reject a valid package: ${r.error ?? ""}`);
+  assert.doesNotMatch(r.error ?? "", /link member/);
+  rmSync(work, { recursive: true, force: true });
+  rmSync(HOME, { recursive: true, force: true });
+});
+
 test("builtinDescriptor resolves an installed source type at the target home (Bugbot #110)", () => {
   const savedEnv = process.env.OVERCAST_HOME;
   delete process.env.OVERCAST_HOME;

--- a/test/unit/provider-install.test.ts
+++ b/test/unit/provider-install.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, appendFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, appendFileSync, symlinkSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -279,6 +279,39 @@ test("install: refuses a tarball whose members escape via .. / absolute path (Bu
   assert.match(r.error ?? "", /unsafe member|path traversal/);
   assert.equal(existsSync(join(HOME, "escape.txt")), false, "nothing written outside the package dir");
 
+  rmSync(work, { recursive: true, force: true });
+  rmSync(HOME, { recursive: true, force: true });
+});
+
+test("install: refuses a tarball containing a symlink member (write-through escape)", () => {
+  HOME = freshHome();
+  const work = mkdtempSync(join(tmpdir(), "oc-install-symlink-"));
+  const pkg = join(work, "pkg");
+  mkdirSync(pkg, { recursive: true });
+  writeFileSync(join(pkg, "provider.json"), "{}");
+  // a symlink member pointing outside the staging dir — a follow-up file member
+  // under it could write through it during extraction, so install must refuse
+  // the tarball at listing time (before extraction).
+  try {
+    symlinkSync("/tmp", join(pkg, "escape"));
+  } catch {
+    rmSync(work, { recursive: true, force: true }); // platform without symlink support
+    rmSync(HOME, { recursive: true, force: true });
+    return;
+  }
+  const tgz = join(work, "sym.tgz");
+  const made = spawnSync("tar", ["-czf", tgz, "-C", pkg, "provider.json", "escape"], { encoding: "utf8" });
+  // verify the symlink actually survived AS a link member (some tars deref)
+  const vlist = spawnSync("tar", ["-tvzf", tgz], { encoding: "utf8" }).stdout || "";
+  const isLink = vlist.split("\n").some((l) => l.trim() && (l.trim()[0] === "l" || / -> | link to /.test(l)));
+  if (made.status !== 0 || !isLink) {
+    rmSync(work, { recursive: true, force: true });
+    rmSync(HOME, { recursive: true, force: true });
+    return;
+  }
+  const r = rec(installProvider(tgz, { yes: true }));
+  assert.equal(r.state, "error");
+  assert.match(r.error ?? "", /link member|symlink/);
   rmSync(work, { recursive: true, force: true });
   rmSync(HOME, { recursive: true, force: true });
 });


### PR DESCRIPTION
Prep for the launch: a second security-hardening pass plus the community/legal scaffolding a public repo needs. Two commits — security fixes, then docs/OSS files.

## Security hardening (commit 1)

Findings from a fresh multi-surface audit (process spawning, network/SSRF, secrets). The codebase was already well-hardened; these close what remained.

| Sev | Fix |
|---|---|
| **HIGH** | Command injection in `quoteCommandArg` (`src/verbs/case.ts`) — it used `JSON.stringify` (double quotes), so `$(...)`/backticks in a **case dir / `--home` / `--profile`** path still executed when the generated `/bin/sh` memory-index job ran. Now POSIX single-quote escaping. |
| **MED** | Provider-install tarball symlink/hardlink members now rejected at **list time** (`tar -tvzf`), before extraction — the post-extract scan couldn't stop a write-through a symlink member. |
| **LOW** | SSRF guard now blocks multicast `224/4`, reserved `240/4` (incl. broadcast), and `192.0.0.0/24` — in both `src/media/fetch.ts` and the screenshot engine's reimplemented guard. |
| **LOW** | `redactSecrets` covers more key formats (`hf_`, Google `AIza`, AWS `AKIA`, Slack `xox`). |
| **LOW** | `exif`/`verify` shell providers `./`-prefix a leading-dash path so it isn't parsed as a tool option. |

Regression tests added for each. **1186 unit tests pass; typecheck + shellcheck clean.**

### Deferred by design (documented in SECURITY.md, not silently changed)
- **DNS-rebind TOCTOU** on the media/screenshot fetch path — documented residual; a real fix needs an undici IP-pin dispatcher the compiled `bun` binary can't use.
- **Host-header validation** on the chair/situation servers — skipped: it would break the intended tailnet/`--bind` feature, and the 256-bit token already defeats rebinding.
- **`providerEnv` full-environment inheritance** to exec providers — documented as the trust model; scoping it would break providers that need their own keys.

## Docs + OSS scaffolding (commit 2)

- **RESPONSIBLE_USE.md** — dual-use acceptable-use policy + per-source legal notes (DPPA/plate, non-FCRA/person, biometric/facesearch, third-party ToS).
- **SECURITY.md** — private disclosure via GitHub Security Advisories + an explicit "by design vs. in scope" trust model.
- **CONTRIBUTING.md**, **CODE_OF_CONDUCT.md** (Contributor Covenant 2.1), **SUPPORT.md**, **CITATION.cff**, **docs/README.md** index.
- **.github/**: bug + feature issue forms (with a redaction reminder), `config.yml` routing security reports to advisories, `PULL_REQUEST_TEMPLATE.md`, and a **CodeQL** workflow.
- **README**: adds the missing **Node ≥ 22** prerequisite, a responsible-use + security-model callout above the fold, and a community/license footer.

## Notes / follow-ups
- Code of Conduct contact set to `kdr@cloudglue.dev` (placeholder for now — swap for a dedicated alias if preferred).
- To enable GitHub's private vulnerability reporting, turn on **Settings → Security → Private vulnerability reporting** so the SECURITY.md advisory link works.
- CodeQL uses `security-extended` queries; drop to `security-and-quality` if too noisy.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches command generation, tarball install, and outbound fetch guards—security-sensitive paths—but changes are defensive with tests; OSS files are docs/CI only.
> 
> **Overview**
> Prepares the repo for public launch with a **security hardening pass** and **community/OSS scaffolding**.
> 
> **Security fixes:** `quoteCommandArg` in `case.ts` now uses POSIX single-quote escaping instead of `JSON.stringify`, so hostile case/`--home`/`--profile` paths cannot inject into generated `/bin/sh` memory-index rebuild jobs. Provider install rejects symlink/hardlink tarball members at `tar -tvzf` listing time (before extraction). The SSRF guard in `fetch.ts` and the screenshot engine blocks multicast, reserved/broadcast, and `192.0.0.0/24`. `redactSecrets` adds inline patterns for Hugging Face, Google, AWS, and Slack keys. `exif` and `verify` shell providers prefix `./` on paths that start with `-` so tools do not treat them as CLI flags. Regression tests cover these changes.
> 
> **OSS scaffolding:** New `RESPONSIBLE_USE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `CITATION.cff`, and `docs/README.md`. GitHub bug/feature issue forms, issue config (security → advisories), PR template with security checklist, and a **CodeQL** workflow (`security-extended`). README adds Node ≥ 22, a responsible-use/security callout, and a contributing footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b955f88d9b4a67dfff7872aae0e3a84a32e14dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->