### PR TITLE
docs: expand Cursor Cloud setup notes for multi-repo workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,13 +473,26 @@ the generated `report.md`. Keep pi touch-points isolated in `src/extension/` and
 
 ## Cursor Cloud specific instructions
 
-The startup update script runs `npm ci` (root) and `npm ci --prefix vscode`; the
-root `postinstall` (`scripts/brand-pi.mjs`) runs automatically. `ffmpeg`/`ffprobe`
+The startup update script runs `npm ci` for the root, `vscode/`, and the sibling
+`overcast.video` marketing-site repo (all guarded by their `package.json`, via
+`npm --prefix`, so it is cwd-independent and safe if a repo is absent); the root
+`postinstall` (`scripts/brand-pi.mjs`) runs automatically. `ffmpeg`/`ffprobe`
 are already installed system-wide. Standard verb/test/build commands live in the
 `## Commands` section above and in `package.json` — reference those, not copies.
 
+This cloud workspace mounts two sibling repos under `/agent/repos/`: this one
+(`overcast`, the CLI toolkit) and `overcast.video` (a Vite + React + Tailwind
+marketing site — `npm run dev` on `http://localhost:5173`, `npm run lint` =
+oxlint, `npm run build` = `tsc -b && vite build`; see its own `README.md`).
+
 Non-obvious caveats for this environment:
 
+- **`bun` is NOT installed.** The dev build (`tsup`/`vite`), typecheck, `npm test`,
+ and offline `npm run test:e2e` all run under `node`. Only `npm run build:bun` and
+ `npm run test:e2e:live` need bun (plus live creds) and are not runnable as-is.
+- **Run the built CLI as `node dist/bin/overcast.js`** (no global `overcast` bin on
+ PATH); `npm run dev` (`tsx bin/overcast.ts`) runs it from source. A local case is
+ just a folder — `case init` in any dir, or `--case <dir>`.
 - **Node version.** The default `node` is 22.14.x, which runs the CLI, build,
  typecheck, and all test suites fine. `@earendil-works/pi-tui` declares
  `engines.node >= 22.19.0`, so `npm ci` prints an `EBADENGINE` **warning** (not an


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified the development environment for this Cloud workspace and expanded the `## Cursor Cloud specific instructions` in `CLAUDE.md` (symlinked as `AGENTS.md`) to reflect what I found. No product code changed — docs only.

The Cloud workspace mounts two sibling repos under `/agent/repos/`: `overcast` (the CLI toolkit) and `overcast.video` (the Vite + React marketing site). The startup update script now installs deps for all three `package.json`s (root, `vscode/`, and `overcast.video`), guarded and cwd-independent via `npm --prefix`.

### Doc additions
- Update script now covers the sibling `overcast.video` repo (guarded `npm --prefix` installs).
- `bun` is not installed — dev build, typecheck, unit + offline e2e all run under `node`; only `build:bun` / `test:e2e:live` need bun.
- Run the built CLI as `node dist/bin/overcast.js` (no global `overcast` on PATH).

## Verification performed

overcast (CLI toolkit):
- `npm run build` — tsup + vite web consoles built OK
- `npm run typecheck` — clean (src + web/chair + web/situation)
- `npm test` — 1187/1187 unit tests pass
- `SKIP_BUILD=1 npm run test:e2e` — 321/321 offline e2e pass
- hello-world: `case init` → `target add` → `chronolocate solve` (real evidence record) → `ask` cited it from case memory

overcast.video (marketing site):
- `npm run lint` (oxlint) — clean
- `npm run build` (`tsc -b && vite build`) — OK
- `npm run dev` — serves at `http://localhost:5173` (HTTP 200), rendered + interactive verified in browser

[overcast_video_site_walkthrough.mp4](https://cursor.com/agents/bc-5df4321a-bb18-4e7a-92f3-85ef0e3a744b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fovercast_video_site_walkthrough.mp4)

[overcast.video hero](https://cursor.com/agents/bc-5df4321a-bb18-4e7a-92f3-85ef0e3a744b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fovercast_video_hero.webp)
[overcast.video case files](https://cursor.com/agents/bc-5df4321a-bb18-4e7a-92f3-85ef0e3a744b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fovercast_video_casefiles.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5df4321a-bb18-4e7a-92f3-85ef0e3a744b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5df4321a-bb18-4e7a-92f3-85ef0e3a744b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

