### PR TITLE
security: clear all CodeQL alerts, then 24 rounds of review hardening

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,16 @@ jobs:
           # security-extended adds higher-signal security queries beyond the
           # default set; drop to `security-and-quality` if noise is too high.
           queries: security-extended
+          # Scan shipped source only. Test files are not distributed and handle
+          # no attacker input, but their ASSERTIONS trip the taint/URL queries:
+          # `assert.match(html, /tile\.openstreetmap\.org/)` reads as an
+          # unanchored host check, a fixture server's `hits[req.url]` counter as
+          # property injection. Rewriting assertions to appease a syntactic query
+          # makes them worse at their actual job, so scope the queries instead.
+          config: |
+            paths-ignore:
+              - test
+              - vscode/test
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,8 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   authenticated `/media` route with Range (a page served from http:// can't load
   `file://` like the static wall); remote embeds gated by
   `OVERCAST_REPORT_REMOTE_MEDIA`. Control plane = `.overcast/situation/`
-  (`runtime.json` discovery + `control.json`, consumed on the ~2s poll tick), so
+  (`runtime.json` discovery + an append-only `control.d/` patch log, drained on
+  the ~2s poll tick), so
   `situation set`/`stop` (CLI, agent tool, or chair→agent) retune/stop a running
   page cross-process. `/situation on` in the TUI runs the SAME server in-process,
   bound to the session lifecycle, as a viewer (the agent feeds it). Operational:

--- a/bin/overcast.ts
+++ b/bin/overcast.ts
@@ -3,7 +3,7 @@
 // directly, and otherwise launches the pi TUI with the overcast extension
 // attached (CLAUDE.md invariant #1: reuse pi's loop/TUI, don't fork).
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { runCli } from "../src/cli.js";
@@ -62,9 +62,17 @@ function ensureQuietStartup(): void {
   try {
     const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
     const file = join(agentDir, "settings.json");
-    const settings: Record<string, unknown> = existsSync(file)
-      ? (JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>)
-      : {};
+    // read-then-handle rather than existsSync-then-read: the exists check is a
+    // TOCTOU race (CodeQL js/file-system-race) and buys nothing here. Only a
+    // MISSING file falls back to defaults — a corrupt/unreadable settings.json
+    // must propagate to the outer catch so we never clobber real user settings.
+    let raw: string | undefined;
+    try {
+      raw = readFileSync(file, "utf8");
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+    const settings: Record<string, unknown> = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
     if (settings.quietStartup === undefined) {
       settings.quietStartup = true;
       mkdirSync(agentDir, { recursive: true });

--- a/bin/overcast.ts
+++ b/bin/overcast.ts
@@ -72,7 +72,11 @@ function ensureQuietStartup(): void {
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
     }
-    const settings: Record<string, unknown> = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    // `=== undefined`, not truthiness: an EMPTY settings.json is corrupt, not
+    // absent, and must reach JSON.parse so it throws to the outer catch and we
+    // skip the write — same as any other unparseable content.
+    const settings: Record<string, unknown> =
+      raw === undefined ? {} : (JSON.parse(raw) as Record<string, unknown>);
     if (settings.quietStartup === undefined) {
       settings.quietStartup = true;
       mkdirSync(agentDir, { recursive: true });

--- a/providers/sources/youtube/youtube.sh
+++ b/providers/sources/youtube/youtube.sh
@@ -234,14 +234,18 @@ case "$op" in
         fi
         # VTT → plain text: strip cue timings/headers/inline karaoke tags, drop
         # the rolling duplicate lines auto-captions emit, cap at 200KB (the full
-        # VTT stays as the file artifact). \r is stripped FIRST so CRLF VTTs
+        # VTT stays as the file artifact). The tag strip LOOPS to a fixed point
+        # (`:a … ta`) rather than running once: one pass matches `<` to the next
+        # `>`, so interleaved brackets leave residue — `<<b>b>hi` would keep a
+        # stray `b>`. Mirrors stripCueTags in the tinycloud watch mapper, which
+        # parses the same caption text. \r is stripped FIRST so CRLF VTTs
         # anchor like LF ones. A digit-only line is removed ONLY when the next
         # line is a cue TIMING (id + "-->" line = a VTT cue identifier), and
         # only real timing lines (with the arrow) are dropped — spoken numbers
         # ("2026") and spoken times ("12:30 news") are captions and survive.
         txf="$(mktemp)"
         if [ -n "$vtt" ] && [ -s "$vtt" ]; then
-          sed -E -e 's/\r$//' -e 's/<[^>]+>//g' "$vtt" \
+          sed -E -e 's/\r$//' -e ':a' -e 's/<[^<>]*>//g' -e 'ta' "$vtt" \
             | awk 'NR > 1 { if (!(prev ~ /^[0-9]+$/ && $0 ~ /^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?[.,][0-9][0-9][0-9] --> /)) print prev } { prev = $0 } END { if (NR > 0) print prev }' \
             | grep -Ev '^WEBVTT|^Kind:|^Language:|^NOTE( |$)|^[0-9]{2}:[0-9]{2}(:[0-9]{2})?[.,][0-9]{3} -->' \
             | awk 'NF' | awk '$0 != prev { print; prev = $0 }' \

--- a/providers/sources/youtube/youtube.sh
+++ b/providers/sources/youtube/youtube.sh
@@ -238,12 +238,18 @@ case "$op" in
         # pass, mirroring stripCueTags in the tinycloud watch mapper (same
         # caption text, same semantics): each `<` marks the kept-piece index and
         # the matching `>` rewinds to it, so nesting is handled in ONE traversal.
-        # It works over an ARRAY of characters (split once, printf the kept ones)
-        # rather than string ops: `out = out c` copies the growing string, and
-        # even `substr($0, i, 1)` per character rescans, so either makes a long
+        # It works over an ARRAY of characters (printf the kept ones) rather than
+        # string ops: `out = out c` copies the growing string, and even
+        # `substr($0, i, 1)` per character rescans, so either makes a long
         # provider-controlled caption line quadratic while the nesting logic
-        # stays single-pass. Measured on this shape: 800KB in one line went
-        # 11.2s → 0.73s, and time now doubles with size instead of quadrupling.
+        # stays single-pass. Measured: 800KB in one line went 11.2s → 0.73s, and
+        # time now doubles with size instead of quadrupling.
+        #
+        # Empty-separator `split` fills that array in one linear step, but it is
+        # a gawk/mawk/BWK extension rather than POSIX, so BEGIN probes for it and
+        # falls back to a per-character substr walk on an awk that lacks it. The
+        # fallback is quadratic on a pathological single line — correct output
+        # everywhere, fast where the extension exists.
         # A `sed` fixed-point loop peels one layer per pass (quadratic on deep
         # nesting); a plain depth counter swallows the rest of a cue after a lone
         # `<`. A bracket is markup only when it PAIRS, so spoken "x < y" and
@@ -255,7 +261,10 @@ case "$op" in
         txf="$(mktemp)"
         if [ -n "$vtt" ] && [ -s "$vtt" ]; then
           sed -E 's/\r$//' "$vtt" \
-            | awk '{ m = split($0, ch, ""); k = 0; top = 0
+            | awk 'BEGIN { SPLIT_CHARS = (split("ab", probe_, "") == 2) }
+                   { if (SPLIT_CHARS) m = split($0, ch, "")
+                     else { m = length($0); for (i = 1; i <= m; i++) ch[i] = substr($0, i, 1) }
+                     k = 0; top = 0
                      for (i = 1; i <= m; i++) {
                        c = ch[i]
                        if (c == "<") { mark[++top] = k; out[++k] = c }

--- a/providers/sources/youtube/youtube.sh
+++ b/providers/sources/youtube/youtube.sh
@@ -234,18 +234,29 @@ case "$op" in
         fi
         # VTT → plain text: strip cue timings/headers/inline karaoke tags, drop
         # the rolling duplicate lines auto-captions emit, cap at 200KB (the full
-        # VTT stays as the file artifact). The tag strip LOOPS to a fixed point
-        # (`:a … ta`) rather than running once: one pass matches `<` to the next
-        # `>`, so interleaved brackets leave residue — `<<b>b>hi` would keep a
-        # stray `b>`. Mirrors stripCueTags in the tinycloud watch mapper, which
-        # parses the same caption text. \r is stripped FIRST so CRLF VTTs
+        # VTT stays as the file artifact). The tag strip is a single MARK-STACK
+        # pass, mirroring stripCueTags in the tinycloud watch mapper (same
+        # caption text, same semantics): each `<` records the output length and
+        # the matching `>` rewinds to it, so nesting is handled in ONE traversal.
+        # A `sed` fixed-point loop peels one layer per pass (quadratic on deep
+        # nesting); a plain depth counter swallows the rest of a cue after a lone
+        # `<`. A bracket is markup only when it PAIRS, so spoken "x < y" and
+        # "2 > 1" survive. \r is stripped FIRST so CRLF VTTs
         # anchor like LF ones. A digit-only line is removed ONLY when the next
         # line is a cue TIMING (id + "-->" line = a VTT cue identifier), and
         # only real timing lines (with the arrow) are dropped — spoken numbers
         # ("2026") and spoken times ("12:30 news") are captions and survive.
         txf="$(mktemp)"
         if [ -n "$vtt" ] && [ -s "$vtt" ]; then
-          sed -E -e 's/\r$//' -e ':a' -e 's/<[^<>]*>//g' -e 'ta' "$vtt" \
+          sed -E 's/\r$//' "$vtt" \
+            | awk '{ s=$0; n=length(s); out=""; top=0
+                     for (i = 1; i <= n; i++) {
+                       c = substr(s, i, 1)
+                       if (c == "<") { top++; mark[top] = length(out); out = out c }
+                       else if (c == ">" && top > 0) { out = substr(out, 1, mark[top]); top-- }
+                       else { out = out c }
+                     }
+                     print out }' \
             | awk 'NR > 1 { if (!(prev ~ /^[0-9]+$/ && $0 ~ /^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?[.,][0-9][0-9][0-9] --> /)) print prev } { prev = $0 } END { if (NR > 0) print prev }' \
             | grep -Ev '^WEBVTT|^Kind:|^Language:|^NOTE( |$)|^[0-9]{2}:[0-9]{2}(:[0-9]{2})?[.,][0-9]{3} -->' \
             | awk 'NF' | awk '$0 != prev { print; prev = $0 }' \

--- a/providers/sources/youtube/youtube.sh
+++ b/providers/sources/youtube/youtube.sh
@@ -236,8 +236,14 @@ case "$op" in
         # the rolling duplicate lines auto-captions emit, cap at 200KB (the full
         # VTT stays as the file artifact). The tag strip is a single MARK-STACK
         # pass, mirroring stripCueTags in the tinycloud watch mapper (same
-        # caption text, same semantics): each `<` records the output length and
+        # caption text, same semantics): each `<` marks the kept-piece index and
         # the matching `>` rewinds to it, so nesting is handled in ONE traversal.
+        # It works over an ARRAY of characters (split once, printf the kept ones)
+        # rather than string ops: `out = out c` copies the growing string, and
+        # even `substr($0, i, 1)` per character rescans, so either makes a long
+        # provider-controlled caption line quadratic while the nesting logic
+        # stays single-pass. Measured on this shape: 800KB in one line went
+        # 11.2s → 0.73s, and time now doubles with size instead of quadrupling.
         # A `sed` fixed-point loop peels one layer per pass (quadratic on deep
         # nesting); a plain depth counter swallows the rest of a cue after a lone
         # `<`. A bracket is markup only when it PAIRS, so spoken "x < y" and
@@ -249,14 +255,15 @@ case "$op" in
         txf="$(mktemp)"
         if [ -n "$vtt" ] && [ -s "$vtt" ]; then
           sed -E 's/\r$//' "$vtt" \
-            | awk '{ s=$0; n=length(s); out=""; top=0
-                     for (i = 1; i <= n; i++) {
-                       c = substr(s, i, 1)
-                       if (c == "<") { top++; mark[top] = length(out); out = out c }
-                       else if (c == ">" && top > 0) { out = substr(out, 1, mark[top]); top-- }
-                       else { out = out c }
+            | awk '{ m = split($0, ch, ""); k = 0; top = 0
+                     for (i = 1; i <= m; i++) {
+                       c = ch[i]
+                       if (c == "<") { mark[++top] = k; out[++k] = c }
+                       else if (c == ">" && top > 0) { k = mark[top--] }
+                       else { out[++k] = c }
                      }
-                     print out }' \
+                     for (i = 1; i <= k; i++) printf "%s", out[i]
+                     printf "\n" }' \
             | awk 'NR > 1 { if (!(prev ~ /^[0-9]+$/ && $0 ~ /^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?[.,][0-9][0-9][0-9] --> /)) print prev } { prev = $0 } END { if (NR > 0) print prev }' \
             | grep -Ev '^WEBVTT|^Kind:|^Language:|^NOTE( |$)|^[0-9]{2}:[0-9]{2}(:[0-9]{2})?[.,][0-9]{3} -->' \
             | awk 'NF' | awk '$0 != prev { print; prev = $0 }' \

--- a/scripts/brand-pi.mjs
+++ b/scripts/brand-pi.mjs
@@ -64,12 +64,20 @@ function piPackageJsonPath() {
 
 function main() {
   const pkgPath = piPackageJsonPath();
-  if (!pkgPath || !existsSync(pkgPath)) {
-    // pi not installed yet (e.g. running before deps) — nothing to brand.
+  // read-then-handle, not existsSync-then-read: the exists check is a TOCTOU
+  // race (CodeQL js/file-system-race) and the read has to be fault-tolerant
+  // anyway — pi may not be installed yet (e.g. running before deps).
+  let raw;
+  try {
+    raw = pkgPath ? readFileSync(pkgPath, "utf8") : undefined;
+  } catch {
+    raw = undefined;
+  }
+  if (raw === undefined) {
     console.error("[brand-pi] pi-coding-agent not found; skipping rebrand");
     return;
   }
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  const pkg = JSON.parse(raw);
   pkg.piConfig = pkg.piConfig ?? {};
   if (pkg.piConfig.name === BRAND) {
     return; // already branded

--- a/src/extension/situation.ts
+++ b/src/extension/situation.ts
@@ -117,7 +117,7 @@ export function registerSituation(pi: ExtensionAPI): SituationHandle {
         // honor it instead of restarting over it (Bugbot #98/high: the restart
         // used to clearStaleStop it away and bring the page straight back up).
         const next = openCase(cur);
-        if (readControl(next)?.control.stop === true) {
+        if (readControl(next)?.stop === true) {
           optedOut = true;
           desired = false;
           sessionToken = undefined;

--- a/src/extension/situation.ts
+++ b/src/extension/situation.ts
@@ -7,7 +7,7 @@
 //
 // Like the chair, the LLM gets NO tool that can OPEN the listener: /situation
 // on is an operator command (invariant #10). The agent controls a running page
-// through the `situation` verb's agent-safe ops (status/set/stop → control.json,
+// through the `situation` verb's agent-safe ops (status/set/stop → control patches,
 // consumed by this in-process server's poll tick like any other).
 //
 // The TUI server is a VIEWER: it never owns a monitor cadence (--every). In a

--- a/src/extension/situation.ts
+++ b/src/extension/situation.ts
@@ -27,6 +27,7 @@ import {
   clearStaleStop,
   parsePanels,
   readControl,
+  controlBlocked,
   readRuntime,
   registerInProcessSituation,
   runtimeServing,
@@ -117,7 +118,12 @@ export function registerSituation(pi: ExtensionAPI): SituationHandle {
         // honor it instead of restarting over it (Bugbot #98/high: the restart
         // used to clearStaleStop it away and bring the page straight back up).
         const next = openCase(cur);
-        if (readControl(next)?.stop === true) {
+        // readControl only returns the APPLYABLE prefix, so a stop sitting
+        // behind an unreadable patch is invisible here. Treat a blocked log as
+        // "cannot confirm" and leave the page up rather than acting on a
+        // half-read queue — the server's own tick is equally stuck, so nothing
+        // is silently skipped.
+        if (!controlBlocked(next) && readControl(next)?.stop === true) {
           optedOut = true;
           desired = false;
           sessionToken = undefined;

--- a/src/extension/situation.ts
+++ b/src/extension/situation.ts
@@ -27,7 +27,6 @@ import {
   clearStaleStop,
   parsePanels,
   readControl,
-  controlBlocked,
   readRuntime,
   registerInProcessSituation,
   runtimeServing,
@@ -118,12 +117,13 @@ export function registerSituation(pi: ExtensionAPI): SituationHandle {
         // honor it instead of restarting over it (Bugbot #98/high: the restart
         // used to clearStaleStop it away and bring the page straight back up).
         const next = openCase(cur);
-        // readControl only returns the APPLYABLE prefix, so a stop sitting
-        // behind an unreadable patch is invisible here. Treat a blocked log as
-        // "cannot confirm" and leave the page up rather than acting on a
-        // half-read queue — the server's own tick is equally stuck, so nothing
-        // is silently skipped.
-        if (!controlBlocked(next) && readControl(next)?.stop === true) {
+        // readControl returns the APPLYABLE PREFIX, so a stop it can see is one
+        // the server's own tick can see too — honor it whether or not something
+        // further down the log is unreadable. Gating this on a blocked log (as
+        // an earlier pass did) makes the page start and then get stopped by that
+        // same tick a moment later: a flash-start for no reason. A stop hidden
+        // BEHIND a blocker is invisible to both of us, which is symmetric.
+        if (readControl(next)?.stop === true) {
           optedOut = true;
           desired = false;
           sessionToken = undefined;

--- a/src/fs-atomic.ts
+++ b/src/fs-atomic.ts
@@ -13,12 +13,16 @@ import { writeFileSync, renameSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, join, basename } from "node:path";
 import { randomBytes } from "node:crypto";
 
-export function writeFileAtomic(file: string, data: string): void {
+export function writeFileAtomic(file: string, data: string | Buffer): void {
   const dir = dirname(file);
   mkdirSync(dir, { recursive: true });
   const tmp = join(dir, `.${basename(file)}.${randomBytes(6).toString("hex")}.tmp`);
   try {
-    writeFileSync(tmp, data, "utf8");
+    // Buffers pass through unencoded — the crop frame cache publishes binary
+    // image bytes through this same rename, so "complete or absent" holds for
+    // media artifacts too, not just the JSON state stores.
+    if (typeof data === "string") writeFileSync(tmp, data, "utf8");
+    else writeFileSync(tmp, data);
     renameSync(tmp, file);
   } catch (err) {
     try {

--- a/src/fs-path.ts
+++ b/src/fs-path.ts
@@ -2,7 +2,9 @@
 
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
-import { closeSync, fstatSync, openSync, realpathSync, statSync } from "node:fs";
+import { closeSync, constants, fstatSync, openSync, realpathSync, statSync } from "node:fs";
+
+const { O_RDONLY, O_NOFOLLOW } = constants;
 
 /** True if `target` (which must already exist) resolves — THROUGH symlinks — to a
  *  path inside `root` (or root itself). Callers do the lexical + existence checks;
@@ -33,23 +35,29 @@ function inodeIdentityReliable(): boolean {
  *  on a different inode (TOCTOU) — containment says yes about one file while the
  *  server streams another.
  *
- *  Two layers, because neither is sufficient alone:
+ *  Three layers, because each covers a hole the others leave:
  *
  *  1. Resolve FIRST, then open the RESOLVED path. `realpathSync` output contains
- *     no symlinks, so the open cannot be redirected by swapping the caller's
- *     path or any link along it. This is the layer that carries platforms where
- *     inode identity is unusable.
- *  2. On POSIX, confirm the descriptor is the file that path still names, via
- *     dev+ino. That catches a component swapped in the remaining window between
- *     the resolve and the open.
+ *     no symlinks, so the open cannot be redirected by a link along the caller's
+ *     path. Legitimate symlinked assets still work — they were resolved.
+ *  2. Open with `O_NOFOLLOW`, so if the final component is REPLACED by a symlink
+ *     in the window between the resolve and the open, the open fails outright.
+ *     Without this the dev/ino check below cannot help: the open and the stat
+ *     both follow the new link and agree on the escaped target, confirming only
+ *     that the fd matches what the path names NOW — not that it is inside root.
+ *  3. On POSIX, dev+ino between the descriptor and the path, which rejects an
+ *     identity change landing between the open and the stat.
  *
- *  Windows is deliberately layer 1 only: Node fills dev/ino there from a
- *  different source per call and can report 0 or a disagreeing pair for an
- *  UNCHANGED file, so enforcing it would 404 every asset rather than catch
- *  anything. The residual exposure is a directory component replaced by a
- *  junction inside that narrow window, which needs write access within the root
- *  already — strictly better than the path-string check this replaced, and the
- *  best Node's API supports there.
+ *  Windows gets layer 1 only: `O_NOFOLLOW` is not supported there, and Node
+ *  fills dev/ino from a different source per call — it can report 0 or a
+ *  disagreeing pair for an UNCHANGED file, so enforcing layer 3 would 404 every
+ *  asset rather than catch anything.
+ *
+ *  Residual, documented rather than implied away: a DIRECTORY component of the
+ *  resolved path swapped for a link inside the same window (O_NOFOLLOW only
+ *  guards the final component), and a hard link or file substituted at the
+ *  resolved path itself. Both require write access inside the root already,
+ *  which is game over for a static asset dir regardless.
  *
  *  Everything downstream must use the fd, never the path — handing the path back
  *  would reopen the race. Returns undefined for anything unreadable, not a
@@ -60,7 +68,8 @@ export function openContainedFile(root: string, target: string): number | undefi
     const realRoot = realpathSync(root);
     const real = realpathSync(target);
     if (real !== realRoot && !real.startsWith(realRoot + sep)) return undefined;
-    fd = openSync(real, "r"); // the resolved path — no links left to swap
+    // O_NOFOLLOW is POSIX-only; `?? 0` degrades to a plain read elsewhere
+    fd = openSync(real, O_RDONLY | (O_NOFOLLOW ?? 0));
     const opened = fstatSync(fd);
     if (!opened.isFile()) throw new Error("not a regular file");
     if (inodeIdentityReliable()) {

--- a/src/fs-path.ts
+++ b/src/fs-path.ts
@@ -2,7 +2,7 @@
 
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
-import { realpathSync } from "node:fs";
+import { closeSync, fstatSync, openSync, realpathSync, statSync } from "node:fs";
 
 /** True if `target` (which must already exist) resolves — THROUGH symlinks — to a
  *  path inside `root` (or root itself). Callers do the lexical + existence checks;
@@ -16,6 +16,40 @@ export function realpathContained(root: string, target: string): boolean {
     return real === realRoot || real.startsWith(realRoot + sep);
   } catch {
     return false;
+  }
+}
+
+/** Open `target` for reading and prove the OPEN DESCRIPTOR is the file that
+ *  passed containment. `realpathContained` validates a path STRING; anything the
+ *  caller then does with that string re-resolves it, so a symlink swapped in
+ *  between lands on a different inode (TOCTOU) — the containment check says yes
+ *  about one file while the server streams another.
+ *
+ *  Opening first and matching the resolved path's dev+ino against the
+ *  descriptor's closes the window from both sides: a swap BEFORE the open is
+ *  caught by containment (which now runs against the new resolved path), and a
+ *  swap AFTER it by the inode mismatch. Everything downstream must use the fd,
+ *  never the path — handing the path back would reopen the race.
+ *
+ *  Returns undefined for anything unreadable, not a regular file, or outside
+ *  root. The caller owns closing the fd. */
+export function openContainedFile(root: string, target: string): number | undefined {
+  let fd: number | undefined;
+  try {
+    fd = openSync(target, "r");
+    const opened = fstatSync(fd);
+    if (!opened.isFile()) throw new Error("not a regular file");
+    const realRoot = realpathSync(root);
+    const real = realpathSync(target);
+    if (real !== realRoot && !real.startsWith(realRoot + sep)) throw new Error("outside root");
+    const resolved = statSync(real);
+    if (resolved.dev !== opened.dev || resolved.ino !== opened.ino) {
+      throw new Error("path no longer resolves to the opened file");
+    }
+    return fd;
+  } catch {
+    if (fd !== undefined) closeSync(fd);
+    return undefined;
   }
 }
 

--- a/src/fs-path.ts
+++ b/src/fs-path.ts
@@ -27,35 +27,42 @@ function inodeIdentityReliable(): boolean {
   return process.platform !== "win32";
 }
 
-/** Open `target` for reading and prove the OPEN DESCRIPTOR is the file that
- *  passed containment. `realpathContained` validates a path STRING; anything the
- *  caller then does with that string re-resolves it, so a symlink swapped in
- *  between lands on a different inode (TOCTOU) — the containment check says yes
- *  about one file while the server streams another.
+/** Open `target` for reading and return a descriptor proven to be a file inside
+ *  `root`. `realpathContained` validates a path STRING; anything the caller then
+ *  does with that string re-resolves it, so a symlink swapped in between lands
+ *  on a different inode (TOCTOU) — containment says yes about one file while the
+ *  server streams another.
  *
- *  Opening first and matching the resolved path's dev+ino against the
- *  descriptor's closes the window from both sides: a swap BEFORE the open is
- *  caught by containment (which now runs against the new resolved path), and a
- *  swap AFTER it by the inode mismatch. Everything downstream must use the fd,
- *  never the path — handing the path back would reopen the race.
+ *  Two layers, because neither is sufficient alone:
  *
- *  Returns undefined for anything unreadable, not a regular file, or outside
- *  root. The caller owns closing the fd. */
+ *  1. Resolve FIRST, then open the RESOLVED path. `realpathSync` output contains
+ *     no symlinks, so the open cannot be redirected by swapping the caller's
+ *     path or any link along it. This is the layer that carries platforms where
+ *     inode identity is unusable.
+ *  2. On POSIX, confirm the descriptor is the file that path still names, via
+ *     dev+ino. That catches a component swapped in the remaining window between
+ *     the resolve and the open.
+ *
+ *  Windows is deliberately layer 1 only: Node fills dev/ino there from a
+ *  different source per call and can report 0 or a disagreeing pair for an
+ *  UNCHANGED file, so enforcing it would 404 every asset rather than catch
+ *  anything. The residual exposure is a directory component replaced by a
+ *  junction inside that narrow window, which needs write access within the root
+ *  already — strictly better than the path-string check this replaced, and the
+ *  best Node's API supports there.
+ *
+ *  Everything downstream must use the fd, never the path — handing the path back
+ *  would reopen the race. Returns undefined for anything unreadable, not a
+ *  regular file, or outside root. The caller owns closing the fd. */
 export function openContainedFile(root: string, target: string): number | undefined {
   let fd: number | undefined;
   try {
-    fd = openSync(target, "r");
-    const opened = fstatSync(fd);
-    if (!opened.isFile()) throw new Error("not a regular file");
     const realRoot = realpathSync(root);
     const real = realpathSync(target);
-    if (real !== realRoot && !real.startsWith(realRoot + sep)) throw new Error("outside root");
-    // Identity check only where inode identity is meaningful. POSIX dev+ino
-    // uniquely names the file, so a mismatch proves a swap. Windows reports
-    // these from a different source per call and can hand back 0 or a
-    // disagreeing pair for an UNCHANGED file — enforcing it there would 404
-    // every static asset and /media response. Fall back to the realpath
-    // containment above, which is what this guarded before the fd was added.
+    if (real !== realRoot && !real.startsWith(realRoot + sep)) return undefined;
+    fd = openSync(real, "r"); // the resolved path — no links left to swap
+    const opened = fstatSync(fd);
+    if (!opened.isFile()) throw new Error("not a regular file");
     if (inodeIdentityReliable()) {
       const resolved = statSync(real);
       if (resolved.dev !== opened.dev || resolved.ino !== opened.ino) {

--- a/src/fs-path.ts
+++ b/src/fs-path.ts
@@ -19,6 +19,14 @@ export function realpathContained(root: string, target: string): boolean {
   }
 }
 
+/** Whether this platform's `dev`/`ino` pair is a trustworthy file identity.
+ *  POSIX: yes. Windows: Node fills these from a different source per call and
+ *  may report 0 or a disagreeing pair for the same unchanged file, so comparing
+ *  them there produces false "swapped" verdicts rather than catching real ones. */
+function inodeIdentityReliable(): boolean {
+  return process.platform !== "win32";
+}
+
 /** Open `target` for reading and prove the OPEN DESCRIPTOR is the file that
  *  passed containment. `realpathContained` validates a path STRING; anything the
  *  caller then does with that string re-resolves it, so a symlink swapped in
@@ -42,9 +50,17 @@ export function openContainedFile(root: string, target: string): number | undefi
     const realRoot = realpathSync(root);
     const real = realpathSync(target);
     if (real !== realRoot && !real.startsWith(realRoot + sep)) throw new Error("outside root");
-    const resolved = statSync(real);
-    if (resolved.dev !== opened.dev || resolved.ino !== opened.ino) {
-      throw new Error("path no longer resolves to the opened file");
+    // Identity check only where inode identity is meaningful. POSIX dev+ino
+    // uniquely names the file, so a mismatch proves a swap. Windows reports
+    // these from a different source per call and can hand back 0 or a
+    // disagreeing pair for an UNCHANGED file — enforcing it there would 404
+    // every static asset and /media response. Fall back to the realpath
+    // containment above, which is what this guarded before the fd was added.
+    if (inodeIdentityReliable()) {
+      const resolved = statSync(real);
+      if (resolved.dev !== opened.dev || resolved.ino !== opened.ino) {
+        throw new Error("path no longer resolves to the opened file");
+      }
     }
     return fd;
   } catch {

--- a/src/live/httpd.ts
+++ b/src/live/httpd.ts
@@ -15,7 +15,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readFileSync } from "node:fs";
 import { extname, resolve, sep } from "node:path";
 import { realpathContained } from "../fs-path.js";
 
@@ -332,14 +332,29 @@ export abstract class LiveHttpd<EIn extends object = Record<string, unknown>> {
     const file = resolve(root, rel === "" ? "index.html" : rel);
     // traversal guard: the resolved path must stay inside the assets dir
     if (file !== root && !file.startsWith(root + sep)) return this.json(res, 404, { error: "not found" });
-    if (!existsSync(file) || !statSync(file).isFile()) return this.json(res, 404, { error: "not found" });
     // symlink-safe: a link inside the assets dir must not serve a file outside it
     if (!realpathContained(root, file)) return this.json(res, 404, { error: "not found" });
-    res.writeHead(200, {
-      "Content-Type": CONTENT_TYPES[extname(file)] ?? "application/octet-stream",
-      "Cache-Control": "no-store",
-    });
-    res.end(readFileSync(file));
+    // Open ONCE, then stat and read THAT descriptor. The old exists → stat → read
+    // sequence re-resolved the path three times, so a symlink swapped in after the
+    // containment check could get served from outside the root (CodeQL
+    // js/file-system-race). A held fd is immune: it points at the inode we checked.
+    let fd: number;
+    try {
+      fd = openSync(file, "r");
+    } catch {
+      return this.json(res, 404, { error: "not found" });
+    }
+    try {
+      if (!fstatSync(fd).isFile()) return this.json(res, 404, { error: "not found" });
+      const body = readFileSync(fd);
+      res.writeHead(200, {
+        "Content-Type": CONTENT_TYPES[extname(file)] ?? "application/octet-stream",
+        "Cache-Control": "no-store",
+      });
+      res.end(body);
+    } finally {
+      closeSync(fd);
+    }
   }
 
   // --- auth --------------------------------------------------------------------

--- a/src/live/httpd.ts
+++ b/src/live/httpd.ts
@@ -15,9 +15,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
-import { closeSync, fstatSync, openSync, readFileSync } from "node:fs";
+import { closeSync, readFileSync } from "node:fs";
 import { extname, resolve, sep } from "node:path";
-import { realpathContained } from "../fs-path.js";
+import { openContainedFile } from "../fs-path.js";
 
 export interface LiveHttpdOptions {
   /** Bind address; default loopback. Never bind wildcard unless asked to. */
@@ -332,20 +332,13 @@ export abstract class LiveHttpd<EIn extends object = Record<string, unknown>> {
     const file = resolve(root, rel === "" ? "index.html" : rel);
     // traversal guard: the resolved path must stay inside the assets dir
     if (file !== root && !file.startsWith(root + sep)) return this.json(res, 404, { error: "not found" });
-    // symlink-safe: a link inside the assets dir must not serve a file outside it
-    if (!realpathContained(root, file)) return this.json(res, 404, { error: "not found" });
-    // Open ONCE, then stat and read THAT descriptor. The old exists → stat → read
-    // sequence re-resolved the path three times, so a symlink swapped in after the
-    // containment check could get served from outside the root (CodeQL
-    // js/file-system-race). A held fd is immune: it points at the inode we checked.
-    let fd: number;
+    // symlink-safe AND race-safe: the old exists → stat → read sequence re-resolved
+    // the path at each step, so a link swapped in after the containment check could
+    // be served from outside the root (CodeQL js/file-system-race). openContainedFile
+    // hands back a descriptor already proven to BE the contained file; read that.
+    const fd = openContainedFile(root, file);
+    if (fd === undefined) return this.json(res, 404, { error: "not found" });
     try {
-      fd = openSync(file, "r");
-    } catch {
-      return this.json(res, 404, { error: "not found" });
-    }
-    try {
-      if (!fstatSync(fd).isFile()) return this.json(res, 404, { error: "not found" });
       const body = readFileSync(fd);
       res.writeHead(200, {
         "Content-Type": CONTENT_TYPES[extname(file)] ?? "application/octet-stream",

--- a/src/providers/tinycloud/collection.ts
+++ b/src/providers/tinycloud/collection.ts
@@ -4,14 +4,14 @@
 // `ask --index` drives tcAsk. Each function returns the mapped record plus the
 // few extracted ids the verb needs to update its local mirror (state/index.ts).
 
-import { makeRecord, type OvercastRecord } from "../../record.js";
+import { makeRecord, stripUrlTail, type OvercastRecord } from "../../record.js";
 import { runTinycloud, type RunTinycloudOpts, type TinycloudOutcome } from "./envelope.js";
 
 const META = (op: string) => ({ provider: "tinycloud", model: "cloudglue", op });
 
 const base = (ref: unknown): string => {
   const s = typeof ref === "string" ? ref : "";
-  return s.replace(/[?#].*$/, "").replace(/\/+$/, "").split("/").pop() || s;
+  return stripUrlTail(s).replace(/\/+$/, "").split("/").pop() || s;
 };
 
 /** Normalize a collection file's status into ready / processing / failed. */

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -3,7 +3,7 @@
 // boundary (invariant #3). A comprehensive describe → flat payload with
 // content / transcript / detailed keys.
 
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readSync } from "node:fs";
 import { makeRecord, type OvercastRecord } from "../../record.js";
 import { redactSecrets } from "../../env.js";
 import {
@@ -58,31 +58,73 @@ function textFromVttCue(raw: string): { speaker?: string; text: string } | undef
   return { text: stripCueTags(cleaned).trim() };
 }
 
-/** Strip WebVTT cue tags (`<b>`, `<v Name>`, `<00:00.500>`, …) to a FIXED POINT.
- *  One pass is incomplete (CodeQL js/incomplete-multi-character-sanitization):
- *  each match runs `<` → the next `>`, so interleaved brackets leave residue —
- *  `<<b>b>hello<</i>i>` reduces to `b>helloi>`, not `hello`. Reports escape this
- *  text downstream, so it's tidiness + defense in depth on provider input rather
- *  than the last line of defense; loop until a pass changes nothing. */
+/** Strip WebVTT cue tags (`<b>`, `<v Name>`, `<00:00.500>`, …) in ONE linear
+ *  pass, tracking bracket depth.
+ *
+ *  A single regex pass is incomplete (CodeQL
+ *  js/incomplete-multi-character-sanitization): each match runs `<` → the next
+ *  `>`, so interleaved brackets leave residue — `<<b>b>hello` keeps a stray
+ *  `b>`. But re-running that regex to a fixed point only peels ONE nesting layer
+ *  per pass, so deeply nested provider text costs O(n²) and a crafted sidecar
+ *  could stall the mapper — trading an incomplete sanitizer for a slow one.
+ *
+ *  Depth counting gets both in O(n): everything between an unmatched `<` and its
+ *  closing `>` is dropped, at any nesting depth, in a single traversal. A `>`
+ *  with no open `<` is ordinary text and survives, so spoken "2 > 1" is intact.
+ *  A dangling unclosed `<foo` drops too, which the fixed point would have kept —
+ *  strictly safer, since a lone `<` is what could recombine downstream. */
 function stripCueTags(s: string): string {
-  let out = s;
-  for (;;) {
-    const next = out.replace(/<\/?[^<>]*>/g, "");
-    if (next === out) return out;
-    out = next;
+  const out: string[] = [];
+  let depth = 0;
+  for (const ch of s) {
+    if (ch === "<") depth++;
+    else if (ch === ">") { if (depth > 0) depth--; else out.push(ch); }
+    else if (depth === 0) out.push(ch);
+  }
+  return out.join("");
+}
+
+/** Cap for the provider-written sidecars (speech VTT, describe markdown). Real
+ *  ones for hour-long media land in the low MBs; past this we're being handed
+ *  something else. */
+const MAX_SIDECAR_BYTES = 16 * 1024 * 1024;
+
+/** Read at most `maxBytes` of a file as utf8, or undefined if it can't be read.
+ *  Sizes and reads the SAME descriptor, so nothing is re-resolved by path. */
+function readCappedUtf8(path: string, maxBytes: number): string | undefined {
+  let fd: number;
+  try {
+    fd = openSync(path, "r");
+  } catch {
+    return undefined;
+  }
+  try {
+    const want = Math.min(fstatSync(fd).size, maxBytes);
+    const buf = Buffer.alloc(want);
+    let read = 0;
+    while (read < want) {
+      const n = readSync(fd, buf, read, want - read, read);
+      if (n <= 0) break;
+      read += n;
+    }
+    return buf.subarray(0, read).toString("utf8");
+  } catch {
+    return undefined;
+  } finally {
+    closeSync(fd);
   }
 }
 
 /** Tinycloud full describe writes speech to a WebVTT sidecar. Convert it to a
  * readable speaker transcript so watch records expose spoken words inline. */
 function transcriptFromVttPath(path: string): string {
-  if (!existsSync(path)) return "";
-  let vtt = "";
-  try {
-    vtt = readFileSync(path, "utf8");
-  } catch {
-    return "";
-  }
+  // Bounded read off ONE descriptor: the sidecar is provider-controlled, so an
+  // unbounded readFileSync can be handed an arbitrarily large file, and the
+  // existsSync-then-read it replaces was the same check-then-use race this
+  // change set has been closing elsewhere. Over the cap we keep the leading
+  // bytes — a truncated transcript beats none, and beats an OOM.
+  const vtt = readCappedUtf8(path, MAX_SIDECAR_BYTES);
+  if (vtt === undefined) return "";
   const out: Array<{ speaker?: string; text: string }> = [];
   for (const block of vtt.split(/\n\s*\n/)) {
     const lines = block.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
@@ -146,13 +188,11 @@ function contentMarkdown(data: Record<string, unknown>): string {
   if (data.describe && typeof data.describe === "object") {
     const d = data.describe as Record<string, unknown>;
     const mdPath = d.markdown_path;
-    if (typeof mdPath === "string" && existsSync(mdPath)) {
-      try {
-        const md = readFileSync(mdPath, "utf8");
-        if (md.trim()) return md;
-      } catch {
-        /* fall through to synthesized content */
-      }
+    if (typeof mdPath === "string") {
+      // same capped, single-descriptor read as the VTT sidecar — both are
+      // provider-written files reached by path
+      const md = readCappedUtf8(mdPath, MAX_SIDECAR_BYTES);
+      if (md && md.trim()) return md;
     }
   }
 

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -58,28 +58,35 @@ function textFromVttCue(raw: string): { speaker?: string; text: string } | undef
   return { text: stripCueTags(cleaned).trim() };
 }
 
-/** Strip WebVTT cue tags (`<b>`, `<v Name>`, `<00:00.500>`, …) in ONE linear
- *  pass, tracking bracket depth.
+/** Strip WebVTT cue tags (`<b>`, `<v Name>`, `<00:00.500>`, …) in ONE pass.
  *
  *  A single regex pass is incomplete (CodeQL
  *  js/incomplete-multi-character-sanitization): each match runs `<` → the next
  *  `>`, so interleaved brackets leave residue — `<<b>b>hello` keeps a stray
- *  `b>`. But re-running that regex to a fixed point only peels ONE nesting layer
- *  per pass, so deeply nested provider text costs O(n²) and a crafted sidecar
- *  could stall the mapper — trading an incomplete sanitizer for a slow one.
+ *  `b>`. Re-running that regex to a fixed point fixes the residue but peels only
+ *  ONE nesting layer per pass, so deeply nested text costs O(n²).
  *
- *  Depth counting gets both in O(n): everything between an unmatched `<` and its
- *  closing `>` is dropped, at any nesting depth, in a single traversal. A `>`
- *  with no open `<` is ordinary text and survives, so spoken "2 > 1" is intact.
- *  A dangling unclosed `<foo` drops too, which the fixed point would have kept —
- *  strictly safer, since a lone `<` is what could recombine downstream. */
+ *  A mark stack gets both. Each `<` records the output length at that point; the
+ *  matching `>` rewinds the output to it, dropping the whole region — at any
+ *  nesting depth, in one traversal, amortized O(n).
+ *
+ *  A bracket only counts as markup when it PAIRS. An unmatched `<` (spoken
+ *  "x < y") and an unmatched `>` ("2 > 1") are ordinary text and survive intact
+ *  — a plain depth counter gets this wrong, swallowing the rest of the cue after
+ *  a lone `<`. This matches the fixed point's semantics exactly; it is only
+ *  faster. */
 function stripCueTags(s: string): string {
   const out: string[] = [];
-  let depth = 0;
+  const marks: number[] = []; // output length at each so-far-unmatched '<'
   for (const ch of s) {
-    if (ch === "<") depth++;
-    else if (ch === ">") { if (depth > 0) depth--; else out.push(ch); }
-    else if (depth === 0) out.push(ch);
+    if (ch === "<") {
+      marks.push(out.length);
+      out.push(ch);
+    } else if (ch === ">" && marks.length > 0) {
+      out.length = marks.pop() as number; // rewind over the matched <…> region
+    } else {
+      out.push(ch);
+    }
   }
   return out.join("");
 }

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -52,7 +52,22 @@ function textFromVttCue(raw: string): { speaker?: string; text: string } | undef
   if (!cleaned) return undefined;
   const voice = cleaned.match(/^<v\s+([^>]+)>(.*)<\/v>$/i);
   if (voice) return { speaker: voice[1].trim(), text: voice[2].trim() };
-  return { text: cleaned.replace(/<\/?[^>]+>/g, "").trim() };
+  return { text: stripCueTags(cleaned).trim() };
+}
+
+/** Strip WebVTT cue tags (`<b>`, `<v Name>`, `<00:00.500>`, …) to a FIXED POINT.
+ *  One pass is incomplete (CodeQL js/incomplete-multi-character-sanitization):
+ *  each match runs `<` → the next `>`, so interleaved brackets leave residue —
+ *  `<<b>b>hello<</i>i>` reduces to `b>helloi>`, not `hello`. Reports escape this
+ *  text downstream, so it's tidiness + defense in depth on provider input rather
+ *  than the last line of defense; loop until a pass changes nothing. */
+function stripCueTags(s: string): string {
+  let out = s;
+  for (;;) {
+    const next = out.replace(/<\/?[^<>]*>/g, "");
+    if (next === out) return out;
+    out = next;
+  }
 }
 
 /** Tinycloud full describe writes speech to a WebVTT sidecar. Convert it to a
@@ -69,7 +84,10 @@ function transcriptFromVttPath(path: string): string {
   for (const block of vtt.split(/\n\s*\n/)) {
     const lines = block.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
     if (!lines.length || lines[0] === "WEBVTT") continue;
-    const cue = lines.findIndex((l) => /-->/u.test(l));
+    // a WebVTT timing line, i.e. `00:00:01.000 --> 00:00:04.000` — match the
+    // digit-arrow-digit shape, not a bare `-->` (which also reads as an HTML
+    // comment terminator, CodeQL js/bad-tag-filter, and matches cue TEXT)
+    const cue = lines.findIndex((l) => /\d\s*-->\s*\d/u.test(l));
     if (cue < 0) continue;
     const parsed = textFromVttCue(lines.slice(cue + 1).join(" "));
     if (!parsed?.text) continue;

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -51,7 +51,10 @@ function textFromVttCue(raw: string): { speaker?: string; text: string } | undef
   const cleaned = raw.replace(/\s+/g, " ").trim();
   if (!cleaned) return undefined;
   const voice = cleaned.match(/^<v\s+([^>]+)>(.*)<\/v>$/i);
-  if (voice) return { speaker: voice[1].trim(), text: voice[2].trim() };
+  // strip BOTH halves of a voice cue, not just the fallback branch — tinycloud
+  // VTTs lean on `<v Name>`, and its body routinely carries nested `<b>`/`<i>`/
+  // timestamp tags that would otherwise survive verbatim into the transcript
+  if (voice) return { speaker: stripCueTags(voice[1]).trim(), text: stripCueTags(voice[2]).trim() };
   return { text: stripCueTags(cleaned).trim() };
 }
 

--- a/src/record.ts
+++ b/src/record.ts
@@ -138,7 +138,16 @@ export function memoryRecords(records: OvercastRecord[]): OvercastRecord[] {
   });
 }
 
-const VISUAL_EXT_RE = /\.(avif|bmp|gif|jpe?g|png|svg|webp)(?:[?#].*)?$/i;
+const VISUAL_EXT_RE = /\.(avif|bmp|gif|jpe?g|png|svg|webp)$/i;
+
+/** Drop a URL's `?query`/`#fragment` tail. Deliberately NOT a `/[?#].*$/` regex:
+ *  `.` stops at newlines, so `$` forces a retry from every later separator and a
+ *  crafted ref degrades to quadratic (CodeQL js/polynomial-redos). `search` +
+ *  `slice` is linear and does the same job. */
+export function stripUrlTail(s: string): string {
+  const cut = s.search(/[?#]/);
+  return cut < 0 ? s : s.slice(0, cut);
+}
 // deliberately NOT a bare `path`/`img` — the image-match payload carries
 // `db_img_path` (the reference frame) and `query_path` (a temp frame that's
 // deleted after the run); only the rendered `match_draw_path` overlay and real
@@ -155,7 +164,7 @@ export function collectVisualRefs(value: unknown): string[] {
   const refs = new Set<string>();
   const visit = (v: unknown, key = ""): void => {
     if (typeof v === "string") {
-      if (/^data:image\//i.test(v) || (VISUAL_EXT_RE.test(v) && VISUAL_KEY_RE.test(key))) refs.add(v);
+      if (/^data:image\//i.test(v) || (VISUAL_EXT_RE.test(stripUrlTail(v)) && VISUAL_KEY_RE.test(key))) refs.add(v);
       return;
     }
     if (Array.isArray(v)) {
@@ -292,7 +301,7 @@ export function recordStub(rec: Pick<OvercastRecord, "verb" | "payload"> & Parti
   }
   if (rec.verb === "capture") {
     const path = typeof p.path === "string" ? p.path : rec.media?.ref;
-    if (path) return clip(`captured ${path.replace(/[?#].*$/, "").split(/[\\/]/).pop() || path}`);
+    if (path) return clip(`captured ${stripUrlTail(path).split(/[\\/]/).pop() || path}`);
   }
   if (rec.verb === "scan" && typeof p.url === "string" && p.url) return clip(p.url);
   const op = typeof p.op === "string" ? p.op : undefined;

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { extname } from "node:path";
 import { pathToFileURL } from "node:url";
 import { envEnabled } from "../env.js";
-import { collectVisualRefs, PRIMARY_TEXT_FIELDS, recordStub, type OvercastRecord } from "../record.js";
+import { collectVisualRefs, PRIMARY_TEXT_FIELDS, recordStub, stripUrlTail, type OvercastRecord } from "../record.js";
 import { escapeHtml } from "./components.js";
 // mission is the shared model layer for thread cards / triage / coverage; the
 // graph is acyclic because escapeHtml + collectVisualRefs live below both
@@ -87,7 +87,7 @@ export interface TimelineSynthesis {
 }
 
 // (collectVisualRefs moved to record.ts — re-exported above.)
-const VISUAL_EXT_RE = /\.(avif|bmp|gif|jpe?g|png|svg|webp)(?:[?#].*)?$/i;
+const VISUAL_EXT_RE = /\.(avif|bmp|gif|jpe?g|png|svg|webp)$/i;
 
 export interface TimelineReport {
   title: string;
@@ -724,7 +724,7 @@ const VIDEO_EXT_RE = /\.(mp4|m4v|mov|webm|mkv|avi|mpe?g|ogv|3gp)$/i;
  *  serves extensionless variants under video.twimg.com) or a local video file. */
 function isVideoMediaRef(ref: string): boolean {
   if (/^https?:\/\//i.test(ref)) {
-    const path = ref.replace(/[?#].*$/, "");
+    const path = stripUrlTail(ref);
     return VIDEO_EXT_RE.test(path) || /^https?:\/\/video\.twimg\.com\//i.test(ref);
   }
   return VIDEO_EXT_RE.test(ref);
@@ -759,7 +759,7 @@ function mediaEmbed(record: TimelineRecord): string {
           parts.push(`<video class="embed" controls preload="none"${poster ? ` poster="${escapeHtml(poster)}"` : ""} src="${escapeHtml(src)}"></video>`);
         }
       }
-    } else if (/^https?:\/\//i.test(ref) && VISUAL_EXT_RE.test(ref)) {
+    } else if (/^https?:\/\//i.test(ref) && VISUAL_EXT_RE.test(stripUrlTail(ref))) {
       parts.push(remoteOk ? `<img class="embed" alt="${escapeHtml(ref)}" src="${escapeHtml(ref)}">` : remoteBlockedEmbed(ref));
     } else {
       const t = imageTag(ref);

--- a/src/report/reconstruct-viewers.ts
+++ b/src/report/reconstruct-viewers.ts
@@ -9,7 +9,7 @@
 // Both pages lead with the speculative caveat banner — synthesized imagery must
 // never read as a capture (same posture as the reconstruct gallery).
 
-import { readFileSync, existsSync, statSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, openSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { escapeHtml, imageSrc } from "./html.js";
 
@@ -349,13 +349,30 @@ requestAnimationFrame(frame);
 export function buildOrbitViewerHtml(glbPath: string, opts: ReconstructViewerOpts): string {
   let body: string;
   let head = "";
-  if (!existsSync(glbPath)) {
+  // Open once, then size-check and read THAT descriptor — exists → stat → read
+  // re-resolves the path three times and can size-check one file but embed
+  // another (CodeQL js/file-system-race). Sizing off the held fd also keeps the
+  // over-cap path from ever reading a multi-GB mesh into memory to reject it.
+  let fd: number | undefined;
+  try {
+    fd = openSync(glbPath, "r");
+  } catch {
+    fd = undefined;
+  }
+  if (fd === undefined) {
     body = `<div class="fail">mesh file missing: ${escapeHtml(glbPath)}</div>`;
-  } else if (statSync(glbPath).size > MAX_EMBED_GLB_BYTES) {
-    body = `<div class="fail">mesh is too large to embed (${Math.round(statSync(glbPath).size / 1024 / 1024)} MB &gt; 64 MB).\nOpen it in an external GLB viewer: ${escapeHtml(glbPath)}</div>`;
   } else {
-    const b64 = readFileSync(glbPath).toString("base64");
-    head = `<script>const GLB_B64=${JSON.stringify(b64)};</script>`;
+    try {
+      const size = fstatSync(fd).size;
+      if (size > MAX_EMBED_GLB_BYTES) {
+        body = `<div class="fail">mesh is too large to embed (${Math.round(size / 1024 / 1024)} MB &gt; 64 MB).\nOpen it in an external GLB viewer: ${escapeHtml(glbPath)}</div>`;
+        return shell(opts, head, body);
+      }
+      const b64 = readFileSync(fd).toString("base64");
+      head = `<script>const GLB_B64=${JSON.stringify(b64)};</script>`;
+    } finally {
+      closeSync(fd);
+    }
     body = `<canvas id="gl"></canvas>
 <div id="fail" class="fail" style="display:none"></div>
 <div id="hud" class="hud">AZ —</div>

--- a/src/report/wall.ts
+++ b/src/report/wall.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { basename } from "node:path";
 import { pathToFileURL } from "node:url";
-import { findingStatusMap, isReady, recordTimeMs, type OvercastRecord } from "../record.js";
+import { findingStatusMap, isReady, recordTimeMs, stripUrlTail, type OvercastRecord } from "../record.js";
 import { escapeRegex } from "../text.js";
 import { isRegisterableMediaRecord } from "../verbs/media-ref.js";
 import { isRootFindingRecord } from "../verbs/finding.js";
@@ -452,7 +452,7 @@ function newestFirst(records: OvercastRecord[]): OvercastRecord[] {
  *  `<stem>_t<seconds>.jpg` — not a loose prefix (a_tool_t12.jpg must never
  *  light a.mp4's S badge just because "a_tool_t" starts with "a_t"). */
 function frameFileRe(ref: string): RegExp {
-  const b = basename(ref.replace(/[?#].*$/, ""));
+  const b = basename(stripUrlTail(ref));
   const dot = b.lastIndexOf(".");
   const stem = dot > 0 ? b.slice(0, dot) : b;
   return new RegExp(`^${escapeRegex(stem)}_t\\d+\\.jpg$`, "i");

--- a/src/signals/graph.ts
+++ b/src/signals/graph.ts
@@ -9,7 +9,7 @@
  * suggested leads never enter the graph. Entity harvesting reads the SAME text
  * ask/brief index (`indexableDocument`), so raw boxes/vectors/dumps stay out.
  */
-import { memoryRecords, recordCaptureTimeMs, recordStub, type OvercastRecord } from "../record.js";
+import { memoryRecords, recordCaptureTimeMs, recordStub, stripUrlTail, type OvercastRecord } from "../record.js";
 import { indexableDocument } from "../providers/memory/fields.js";
 import { buildDeviceClusters } from "./devices.js";
 import { buildThreads } from "./threads.js";
@@ -156,7 +156,7 @@ function str(v: unknown): string | undefined {
 }
 
 function baseName(ref: string): string {
-  const parts = ref.replace(/[?#].*$/, "").split(/[\\/]/);
+  const parts = stripUrlTail(ref).split(/[\\/]/);
   return parts[parts.length - 1] || ref;
 }
 

--- a/src/signals/rollup.ts
+++ b/src/signals/rollup.ts
@@ -14,7 +14,7 @@
  * wins, so a whole sweep collapses to one "sweep" group. Records without it fall
  * through to the media-chain rules — so this works today without stamping runs.
  */
-import { recordTimeMs, type OvercastRecord } from "../record.js";
+import { recordTimeMs, stripUrlTail, type OvercastRecord } from "../record.js";
 
 export interface TimelineGroup {
   key: string;
@@ -38,7 +38,7 @@ function timeMs(r: OvercastRecord): number {
 }
 
 function baseName(ref: string): string {
-  const parts = ref.replace(/[?#].*$/, "").split(/[\\/]/);
+  const parts = stripUrlTail(ref).split(/[\\/]/);
   return parts[parts.length - 1] || ref;
 }
 

--- a/src/signals/threads.ts
+++ b/src/signals/threads.ts
@@ -24,7 +24,7 @@
  *   collecting           ← ≥1 evidence record linked
  *   cold                 ← nothing linked yet
  */
-import { findingStatusMap, isMemoryRecord, isReady, recordTimeMs, type OvercastRecord } from "../record.js";
+import { findingStatusMap, isMemoryRecord, isReady, recordTimeMs, stripUrlTail, type OvercastRecord } from "../record.js";
 import { SENSE_VERBS } from "./pulse.js";
 import { isRootFindingRecord } from "../verbs/finding.js";
 import { targetMatchesEvidence, payloadText } from "./triggers.js";
@@ -97,7 +97,7 @@ function timeOf(r: OvercastRecord): number {
 }
 
 function baseName(ref: string): string {
-  const parts = ref.replace(/[?#].*$/, "").split(/[\\/]/);
+  const parts = stripUrlTail(ref).split(/[\\/]/);
   return (parts[parts.length - 1] || ref).toLowerCase();
 }
 

--- a/src/situation/model.ts
+++ b/src/situation/model.ts
@@ -9,7 +9,7 @@
 
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { isReady, recordTimeMs, type OvercastRecord } from "../record.js";
+import { isReady, recordTimeMs, stripUrlTail, type OvercastRecord } from "../record.js";
 import { buildWallModel, type WallTile } from "../report/wall.js";
 import { buildMapModel } from "../report/map.js";
 import { parseSince } from "../providers/memory/local.js";
@@ -125,7 +125,7 @@ const POINTS_CAP = 500;
 const STILLS_CAP = 12;
 
 const REMOTE_RE = /^https?:\/\//i;
-const IMAGE_RE = /\.(avif|bmp|gif|jpe?g|png|webp)(?:[?#].*)?$/i;
+const IMAGE_RE = /\.(avif|bmp|gif|jpe?g|png|webp)$/i;
 
 // Source classes that drive panel auto-selection ("takes a guess based on the
 // sources you've configured") — a configured source lights its panel even
@@ -327,7 +327,7 @@ export function buildSituationModel(records: OvercastRecord[], opts: BuildSituat
       summary: p.summary,
       ref: p.ref,
       url: str(pl.url),
-      thumb: p.ref && IMAGE_RE.test(p.ref) ? mediaRefFor(p.ref, fileExists) : null,
+      thumb: p.ref && IMAGE_RE.test(stripUrlTail(p.ref)) ? mediaRefFor(p.ref, fileExists) : null,
       track: trackOf.get(p.recordId) ?? null,
       heading: num(pl.true_track),
       velocity: num(pl.velocity),
@@ -339,7 +339,7 @@ export function buildSituationModel(records: OvercastRecord[], opts: BuildSituat
   // --- stills: freshest capture per recapture-ish source ----------------------
   const stillCandidates = records.filter((r) => {
     if (!isReady(r) || !r.media?.ref || !withinSince(r)) return false;
-    if (r.verb === "screenshot") return IMAGE_RE.test(r.media.ref);
+    if (r.verb === "screenshot") return IMAGE_RE.test(stripUrlTail(r.media.ref));
     if (r.verb !== "capture") return false;
     const source = str(payloadOf(r).source);
     return source != null && STILL_SOURCE_TYPES.has(source);

--- a/src/situation/server.ts
+++ b/src/situation/server.ts
@@ -474,34 +474,42 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
       // short private cache keeps the loop windows from refetching
       "Cache-Control": "private, max-age=300",
     };
-    // every exit below must dispose of the fd: the streams adopt it (autoClose),
-    // the non-streaming replies close it themselves.
-    if (req.method === "HEAD") {
-      closeSync(fd);
-      res.writeHead(200, { ...headers, "Content-Length": st.size });
-      return void res.end();
-    }
-    const range = req.headers.range;
-    if (typeof range === "string" && range.trim() !== "") {
-      const parsed = parseRange(range, st.size);
-      if (!parsed) {
-        closeSync(fd);
-        res.writeHead(416, { "Content-Range": `bytes */${st.size}` });
+    // ONE disposal path for the descriptor. Only a created stream takes
+    // ownership (autoClose); every other outcome — HEAD, 416, and crucially a
+    // THROW from writeHead on an already-destroyed socket — falls through to the
+    // finally. Closing per-branch (as this did) leaks on the throw, and /media is
+    // the hot route, so a client that hangs up mid-header would bleed fds.
+    let adopted = false;
+    try {
+      if (req.method === "HEAD") {
+        res.writeHead(200, { ...headers, "Content-Length": st.size });
         return void res.end();
       }
-      res.writeHead(206, {
-        ...headers,
-        "Content-Range": `bytes ${parsed.start}-${parsed.end}/${st.size}`,
-        "Content-Length": parsed.end - parsed.start + 1,
-      });
-      const stream = createReadStream("", { fd, start: parsed.start, end: parsed.end, autoClose: true });
+      const range = req.headers.range;
+      if (typeof range === "string" && range.trim() !== "") {
+        const parsed = parseRange(range, st.size);
+        if (!parsed) {
+          res.writeHead(416, { "Content-Range": `bytes */${st.size}` });
+          return void res.end();
+        }
+        res.writeHead(206, {
+          ...headers,
+          "Content-Range": `bytes ${parsed.start}-${parsed.end}/${st.size}`,
+          "Content-Length": parsed.end - parsed.start + 1,
+        });
+        const stream = createReadStream("", { fd, start: parsed.start, end: parsed.end, autoClose: true });
+        adopted = true;
+        stream.on("error", () => res.destroy());
+        return void stream.pipe(res);
+      }
+      res.writeHead(200, { ...headers, "Content-Length": st.size });
+      const stream = createReadStream("", { fd, autoClose: true });
+      adopted = true;
       stream.on("error", () => res.destroy());
-      return void stream.pipe(res);
+      stream.pipe(res);
+    } finally {
+      if (!adopted) closeSync(fd);
     }
-    res.writeHead(200, { ...headers, "Content-Length": st.size });
-    const stream = createReadStream("", { fd, autoClose: true });
-    stream.on("error", () => res.destroy());
-    stream.pipe(res);
   }
 }
 

--- a/src/situation/server.ts
+++ b/src/situation/server.ts
@@ -19,14 +19,14 @@
 // verb (own terminal pane) and the TUI extension (/situation on).
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { createReadStream, statSync } from "node:fs";
+import { closeSync, createReadStream, fstatSync, statSync } from "node:fs";
 import { basename, extname, resolve } from "node:path";
 import { createHash } from "node:crypto";
 import { LiveHttpd, MEDIA_CONTENT_TYPES, type LiveHttpdOptions } from "../live/httpd.js";
 import { reportRemoteMediaEnabled, normalizeHtmlTheme } from "../report/html.js";
 import { posterFrame } from "../media/ffmpeg.js";
 import { listSources } from "../state/source.js";
-import { realpathContained } from "../fs-path.js";
+import { openContainedFile, realpathContained } from "../fs-path.js";
 import type { Case } from "../case.js";
 import { buildSituationModel, type SituationMediaRef, type SituationModel } from "./model.js";
 import { consumeControl, readControl, type SituationConfig, type SituationControl } from "./state.js";
@@ -457,16 +457,14 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
     const id = url.pathname.split("/")[2] ?? "";
     const path = this.mediaMap.get(id) ?? this.prevMediaMap.get(id);
     if (!path) return this.json(res, 404, { error: "not found" });
-    // re-verify containment at serve time (defense in depth; catches a symlink
-    // swap between snapshot build and this request) — never stream outside the case.
-    if (!realpathContained(this.case.dir, path)) return this.json(res, 404, { error: "not found" });
-    let st: ReturnType<typeof statSync>;
-    try {
-      st = statSync(path);
-    } catch {
-      return this.json(res, 404, { error: "not found" });
-    }
-    if (!st.isFile()) return this.json(res, 404, { error: "not found" });
+    // Re-verify containment at serve time (defense in depth; catches a symlink
+    // swap between snapshot build and this request) — never stream outside the
+    // case. Containment, size, and the bytes all come off ONE descriptor: a
+    // check → statSync(path) → createReadStream(path) chain re-resolves the path
+    // three times, so a swap mid-sequence streams a file the check never saw.
+    const fd = openContainedFile(this.case.dir, path);
+    if (fd === undefined) return this.json(res, 404, { error: "not found" });
+    const st = fstatSync(fd);
     const headers: Record<string, string | number> = {
       "Content-Type": MEDIA_CONTENT_TYPES[extname(path).toLowerCase()] ?? "application/octet-stream",
       "Accept-Ranges": "bytes",
@@ -474,7 +472,10 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
       // short private cache keeps the loop windows from refetching
       "Cache-Control": "private, max-age=300",
     };
+    // every exit below must dispose of the fd: the streams adopt it (autoClose),
+    // the non-streaming replies close it themselves.
     if (req.method === "HEAD") {
+      closeSync(fd);
       res.writeHead(200, { ...headers, "Content-Length": st.size });
       return void res.end();
     }
@@ -482,6 +483,7 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
     if (typeof range === "string" && range.trim() !== "") {
       const parsed = parseRange(range, st.size);
       if (!parsed) {
+        closeSync(fd);
         res.writeHead(416, { "Content-Range": `bytes */${st.size}` });
         return void res.end();
       }
@@ -490,12 +492,12 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
         "Content-Range": `bytes ${parsed.start}-${parsed.end}/${st.size}`,
         "Content-Length": parsed.end - parsed.start + 1,
       });
-      const stream = createReadStream(path, { start: parsed.start, end: parsed.end });
+      const stream = createReadStream("", { fd, start: parsed.start, end: parsed.end, autoClose: true });
       stream.on("error", () => res.destroy());
       return void stream.pipe(res);
     }
     res.writeHead(200, { ...headers, "Content-Length": st.size });
-    const stream = createReadStream(path);
+    const stream = createReadStream("", { fd, autoClose: true });
     stream.on("error", () => res.destroy());
     stream.pipe(res);
   }

--- a/src/situation/server.ts
+++ b/src/situation/server.ts
@@ -29,7 +29,7 @@ import { listSources } from "../state/source.js";
 import { openContainedFile, realpathContained } from "../fs-path.js";
 import type { Case } from "../case.js";
 import { buildSituationModel, type SituationMediaRef, type SituationModel } from "./model.js";
-import { consumeControl, readControl, type SituationConfig, type SituationControl } from "./state.js";
+import { takeControl, type SituationConfig, type SituationControl } from "./state.js";
 import type { SituationSnapshot, SituationWireEvent } from "./wire.js";
 
 type SituationEventInput = SituationWireEvent extends infer E
@@ -138,11 +138,13 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
    *  retune/stop from the agent/CLI/chair lands within a couple seconds. */
   private async applyControlTick(): Promise<void> {
     if (this.stopRequested) return;
-    const ctl = readControl(this.case);
-    if (!ctl) return;
-    const { stop, ...patch } = ctl.control;
+    // take-then-apply: the control is claimed atomically, so a `situation set`
+    // racing this tick lands a NEW control.json for the next one rather than
+    // being deleted unapplied
+    const control = takeControl(this.case);
+    if (!control) return;
+    const { stop, ...patch } = control;
     this.applyConfig(patch);
-    consumeControl(this.case, ctl.mtimeMs);
     if (stop === true) {
       this.stopRequested = true;
       this.announceStopping("stop requested via situation stop");

--- a/src/situation/server.ts
+++ b/src/situation/server.ts
@@ -11,9 +11,10 @@
 //     trick), so local media streams through the server. The servable set is an
 //     ALLOWLIST derived from the current model — only media the page actually
 //     shows resolves; nothing else on disk is reachable, even with the token.
-//   control.json — the cross-process control plane (.overcast/situation/):
-//     `situation set/stop` (CLI, agent tool, chair→agent) writes it; the server
-//     applies it on the next poll tick. See src/situation/state.ts.
+//   control.d/ — the cross-process control plane (.overcast/situation/):
+//     `situation set/stop` (CLI, agent tool, chair→agent) appends a patch; the
+//     server folds and drains them on the next poll tick. See
+//     src/situation/state.ts.
 //
 // Deliberately pi-free and case-driven, so it runs identically under the CLI
 // verb (own terminal pane) and the TUI extension (/situation on).
@@ -50,7 +51,7 @@ const CONTROL_MS = 2000;
 export interface SituationServerOptions extends LiveHttpdOptions {
   case: Case;
   version: string;
-  /** initial view config (CLI flags); mutated at runtime by control.json */
+  /** initial view config (CLI flags); mutated at runtime by control patches */
   config?: SituationConfig;
   /** the monitor cadence string the serving process owns ("5m"), display only —
    *  passes are driven by the caller via monitorStarted/monitorEnded */
@@ -59,7 +60,7 @@ export interface SituationServerOptions extends LiveHttpdOptions {
   pollMs?: number;
   /** false disables the ffmpeg poster pass (tests / no-ffmpeg hosts) */
   posters?: boolean;
-  /** fired when control.json requests a stop — the owner shuts the loop down */
+  /** fired when a control patch requests a stop — the owner shuts the loop down */
   onStopRequested?: (reason: string) => void;
   /** injectable clock for tests */
   now?: () => number;
@@ -138,9 +139,8 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
    *  retune/stop from the agent/CLI/chair lands within a couple seconds. */
   private async applyControlTick(): Promise<void> {
     if (this.stopRequested) return;
-    // take-then-apply: the control is claimed atomically, so a `situation set`
-    // racing this tick lands a NEW control.json for the next one rather than
-    // being deleted unapplied
+    // fold-then-drain: a `situation set` racing this tick appends a NEW patch
+    // that the next tick picks up, rather than being consumed unapplied
     const control = takeControl(this.case);
     if (!control) return;
     const { stop, ...patch } = control;
@@ -169,7 +169,7 @@ export class SituationServer extends LiveHttpd<SituationEventInput> {
     if (!this.stopRequested) await this.pollRebuildTick();
   }
 
-  /** Apply a config patch (from control.json), dropping invalid values rather
+  /** Apply a config patch (from a control patch file), dropping invalid values rather
    *  than failing the tick — the writer already validated; this is the belt.
    *  `clear` keys are DROPPED first (back to default/auto) — the only way to
    *  remove a filter from a long-running serve (Bugbot #98/med) — then any

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -313,19 +313,25 @@ export function takeControl(c: Case): SituationControl | undefined {
  *  concurrently is left untouched rather than swept up — the same rule the take
  *  follows. Runs once, before the server binds. */
 export function clearStaleStop(c: Case): void {
-  const files = pendingPatchFiles(c);
+  // Track exactly which files were READ. Deleting the whole listing would
+  // discard a patch that failed to read — an operator command thrown away
+  // without ever being looked at, which is the rule the take follows and this
+  // must too. An unread patch simply survives to the first tick.
+  const read: string[] = [];
   let pending: SituationControl | undefined;
-  for (const file of files) {
+  for (const file of pendingPatchFiles(c)) {
     try {
-      pending = foldControl(pending ?? {}, JSON.parse(readFileSync(file, "utf8")) as SituationControl);
+      const patch = JSON.parse(readFileSync(file, "utf8")) as SituationControl;
+      pending = foldControl(pending ?? {}, patch);
+      read.push(file);
     } catch {
-      /* unreadable/corrupt — leave it; the first take deals with it */
+      /* unreadable or corrupt — leave it; the first take decides its fate */
     }
   }
   if (!pending || pending.stop !== true) return;
   const { stop: _stop, ...rest } = pending;
   try {
-    for (const file of files) rmSync(file, { force: true });
+    for (const file of read) rmSync(file, { force: true });
     if (Object.keys(rest).length > 0) writeControl(c, rest);
   } catch {
     /* best-effort; the server also ignores a stop it can't attribute */

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -216,18 +216,22 @@ function withControlLock<T>(
       held = true;
       break;
     } catch {
-      try {
-        // a holder that died leaves the file behind; steal it once it's stale
-        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) {
-          rmSync(lock, { force: true });
-          continue;
-        }
-      } catch {
-        continue; // vanished under us — try to acquire
-      }
-      if (Date.now() >= deadline) break;
-      sleepSync(LOCK_POLL_MS);
+      /* contended, or the lock path is unusable (EACCES/ENOSPC/read-only) */
     }
+    try {
+      // a holder that died leaves the file behind; steal it once it's stale
+      if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) rmSync(lock, { force: true });
+    } catch {
+      /* vanished or unreadable — fall through; the deadline still governs */
+    }
+    // EVERY path reaches this. An earlier version `continue`d past it when the
+    // lock file could not be stat'd, so an openSync failing for a reason other
+    // than contention (a read-only or full disk) span forever with no sleep —
+    // on the server's control tick that hangs the event loop, the exact failure
+    // the non-blocking take was added to prevent. With waitMs 0 this breaks on
+    // the first miss, which is what makes that take a single attempt.
+    if (Date.now() >= deadline) break;
+    sleepSync(LOCK_POLL_MS);
   }
   if (!held && ifBusy === "skip") return undefined;
   try {

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -343,28 +343,31 @@ export function takeControl(c: Case): SituationControl | undefined {
  *  concurrently is left untouched rather than swept up — the same rule the take
  *  follows. Runs once, before the server binds. */
 export function clearStaleStop(c: Case): void {
-  // deletes exactly what it CONSUMED — an unread patch is a command nobody has
-  // looked at, so sweeping it up would discard it silently
-  const { control, consumed } = foldPending(pendingPatchFiles(c));
-  if (!control || control.stop !== true || consumed.length === 0) return;
-  const { stop: _stop, ...rest } = control;
-  const keep = Object.keys(rest).length > 0;
-  try {
-    if (keep) {
-      // Republish the surviving config AT THE FIRST CONSUMED NAME, and write it
-      // BEFORE removing anything. Two reasons, both learned the hard way:
-      //   - write-then-delete means a failed write leaves the original patches
-      //     intact. Deleting first and then failing would destroy
-      //     set-before-start config with only an empty catch to show for it.
-      //   - reusing the first name keeps this patch's PLACE in the order. A
-      //     fresh name sorts to the end, so an unreadable patch further along
-      //     would strand config that was applyable a moment ago.
-      writeFileAtomic(consumed[0], JSON.stringify(rest, null, 2) + "\n");
-      for (const file of consumed.slice(1)) rmSync(file, { force: true });
-    } else {
-      for (const file of consumed) rmSync(file, { force: true });
+  // Neutralize a stale stop WHEREVER it sits, patch by patch. Folding only the
+  // applyable prefix (as this did) misses a `stop: true` queued behind an
+  // unreadable patch: the fresh serve starts fine, then dies the moment that
+  // patch is repaired and the take reaches the stop — precisely the failure this
+  // helper exists to prevent.
+  //
+  // Rewriting each offending patch IN PLACE, under its own name, keeps every
+  // other property that took several rounds to get right: order is preserved
+  // (same filename, same sort position), an unreadable patch is skipped rather
+  // than swept up, surviving config is written before anything is removed, and
+  // a failed rewrite leaves that patch untouched.
+  for (const file of pendingPatchFiles(c)) {
+    let patch: SituationControl;
+    try {
+      patch = JSON.parse(readFileSync(file, "utf8")) as SituationControl;
+    } catch {
+      continue; // unreadable or corrupt — not ours to touch
     }
-  } catch {
-    /* best-effort; the server also ignores a stop it can't attribute */
+    if (patch?.stop !== true) continue;
+    const { stop: _stop, ...rest } = patch;
+    try {
+      if (Object.keys(rest).length > 0) writeFileAtomic(file, JSON.stringify(rest, null, 2) + "\n");
+      else rmSync(file, { force: true }); // the patch carried nothing but the stop
+    } catch {
+      /* best-effort; the server also ignores a stop it can't attribute */
+    }
   }
 }

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -176,19 +176,41 @@ export function parsePanels(raw: string | undefined): SituationPanel[] | undefin
  *  interleaving would be the worse trade. A lock left by a killed process is
  *  stolen once it goes stale. */
 const LOCK_STALE_MS = 5_000;
-const LOCK_WAIT_MS = 2_000;
+/** Writers are short CLI/agent calls; the critical section is a parse + atomic
+ *  write of a tiny file (sub-millisecond), so a contended writer realistically
+ *  waits one sleep. The budget only bounds the pathological case. */
+const LOCK_WAIT_MS = 250;
+const LOCK_POLL_MS = 5;
 
 function sleepSync(ms: number): void {
   // no sync sleep in Node; wait on a private SharedArrayBuffer nobody notifies
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-function withControlLock<T>(c: Case, fn: () => T): T {
+/** Acquire, run, release. `waitMs: 0` makes it a SINGLE non-blocking attempt.
+ *
+ *  `Atomics.wait` parks the whole thread, so any waiting here freezes the event
+ *  loop of whatever process is calling — including the situation server, where a
+ *  stall would take /media and SSE down with it. So the server's take never
+ *  waits (see takeControl): it retries on its own poll tick, which is what a
+ *  polling loop is for. Only short-lived writer calls wait at all, and only
+ *  briefly.
+ *
+ *  `ifBusy` decides what a failed acquisition means. Writers PROCEED: dropping
+ *  an operator's command to avoid a rare interleaving is the worse trade. The
+ *  server SKIPS: the control stays pending and the next tick claims it. */
+function withControlLock<T>(
+  c: Case,
+  fn: () => T,
+  opts: { waitMs?: number; ifBusy?: "proceed" | "skip" } = {},
+): T | undefined {
+  const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
+  const ifBusy = opts.ifBusy ?? "proceed";
   const lock = `${controlFile(c)}.lock`;
   mkdirSync(situationDir(c), { recursive: true });
-  const deadline = Date.now() + LOCK_WAIT_MS;
+  const deadline = Date.now() + waitMs;
   let held = false;
-  while (Date.now() < deadline) {
+  for (;;) {
     try {
       closeSync(openSync(lock, "wx")); // atomic create = acquire
       held = true;
@@ -196,13 +218,18 @@ function withControlLock<T>(c: Case, fn: () => T): T {
     } catch {
       try {
         // a holder that died leaves the file behind; steal it once it's stale
-        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) rmSync(lock, { force: true });
-        else sleepSync(10);
+        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) {
+          rmSync(lock, { force: true });
+          continue;
+        }
       } catch {
-        /* vanished under us — loop and try to acquire */
+        continue; // vanished under us — try to acquire
       }
+      if (Date.now() >= deadline) break;
+      sleepSync(LOCK_POLL_MS);
     }
   }
+  if (!held && ifBusy === "skip") return undefined;
   try {
     return fn();
   } finally {
@@ -223,7 +250,9 @@ function withControlLock<T>(c: Case, fn: () => T): T {
  *  (so the re-set wins) — the server can then apply clears before assignments
  *  without reordering the operator's intent. */
 export function writeControl(c: Case, patch: SituationControl): SituationControl {
-  return withControlLock(c, () => writeControlLocked(c, patch));
+  // a writer must never come away having done nothing — ifBusy defaults to
+  // "proceed", so the non-undefined return is guaranteed
+  return withControlLock(c, () => writeControlLocked(c, patch)) as SituationControl;
 }
 
 function writeControlLocked(c: Case, patch: SituationControl): SituationControl {
@@ -273,7 +302,10 @@ export function readControl(c: Case): SituationControl | undefined {
  *  next line, so that window is negligible — and losing a control to a crash is
  *  strictly better than deleting a live one the server never looked at. */
 export function takeControl(c: Case): SituationControl | undefined {
-  return withControlLock(c, () => takeControlLocked(c));
+  // NEVER wait: this runs on the situation server's poll tick, and blocking here
+  // would stall /media and SSE for the whole process. A contended tick simply
+  // finds the control still pending ~2s later.
+  return withControlLock(c, () => takeControlLocked(c), { waitMs: 0, ifBusy: "skip" });
 }
 
 function takeControlLocked(c: Case): SituationControl | undefined {

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -253,14 +253,16 @@ function pendingPatchFiles(c: Case): string[] {
  *  Deliberate consequence: a patch that can never be read blocks the ones behind
  *  it. That is visible (the page stops following commands) and preferable to
  *  applying operator intent out of order, which would be silent. */
-function foldPending(files: string[]): { control?: SituationControl; consumed: string[] } {
+function foldPending(files: string[]): { control?: SituationControl; consumed: string[]; blocked: boolean } {
   let control: SituationControl | undefined;
   const consumed: string[] = [];
+  let blocked = false;
   for (const file of files) {
     let raw: string;
     try {
       raw = readFileSync(file, "utf8");
     } catch {
+      blocked = true;
       break; // ordered log — stop here, do not skip ahead
     }
     consumed.push(file);
@@ -270,7 +272,7 @@ function foldPending(files: string[]): { control?: SituationControl; consumed: s
       /* corrupt: consumed and dropped; no content, so no reordering */
     }
   }
-  return { control, consumed };
+  return { control, consumed, blocked };
 }
 
 /** Append ONE patch. No read-modify-write, so concurrent writers cannot lose
@@ -301,6 +303,14 @@ export function writeControl(c: Case, patch: SituationControl): SituationControl
  *  extension's stop check). The server's apply path uses takeControl. */
 export function readControl(c: Case): SituationControl | undefined {
   return foldPending(pendingPatchFiles(c)).control;
+}
+
+/** True when an unreadable patch is holding the queue, so pending commands
+ *  BEHIND it cannot be applied yet. Callers surface this rather than reporting a
+ *  clean success for something the server cannot take — a `situation set` that
+ *  says "applied within ~2s" while the log is stuck is a lie to the operator. */
+export function controlBlocked(c: Case): boolean {
+  return foldPending(pendingPatchFiles(c)).blocked;
 }
 
 /** TAKE the pending control: fold every pending patch and remove the files that

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -1,4 +1,4 @@
-// Situation control plane = two small files under .overcast/situation/, in the
+// Situation control plane = a small file tree under .overcast/situation/, in the
 // same file-based style as seen.json / sources.json — because the serving
 // process (a terminal pane or the TUI extension) and the controllers (the
 // `situation set|stop|status` verb run by the CLI, the agent tool, or the chair
@@ -7,9 +7,12 @@
 //   runtime.json — written by the server on start, removed on exit. Discovery:
 //     "is a situation live, where". Never contains the pairing token (the token
 //     lives only in the terminal QR / pairing URL).
-//   control.json — written by `situation set` / `situation stop` (atomic
-//     replace, merging any not-yet-consumed control), consumed by the server on
-//     its next poll tick (~2s). `stop: true` shuts the server down gracefully.
+//   control.d/ — an APPEND-ONLY patch directory. `situation set` /
+//     `situation stop` each write ONE new file; the server folds them in
+//     filename (= write) order on its next poll tick (~2s) and removes what it
+//     consumed. `stop: true` shuts the server down gracefully. Deliberately not
+//     a single mutable file: see the note above `controlDir` for why that shape
+//     kept failing.
 
 import { mkdirSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { randomBytes } from "node:crypto";
@@ -158,23 +161,6 @@ export function parsePanels(raw: string | undefined): SituationPanel[] | undefin
   return [...new Set(items)] as SituationPanel[];
 }
 
-/** Serialize every MUTATION of the control file through an O_EXCL lock.
- *
- *  writeControl is a read-modify-write: it folds the operator's patch onto
- *  whatever is still pending. Two `situation set`s racing (the agent and a CLI
- *  in another terminal, say) could both read the same pending state and the
- *  slower publish would clobber the faster one — an operator command lost with
- *  no error, the exact failure this control plane is supposed to have stopped
- *  having. A take landing mid-RMW could likewise resurrect an applied control.
- *
- *  So the lock covers ALL of the mutators (write / take / clearStaleStop), not
- *  just the pair that happened to be reported. Held for microseconds around a
- *  small JSON file.
- *
- *  Never fails the caller: if the lock can't be acquired within the budget we
- *  proceed anyway. Dropping the operator's command to protect against a rare
- *  interleaving would be the worse trade. A lock left by a killed process is
- *  stolen once it goes stale. */
 /** The control plane is an APPEND-ONLY PATCH DIRECTORY, not a shared mutable
  *  file, because every failure this thing has had came from the latter.
  *

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -247,9 +247,10 @@ function foldPending(files: string[]): { control?: SituationControl; consumed: s
     let raw: string;
     try {
       raw = readFileSync(file, "utf8");
-    } catch {
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ENOENT") continue; // already drained by a concurrent take — nothing to hold
       blockedBy = file;
-      break; // ordered log — stop here, do not skip ahead
+      break; // genuinely unreadable: ordered log, stop here rather than skip ahead
     }
     consumed.push(file);
     try {
@@ -301,7 +302,16 @@ export function readControl(c: Case): SituationControl | undefined {
  *  control.d/ (an interrupted upgrade), and a note naming only the directory
  *  sends them looking in the wrong place. */
 export function blockedControlPath(c: Case): string | undefined {
-  return foldPending(pendingPatchFiles(c)).blockedBy;
+  return controlSnapshot(c).blockedBy;
+}
+
+/** Pending control AND the blocker, from ONE fold. Callers that report both must
+ *  use this: two separate folds can be split by a concurrent drain and disagree
+ *  — `blocked: true` beside a `blocked_path` that has since been consumed, or a
+ *  pending control that does not match the blocked verdict shown next to it. */
+export function controlSnapshot(c: Case): { control?: SituationControl; blockedBy?: string } {
+  const { control, blockedBy } = foldPending(pendingPatchFiles(c));
+  return { control, blockedBy };
 }
 
 /** TAKE the pending control: fold every pending patch and remove the files that

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -11,7 +11,7 @@
 //     replace, merging any not-yet-consumed control), consumed by the server on
 //     its next poll tick (~2s). `stop: true` shuts the server down gracefully.
 
-import { closeSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { connect } from "node:net";
 import { join } from "node:path";
@@ -175,209 +175,158 @@ export function parsePanels(raw: string | undefined): SituationPanel[] | undefin
  *  proceed anyway. Dropping the operator's command to protect against a rare
  *  interleaving would be the worse trade. A lock left by a killed process is
  *  stolen once it goes stale. */
-const LOCK_STALE_MS = 5_000;
-/** Writers are short CLI/agent calls; the critical section is a parse + atomic
- *  write of a tiny file (sub-millisecond), so a contended writer realistically
- *  waits one sleep. The budget only bounds the pathological case. */
-const LOCK_WAIT_MS = 250;
-const LOCK_POLL_MS = 5;
-
-function sleepSync(ms: number): void {
-  // no sync sleep in Node; wait on a private SharedArrayBuffer nobody notifies
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-/** Acquire, run, release. `waitMs: 0` makes it a SINGLE non-blocking attempt.
+/** The control plane is an APPEND-ONLY PATCH DIRECTORY, not a shared mutable
+ *  file, because every failure this thing has had came from the latter.
  *
- *  `Atomics.wait` parks the whole thread, so any waiting here freezes the event
- *  loop of whatever process is calling — including the situation server, where a
- *  stall would take /media and SSE down with it. So the server's take never
- *  waits (see takeControl): it retries on its own poll tick, which is what a
- *  polling loop is for. Only short-lived writer calls wait at all, and only
- *  briefly.
+ *  History, so the shape isn't re-litigated: control.json was one file that
+ *  `situation set` read-modify-wrote and the server consumed. That needed a lock
+ *  (concurrent sets clobbered each other), the lock needed a stale-steal (a
+ *  crashed holder wedged it), the steal needed a deadline (it could spin), the
+ *  server needed a NON-blocking acquire (waiting parked the event loop and
+ *  stalled the live page), and the consume needed a restore path (a transient
+ *  read error would destroy the operator's command) which itself could clobber a
+ *  newer write. Each fix was correct and each exposed the next edge.
  *
- *  `ifBusy` decides what a failed acquisition means. Writers PROCEED: dropping
- *  an operator's command to avoid a rare interleaving is the worse trade. The
- *  server SKIPS: the control stays pending and the next tick claims it. */
-function withControlLock<T>(
-  c: Case,
-  fn: () => T,
-  opts: { waitMs?: number; ifBusy?: "proceed" | "skip" } = {},
-): T | undefined {
-  const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
-  const ifBusy = opts.ifBusy ?? "proceed";
-  const lock = `${controlFile(c)}.lock`;
-  mkdirSync(situationDir(c), { recursive: true });
-  const deadline = Date.now() + waitMs;
-  let held = false;
-  for (;;) {
-    try {
-      closeSync(openSync(lock, "wx")); // atomic create = acquire
-      held = true;
-      break;
-    } catch {
-      /* contended, or the lock path is unusable (EACCES/ENOSPC/read-only) */
-    }
-    try {
-      // a holder that died leaves the file behind; steal it once it's stale
-      if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) rmSync(lock, { force: true });
-    } catch {
-      /* vanished or unreadable — fall through; the deadline still governs */
-    }
-    // EVERY path reaches this. An earlier version `continue`d past it when the
-    // lock file could not be stat'd, so an openSync failing for a reason other
-    // than contention (a read-only or full disk) span forever with no sleep —
-    // on the server's control tick that hangs the event loop, the exact failure
-    // the non-blocking take was added to prevent. With waitMs 0 this breaks on
-    // the first miss, which is what makes that take a single attempt.
-    if (Date.now() >= deadline) break;
-    sleepSync(LOCK_POLL_MS);
-  }
-  if (!held && ifBusy === "skip") return undefined;
-  try {
-    return fn();
-  } finally {
-    if (held) {
-      try {
-        rmSync(lock, { force: true });
-      } catch {
-        /* best effort; a leftover lock goes stale and is stolen */
-      }
-    }
-  }
+ *  Writing one file per patch removes the shared mutable state instead:
+ *    - no read-modify-write, so no lost update and no lock to hold, wait on,
+ *      steal, or leave abandoned;
+ *    - no waiting anywhere, so neither a CLI writer nor the in-process TUI
+ *      writer can park the event loop that serves /media and SSE;
+ *    - a patch that can't be read is simply left for the next tick — it is its
+ *      own file, so there is no claim to restore and nothing to clobber.
+ *  Merge order is filename order, which is write order. */
+let patchSeq = 0;
+
+function controlDir(c: Case): string {
+  return join(situationDir(c), "control.d");
 }
 
-/** Merge a control patch onto any pending (unconsumed) control and write it
- *  atomically. Two quick `situation set`s compose instead of clobbering. Clears
- *  compose by ORDER: a clear in the patch drops the key from pending (so the
- *  clear wins), and an assignment in the patch drops the key from pending.clear
- *  (so the re-set wins) — the server can then apply clears before assignments
- *  without reordering the operator's intent. */
-export function writeControl(c: Case, patch: SituationControl): SituationControl {
-  // a writer must never come away having done nothing — ifBusy defaults to
-  // "proceed", so the non-undefined return is guaranteed
-  return withControlLock(c, () => writeControlLocked(c, patch)) as SituationControl;
-}
-
-function writeControlLocked(c: Case, patch: SituationControl): SituationControl {
-  const pending: SituationControl = { ...(readControl(c) ?? {}) };
-  if (patch.clear?.length) for (const key of patch.clear) delete pending[key];
-  if (pending.clear?.length) {
-    const kept = pending.clear.filter((key) => patch[key] === undefined);
-    if (kept.length) pending.clear = kept;
-    else delete pending.clear;
+/** Fold one patch onto the pending state. Clears compose by ORDER: a clear in
+ *  the patch drops the key from pending (the clear wins), and an assignment in
+ *  the patch drops the key from pending.clear (the re-set wins) — so the server
+ *  can apply clears before assignments without reordering operator intent. */
+function foldControl(pending: SituationControl, patch: SituationControl): SituationControl {
+  const next: SituationControl = { ...pending };
+  if (patch.clear?.length) for (const key of patch.clear) delete next[key];
+  if (next.clear?.length) {
+    const kept = next.clear.filter((key) => patch[key] === undefined);
+    if (kept.length) next.clear = kept;
+    else delete next.clear;
   }
-  const merged: SituationControl = { ...pending, ...patch };
-  if (pending.clear?.length && patch.clear?.length) merged.clear = [...new Set([...pending.clear, ...patch.clear])];
-  mkdirSync(situationDir(c), { recursive: true });
-  writeFileAtomic(controlFile(c), JSON.stringify(merged, null, 2) + "\n");
+  const merged: SituationControl = { ...next, ...patch };
+  if (next.clear?.length && patch.clear?.length) merged.clear = [...new Set([...next.clear, ...patch.clear])];
   return merged;
 }
 
+/** Pending patch files, oldest first. Includes a legacy single control.json
+ *  written by an older process, folded as the OLDEST entry so an in-flight
+ *  upgrade doesn't strand it. */
+function pendingPatchFiles(c: Case): string[] {
+  const out: string[] = [];
+  const legacy = controlFile(c);
+  try {
+    statSync(legacy);
+    out.push(legacy);
+  } catch {
+    /* none — the normal case */
+  }
+  try {
+    out.push(...readdirSync(controlDir(c)).filter((f) => f.endsWith(".json")).sort().map((f) => join(controlDir(c), f)));
+  } catch {
+    /* directory absent = nothing pending */
+  }
+  return out;
+}
+
+/** Append ONE patch. No read-modify-write, so concurrent writers cannot lose
+ *  each other's updates and nothing needs to be locked. Returns the resulting
+ *  pending state for the caller's display. */
+export function writeControl(c: Case, patch: SituationControl): SituationControl {
+  mkdirSync(controlDir(c), { recursive: true });
+  // Name sorts by write order. The millisecond alone is NOT enough — two sets
+  // in the same tick would then be ordered by the random suffix, silently
+  // inverting "a later clear beats an earlier assignment" — so a monotonic
+  // per-process sequence breaks the tie. Across processes a same-millisecond
+  // tie is arbitrary, which is honest: those writes are concurrent.
+  const name = [
+    String(Date.now()).padStart(15, "0"),
+    String(++patchSeq).padStart(6, "0"),
+    process.pid,
+    randomBytes(4).toString("hex"),
+  ].join("-") + ".json";
+  writeFileAtomic(join(controlDir(c), name), JSON.stringify(patch, null, 2) + "\n");
+  return readControl(c) ?? patch;
+}
+
+/** Non-destructive PEEK at the pending state (the verb's display, the
+ *  extension's stop check). The server's apply path uses takeControl. */
 export function readControl(c: Case): SituationControl | undefined {
-  try {
-    // A plain read is safe: writeControl publishes through an atomic rename, so
-    // a reader sees a whole control or none — never a half-written one. This is
-    // a non-destructive PEEK (the verb's pending display, the extension's stop
-    // check); the server's apply path uses takeControl below, which claims the
-    // file instead of reading it.
-    return JSON.parse(readFileSync(controlFile(c), "utf8")) as SituationControl;
-  } catch {
-    return undefined;
-  }
-}
-
-/** TAKE the pending control: claim it and return it in ONE atomic step.
- *
- *  The old read → apply → `statSync` → `rmSync` shape could not be made safe. A
- *  `situation set`/`stop` landing between the mtime check and the unlink was
- *  deleted having never been applied — the operator's command vanished with no
- *  error, which is the worst failure mode this control plane has. Narrowing the
- *  window (dropping the existsSync, pairing mtime+body off one descriptor) makes
- *  it rarer, not correct.
- *
- *  `rename(2)` is atomic: this either moves the current control.json aside or
- *  fails because there is nothing pending. A writer that lands a microsecond
- *  later publishes a NEW control.json (writeControl is itself an atomic rename),
- *  which the next tick takes. No update can be consumed unseen.
- *
- *  Trade-off, deliberately: a crash between the take and applyConfig loses that
- *  one control instead of replaying it. Apply is an in-memory call on the very
- *  next line, so that window is negligible — and losing a control to a crash is
- *  strictly better than deleting a live one the server never looked at. */
-export function takeControl(c: Case): SituationControl | undefined {
-  // NEVER wait: this runs on the situation server's poll tick, and blocking here
-  // would stall /media and SSE for the whole process. A contended tick simply
-  // finds the control still pending ~2s later.
-  return withControlLock(c, () => takeControlLocked(c), { waitMs: 0, ifBusy: "skip" });
-}
-
-function takeControlLocked(c: Case): SituationControl | undefined {
-  const file = controlFile(c);
-  // a UNIQUE claim name per take: a fixed `.taken` assumes rename replaces an
-  // existing destination, which POSIX does but Windows does not — one leftover
-  // from a crash would then block every future claim, and pending controls would
-  // never be applied again.
-  const taken = `${file}.taken.${process.pid}.${randomBytes(4).toString("hex")}`;
-  try {
-    renameSync(file, taken); // atomic claim; ENOENT = nothing pending
-  } catch {
-    return undefined;
-  }
-
-  let raw: string;
-  try {
-    raw = readFileSync(taken, "utf8");
-  } catch {
-    // A TRANSIENT IO error is not corruption — deleting here would destroy the
-    // operator's command. Put it back for the next tick, but only if nothing
-    // newer is already pending: a control written since our claim is the more
-    // recent intent and must not be clobbered by our restore.
+  let pending: SituationControl | undefined;
+  for (const file of pendingPatchFiles(c)) {
     try {
-      closeSync(openSync(file, "r")); // newer control exists → drop ours
-      rmSync(taken, { force: true });
+      pending = foldControl(pending ?? {}, JSON.parse(readFileSync(file, "utf8")) as SituationControl);
     } catch {
-      try {
-        renameSync(taken, file);
-      } catch {
-        /* best effort — the claim is lost, but nothing newer was overwritten */
-      }
+      /* unreadable or corrupt — takeControl decides its fate, a peek doesn't */
     }
-    return undefined;
   }
-
-  let parsed: SituationControl | undefined;
-  try {
-    parsed = JSON.parse(raw) as SituationControl;
-  } catch {
-    parsed = undefined; // genuinely corrupt — dropped with the file below
-  }
-  try {
-    rmSync(taken, { force: true });
-  } catch {
-    // must NOT suppress the return: a throw here would discard a control the
-    // caller is about to apply. A leftover claim file is harmless.
-  }
-  return parsed;
+  return pending;
 }
 
-/** Before a FRESH serve binds, drop a stale `stop: true` still sitting in
- *  control.json (Bugbot #98/high): it's left over from an earlier `situation
- *  stop` whose server died before its poll tick consumed it, and would instantly
- *  kill the new server on its first control tick. The stop key is removed; any
- *  set-before-start config is preserved (deleting the file only if nothing else
- *  remains). */
+/** TAKE the pending control: fold every pending patch and remove the files that
+ *  were consumed. Never blocks and never waits.
+ *
+ *  A patch is deleted only after it has been READ, so a transient IO error
+ *  leaves it pending for the next tick rather than destroying the operator's
+ *  command. A corrupt patch IS deleted — otherwise it would wedge the tick loop
+ *  forever. A crash between read and delete replays that patch, which is
+ *  harmless: applying a config patch twice is idempotent, and replaying beats
+ *  dropping. */
+export function takeControl(c: Case): SituationControl | undefined {
+  let pending: SituationControl | undefined;
+  for (const file of pendingPatchFiles(c)) {
+    let raw: string;
+    try {
+      raw = readFileSync(file, "utf8");
+    } catch {
+      continue; // transient — leave it for the next tick
+    }
+    try {
+      pending = foldControl(pending ?? {}, JSON.parse(raw) as SituationControl);
+    } catch {
+      /* corrupt — fall through and delete so it can't block every future tick */
+    }
+    try {
+      rmSync(file, { force: true });
+    } catch {
+      /* left behind; a re-read replays an idempotent patch */
+    }
+  }
+  return pending;
+}
+
+/** Before a FRESH serve binds, drop a stale `stop: true` still pending: it's
+ *  left over from an earlier `situation stop` whose server died before its poll
+ *  tick consumed it, and would instantly kill the new server on its first
+ *  control tick. The stop is removed; any set-before-start config is preserved.
+ *
+ *  Operates on exactly the files it READ, so a `situation set` landing
+ *  concurrently is left untouched rather than swept up — the same rule the take
+ *  follows. Runs once, before the server binds. */
 export function clearStaleStop(c: Case): void {
-  withControlLock(c, () => clearStaleStopLocked(c));
-}
-
-function clearStaleStopLocked(c: Case): void {
-  const cur = readControl(c);
-  if (!cur || cur.stop !== true) return;
-  const { stop: _stop, ...rest } = cur;
+  const files = pendingPatchFiles(c);
+  let pending: SituationControl | undefined;
+  for (const file of files) {
+    try {
+      pending = foldControl(pending ?? {}, JSON.parse(readFileSync(file, "utf8")) as SituationControl);
+    } catch {
+      /* unreadable/corrupt — leave it; the first take deals with it */
+    }
+  }
+  if (!pending || pending.stop !== true) return;
+  const { stop: _stop, ...rest } = pending;
   try {
-    if (Object.keys(rest).length === 0) rmSync(controlFile(c), { force: true });
-    else writeFileAtomic(controlFile(c), JSON.stringify(rest, null, 2) + "\n");
+    for (const file of files) rmSync(file, { force: true });
+    if (Object.keys(rest).length > 0) writeControl(c, rest);
   } catch {
     /* best-effort; the server also ignores a stop it can't attribute */
   }

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -336,11 +336,24 @@ export function clearStaleStop(c: Case): void {
   // deletes exactly what it CONSUMED — an unread patch is a command nobody has
   // looked at, so sweeping it up would discard it silently
   const { control, consumed } = foldPending(pendingPatchFiles(c));
-  if (!control || control.stop !== true) return;
+  if (!control || control.stop !== true || consumed.length === 0) return;
   const { stop: _stop, ...rest } = control;
+  const keep = Object.keys(rest).length > 0;
   try {
-    for (const file of consumed) rmSync(file, { force: true });
-    if (Object.keys(rest).length > 0) writeControl(c, rest);
+    if (keep) {
+      // Republish the surviving config AT THE FIRST CONSUMED NAME, and write it
+      // BEFORE removing anything. Two reasons, both learned the hard way:
+      //   - write-then-delete means a failed write leaves the original patches
+      //     intact. Deleting first and then failing would destroy
+      //     set-before-start config with only an empty catch to show for it.
+      //   - reusing the first name keeps this patch's PLACE in the order. A
+      //     fresh name sorts to the end, so an unreadable patch further along
+      //     would strand config that was applyable a moment ago.
+      writeFileAtomic(consumed[0], JSON.stringify(rest, null, 2) + "\n");
+      for (const file of consumed.slice(1)) rmSync(file, { force: true });
+    } else {
+      for (const file of consumed) rmSync(file, { force: true });
+    }
   } catch {
     /* best-effort; the server also ignores a stop it can't attribute */
   }

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -11,7 +11,7 @@
 //     replace, merging any not-yet-consumed control), consumed by the server on
 //     its next poll tick (~2s). `stop: true` shuts the server down gracefully.
 
-import { closeSync, fstatSync, mkdirSync, openSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { join } from "node:path";
 import { writeFileAtomic } from "../fs-atomic.js";
@@ -164,7 +164,7 @@ export function parsePanels(raw: string | undefined): SituationPanel[] | undefin
  *  (so the re-set wins) — the server can then apply clears before assignments
  *  without reordering the operator's intent. */
 export function writeControl(c: Case, patch: SituationControl): SituationControl {
-  const pending: SituationControl = { ...(readControl(c)?.control ?? {}) };
+  const pending: SituationControl = { ...(readControl(c) ?? {}) };
   if (patch.clear?.length) for (const key of patch.clear) delete pending[key];
   if (pending.clear?.length) {
     const kept = pending.clear.filter((key) => patch[key] === undefined);
@@ -178,20 +178,14 @@ export function writeControl(c: Case, patch: SituationControl): SituationControl
   return merged;
 }
 
-export function readControl(c: Case): { control: SituationControl; mtimeMs: number } | undefined {
-  const file = controlFile(c);
+export function readControl(c: Case): SituationControl | undefined {
   try {
-    // open ONCE and stat/read that descriptor: an existsSync + statSync + read
-    // trio races a concurrent `situation set` rewriting the file between calls
-    // (CodeQL js/file-system-race), which would pair one tick's mtime with the
-    // next tick's body and make the consume-on-match below drop a live update.
-    const fd = openSync(file, "r");
-    try {
-      const mtimeMs = fstatSync(fd).mtimeMs;
-      return { control: JSON.parse(readFileSync(fd, "utf8")) as SituationControl, mtimeMs };
-    } finally {
-      closeSync(fd);
-    }
+    // A plain read is safe: writeControl publishes through an atomic rename, so
+    // a reader sees a whole control or none — never a half-written one. This is
+    // a non-destructive PEEK (the verb's pending display, the extension's stop
+    // check); the server's apply path uses takeControl below, which claims the
+    // file instead of reading it.
+    return JSON.parse(readFileSync(controlFile(c), "utf8")) as SituationControl;
   } catch {
     return undefined;
   }
@@ -240,7 +234,7 @@ export function takeControl(c: Case): SituationControl | undefined {
  *  set-before-start config is preserved (deleting the file only if nothing else
  *  remains). */
 export function clearStaleStop(c: Case): void {
-  const cur = readControl(c)?.control;
+  const cur = readControl(c);
   if (!cur || cur.stop !== true) return;
   const { stop: _stop, ...rest } = cur;
   try {

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -238,10 +238,49 @@ function pendingPatchFiles(c: Case): string[] {
   return out;
 }
 
+/** Fold pending patches IN ORDER, and report which files were consumed.
+ *
+ *  Read failure STOPS the fold rather than skipping past it. The patches are an
+ *  ordered log: applying a later one while an earlier one stays pending would
+ *  replay the earlier patch on the NEXT tick, after the later one already
+ *  landed — an old assignment silently undoing a newer clear. Stopping keeps
+ *  the suffix pending as a unit, so order survives.
+ *
+ *  A patch that reads but does not PARSE is consumed and dropped: it carries no
+ *  content, so skipping it cannot reorder anything, and leaving it would wedge
+ *  the queue forever.
+ *
+ *  Deliberate consequence: a patch that can never be read blocks the ones behind
+ *  it. That is visible (the page stops following commands) and preferable to
+ *  applying operator intent out of order, which would be silent. */
+function foldPending(files: string[]): { control?: SituationControl; consumed: string[] } {
+  let control: SituationControl | undefined;
+  const consumed: string[] = [];
+  for (const file of files) {
+    let raw: string;
+    try {
+      raw = readFileSync(file, "utf8");
+    } catch {
+      break; // ordered log — stop here, do not skip ahead
+    }
+    consumed.push(file);
+    try {
+      control = foldControl(control ?? {}, JSON.parse(raw) as SituationControl);
+    } catch {
+      /* corrupt: consumed and dropped; no content, so no reordering */
+    }
+  }
+  return { control, consumed };
+}
+
 /** Append ONE patch. No read-modify-write, so concurrent writers cannot lose
  *  each other's updates and nothing needs to be locked. Returns the resulting
  *  pending state for the caller's display. */
 export function writeControl(c: Case, patch: SituationControl): SituationControl {
+  // Snapshot BEFORE appending. Peeking afterwards would let a concurrent take
+  // drain our own file first, so the value handed back to `situation set` could
+  // omit the very update it just made — misreporting to an operator or agent.
+  const before = readControl(c);
   mkdirSync(controlDir(c), { recursive: true });
   // Name sorts by write order. The millisecond alone is NOT enough — two sets
   // in the same tick would then be ordered by the random suffix, silently
@@ -255,21 +294,13 @@ export function writeControl(c: Case, patch: SituationControl): SituationControl
     randomBytes(4).toString("hex"),
   ].join("-") + ".json";
   writeFileAtomic(join(controlDir(c), name), JSON.stringify(patch, null, 2) + "\n");
-  return readControl(c) ?? patch;
+  return foldControl(before ?? {}, patch);
 }
 
 /** Non-destructive PEEK at the pending state (the verb's display, the
  *  extension's stop check). The server's apply path uses takeControl. */
 export function readControl(c: Case): SituationControl | undefined {
-  let pending: SituationControl | undefined;
-  for (const file of pendingPatchFiles(c)) {
-    try {
-      pending = foldControl(pending ?? {}, JSON.parse(readFileSync(file, "utf8")) as SituationControl);
-    } catch {
-      /* unreadable or corrupt — takeControl decides its fate, a peek doesn't */
-    }
-  }
-  return pending;
+  return foldPending(pendingPatchFiles(c)).control;
 }
 
 /** TAKE the pending control: fold every pending patch and remove the files that
@@ -282,26 +313,15 @@ export function readControl(c: Case): SituationControl | undefined {
  *  harmless: applying a config patch twice is idempotent, and replaying beats
  *  dropping. */
 export function takeControl(c: Case): SituationControl | undefined {
-  let pending: SituationControl | undefined;
-  for (const file of pendingPatchFiles(c)) {
-    let raw: string;
-    try {
-      raw = readFileSync(file, "utf8");
-    } catch {
-      continue; // transient — leave it for the next tick
-    }
-    try {
-      pending = foldControl(pending ?? {}, JSON.parse(raw) as SituationControl);
-    } catch {
-      /* corrupt — fall through and delete so it can't block every future tick */
-    }
+  const { control, consumed } = foldPending(pendingPatchFiles(c));
+  for (const file of consumed) {
     try {
       rmSync(file, { force: true });
     } catch {
       /* left behind; a re-read replays an idempotent patch */
     }
   }
-  return pending;
+  return control;
 }
 
 /** Before a FRESH serve binds, drop a stale `stop: true` still pending: it's
@@ -313,25 +333,13 @@ export function takeControl(c: Case): SituationControl | undefined {
  *  concurrently is left untouched rather than swept up — the same rule the take
  *  follows. Runs once, before the server binds. */
 export function clearStaleStop(c: Case): void {
-  // Track exactly which files were READ. Deleting the whole listing would
-  // discard a patch that failed to read — an operator command thrown away
-  // without ever being looked at, which is the rule the take follows and this
-  // must too. An unread patch simply survives to the first tick.
-  const read: string[] = [];
-  let pending: SituationControl | undefined;
-  for (const file of pendingPatchFiles(c)) {
-    try {
-      const patch = JSON.parse(readFileSync(file, "utf8")) as SituationControl;
-      pending = foldControl(pending ?? {}, patch);
-      read.push(file);
-    } catch {
-      /* unreadable or corrupt — leave it; the first take decides its fate */
-    }
-  }
-  if (!pending || pending.stop !== true) return;
-  const { stop: _stop, ...rest } = pending;
+  // deletes exactly what it CONSUMED — an unread patch is a command nobody has
+  // looked at, so sweeping it up would discard it silently
+  const { control, consumed } = foldPending(pendingPatchFiles(c));
+  if (!control || control.stop !== true) return;
+  const { stop: _stop, ...rest } = control;
   try {
-    for (const file of read) rmSync(file, { force: true });
+    for (const file of consumed) rmSync(file, { force: true });
     if (Object.keys(rest).length > 0) writeControl(c, rest);
   } catch {
     /* best-effort; the server also ignores a stop it can't attribute */

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -11,7 +11,7 @@
 //     replace, merging any not-yet-consumed control), consumed by the server on
 //     its next poll tick (~2s). `stop: true` shuts the server down gracefully.
 
-import { closeSync, fstatSync, mkdirSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
+import { closeSync, fstatSync, mkdirSync, openSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { join } from "node:path";
 import { writeFileAtomic } from "../fs-atomic.js";
@@ -197,17 +197,39 @@ export function readControl(c: Case): { control: SituationControl; mtimeMs: numb
   }
 }
 
-/** Consume (delete) the control file the server just applied — but only when
- *  its mtime still matches what was read, so a `situation set` racing the
- *  consume isn't silently dropped (it survives to the next tick). */
-export function consumeControl(c: Case, mtimeMs: number): void {
+/** TAKE the pending control: claim it and return it in ONE atomic step.
+ *
+ *  The old read → apply → `statSync` → `rmSync` shape could not be made safe. A
+ *  `situation set`/`stop` landing between the mtime check and the unlink was
+ *  deleted having never been applied — the operator's command vanished with no
+ *  error, which is the worst failure mode this control plane has. Narrowing the
+ *  window (dropping the existsSync, pairing mtime+body off one descriptor) makes
+ *  it rarer, not correct.
+ *
+ *  `rename(2)` is atomic: this either moves the current control.json aside or
+ *  fails because there is nothing pending. A writer that lands a microsecond
+ *  later publishes a NEW control.json (writeControl is itself an atomic rename),
+ *  which the next tick takes. No update can be consumed unseen.
+ *
+ *  Trade-off, deliberately: a crash between the take and applyConfig loses that
+ *  one control instead of replaying it. Apply is an in-memory call on the very
+ *  next line, so that window is negligible — and losing a control to a crash is
+ *  strictly better than deleting a live one the server never looked at. */
+export function takeControl(c: Case): SituationControl | undefined {
   const file = controlFile(c);
+  const taken = `${file}.taken`;
   try {
-    // no existsSync pre-check — a missing file throws ENOENT into the catch below,
-    // which is the same outcome without the check-then-use race
-    if (statSync(file).mtimeMs === mtimeMs) rmSync(file, { force: true });
+    renameSync(file, taken); // atomic claim; ENOENT = nothing pending
   } catch {
-    /* another writer landed mid-consume — leave it for the next tick */
+    return undefined;
+  }
+  try {
+    return JSON.parse(readFileSync(taken, "utf8")) as SituationControl;
+  } catch {
+    return undefined; // corrupt/truncated — dropped along with the file
+  } finally {
+    // a crash before this leaves one stale .taken; the next rename replaces it
+    rmSync(taken, { force: true });
   }
 }
 

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -239,16 +239,16 @@ function pendingPatchFiles(c: Case): string[] {
  *  Deliberate consequence: a patch that can never be read blocks the ones behind
  *  it. That is visible (the page stops following commands) and preferable to
  *  applying operator intent out of order, which would be silent. */
-function foldPending(files: string[]): { control?: SituationControl; consumed: string[]; blocked: boolean } {
+function foldPending(files: string[]): { control?: SituationControl; consumed: string[]; blockedBy?: string } {
   let control: SituationControl | undefined;
   const consumed: string[] = [];
-  let blocked = false;
+  let blockedBy: string | undefined;
   for (const file of files) {
     let raw: string;
     try {
       raw = readFileSync(file, "utf8");
     } catch {
-      blocked = true;
+      blockedBy = file;
       break; // ordered log — stop here, do not skip ahead
     }
     consumed.push(file);
@@ -258,7 +258,7 @@ function foldPending(files: string[]): { control?: SituationControl; consumed: s
       /* corrupt: consumed and dropped; no content, so no reordering */
     }
   }
-  return { control, consumed, blocked };
+  return { control, consumed, blockedBy };
 }
 
 /** Append ONE patch. No read-modify-write, so concurrent writers cannot lose
@@ -291,12 +291,17 @@ export function readControl(c: Case): SituationControl | undefined {
   return foldPending(pendingPatchFiles(c)).control;
 }
 
-/** True when an unreadable patch is holding the queue, so pending commands
+/** The PATH of the unreadable patch holding the queue, if any: pending commands
  *  BEHIND it cannot be applied yet. Callers surface this rather than reporting a
  *  clean success for something the server cannot take — a `situation set` that
- *  says "applied within ~2s" while the log is stuck is a lie to the operator. */
-export function controlBlocked(c: Case): boolean {
-  return foldPending(pendingPatchFiles(c)).blocked;
+ *  says "applied within ~2s" while the log is stuck is a lie to the operator.
+ *
+ *  Returns the path, not a boolean, so the operator is pointed at the actual
+ *  file. The blocker can be the LEGACY control.json rather than anything under
+ *  control.d/ (an interrupted upgrade), and a note naming only the directory
+ *  sends them looking in the wrong place. */
+export function blockedControlPath(c: Case): string | undefined {
+  return foldPending(pendingPatchFiles(c)).blockedBy;
 }
 
 /** TAKE the pending control: fold every pending patch and remove the files that

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -11,7 +11,7 @@
 //     replace, merging any not-yet-consumed control), consumed by the server on
 //     its next poll tick (~2s). `stop: true` shuts the server down gracefully.
 
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { closeSync, fstatSync, mkdirSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
 import { connect } from "node:net";
 import { join } from "node:path";
 import { writeFileAtomic } from "../fs-atomic.js";
@@ -181,9 +181,17 @@ export function writeControl(c: Case, patch: SituationControl): SituationControl
 export function readControl(c: Case): { control: SituationControl; mtimeMs: number } | undefined {
   const file = controlFile(c);
   try {
-    if (!existsSync(file)) return undefined;
-    const mtimeMs = statSync(file).mtimeMs;
-    return { control: JSON.parse(readFileSync(file, "utf8")) as SituationControl, mtimeMs };
+    // open ONCE and stat/read that descriptor: an existsSync + statSync + read
+    // trio races a concurrent `situation set` rewriting the file between calls
+    // (CodeQL js/file-system-race), which would pair one tick's mtime with the
+    // next tick's body and make the consume-on-match below drop a live update.
+    const fd = openSync(file, "r");
+    try {
+      const mtimeMs = fstatSync(fd).mtimeMs;
+      return { control: JSON.parse(readFileSync(fd, "utf8")) as SituationControl, mtimeMs };
+    } finally {
+      closeSync(fd);
+    }
   } catch {
     return undefined;
   }
@@ -195,7 +203,9 @@ export function readControl(c: Case): { control: SituationControl; mtimeMs: numb
 export function consumeControl(c: Case, mtimeMs: number): void {
   const file = controlFile(c);
   try {
-    if (existsSync(file) && statSync(file).mtimeMs === mtimeMs) rmSync(file, { force: true });
+    // no existsSync pre-check — a missing file throws ENOENT into the catch below,
+    // which is the same outcome without the check-then-use race
+    if (statSync(file).mtimeMs === mtimeMs) rmSync(file, { force: true });
   } catch {
     /* another writer landed mid-consume — leave it for the next tick */
   }

--- a/src/situation/state.ts
+++ b/src/situation/state.ts
@@ -11,7 +11,8 @@
 //     replace, merging any not-yet-consumed control), consumed by the server on
 //     its next poll tick (~2s). `stop: true` shuts the server down gracefully.
 
-import { mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { connect } from "node:net";
 import { join } from "node:path";
 import { writeFileAtomic } from "../fs-atomic.js";
@@ -157,6 +158,64 @@ export function parsePanels(raw: string | undefined): SituationPanel[] | undefin
   return [...new Set(items)] as SituationPanel[];
 }
 
+/** Serialize every MUTATION of the control file through an O_EXCL lock.
+ *
+ *  writeControl is a read-modify-write: it folds the operator's patch onto
+ *  whatever is still pending. Two `situation set`s racing (the agent and a CLI
+ *  in another terminal, say) could both read the same pending state and the
+ *  slower publish would clobber the faster one — an operator command lost with
+ *  no error, the exact failure this control plane is supposed to have stopped
+ *  having. A take landing mid-RMW could likewise resurrect an applied control.
+ *
+ *  So the lock covers ALL of the mutators (write / take / clearStaleStop), not
+ *  just the pair that happened to be reported. Held for microseconds around a
+ *  small JSON file.
+ *
+ *  Never fails the caller: if the lock can't be acquired within the budget we
+ *  proceed anyway. Dropping the operator's command to protect against a rare
+ *  interleaving would be the worse trade. A lock left by a killed process is
+ *  stolen once it goes stale. */
+const LOCK_STALE_MS = 5_000;
+const LOCK_WAIT_MS = 2_000;
+
+function sleepSync(ms: number): void {
+  // no sync sleep in Node; wait on a private SharedArrayBuffer nobody notifies
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function withControlLock<T>(c: Case, fn: () => T): T {
+  const lock = `${controlFile(c)}.lock`;
+  mkdirSync(situationDir(c), { recursive: true });
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  let held = false;
+  while (Date.now() < deadline) {
+    try {
+      closeSync(openSync(lock, "wx")); // atomic create = acquire
+      held = true;
+      break;
+    } catch {
+      try {
+        // a holder that died leaves the file behind; steal it once it's stale
+        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) rmSync(lock, { force: true });
+        else sleepSync(10);
+      } catch {
+        /* vanished under us — loop and try to acquire */
+      }
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    if (held) {
+      try {
+        rmSync(lock, { force: true });
+      } catch {
+        /* best effort; a leftover lock goes stale and is stolen */
+      }
+    }
+  }
+}
+
 /** Merge a control patch onto any pending (unconsumed) control and write it
  *  atomically. Two quick `situation set`s compose instead of clobbering. Clears
  *  compose by ORDER: a clear in the patch drops the key from pending (so the
@@ -164,6 +223,10 @@ export function parsePanels(raw: string | undefined): SituationPanel[] | undefin
  *  (so the re-set wins) — the server can then apply clears before assignments
  *  without reordering the operator's intent. */
 export function writeControl(c: Case, patch: SituationControl): SituationControl {
+  return withControlLock(c, () => writeControlLocked(c, patch));
+}
+
+function writeControlLocked(c: Case, patch: SituationControl): SituationControl {
   const pending: SituationControl = { ...(readControl(c) ?? {}) };
   if (patch.clear?.length) for (const key of patch.clear) delete pending[key];
   if (pending.clear?.length) {
@@ -210,21 +273,56 @@ export function readControl(c: Case): SituationControl | undefined {
  *  next line, so that window is negligible — and losing a control to a crash is
  *  strictly better than deleting a live one the server never looked at. */
 export function takeControl(c: Case): SituationControl | undefined {
+  return withControlLock(c, () => takeControlLocked(c));
+}
+
+function takeControlLocked(c: Case): SituationControl | undefined {
   const file = controlFile(c);
-  const taken = `${file}.taken`;
+  // a UNIQUE claim name per take: a fixed `.taken` assumes rename replaces an
+  // existing destination, which POSIX does but Windows does not — one leftover
+  // from a crash would then block every future claim, and pending controls would
+  // never be applied again.
+  const taken = `${file}.taken.${process.pid}.${randomBytes(4).toString("hex")}`;
   try {
     renameSync(file, taken); // atomic claim; ENOENT = nothing pending
   } catch {
     return undefined;
   }
+
+  let raw: string;
   try {
-    return JSON.parse(readFileSync(taken, "utf8")) as SituationControl;
+    raw = readFileSync(taken, "utf8");
   } catch {
-    return undefined; // corrupt/truncated — dropped along with the file
-  } finally {
-    // a crash before this leaves one stale .taken; the next rename replaces it
-    rmSync(taken, { force: true });
+    // A TRANSIENT IO error is not corruption — deleting here would destroy the
+    // operator's command. Put it back for the next tick, but only if nothing
+    // newer is already pending: a control written since our claim is the more
+    // recent intent and must not be clobbered by our restore.
+    try {
+      closeSync(openSync(file, "r")); // newer control exists → drop ours
+      rmSync(taken, { force: true });
+    } catch {
+      try {
+        renameSync(taken, file);
+      } catch {
+        /* best effort — the claim is lost, but nothing newer was overwritten */
+      }
+    }
+    return undefined;
   }
+
+  let parsed: SituationControl | undefined;
+  try {
+    parsed = JSON.parse(raw) as SituationControl;
+  } catch {
+    parsed = undefined; // genuinely corrupt — dropped with the file below
+  }
+  try {
+    rmSync(taken, { force: true });
+  } catch {
+    // must NOT suppress the return: a throw here would discard a control the
+    // caller is about to apply. A leftover claim file is harmless.
+  }
+  return parsed;
 }
 
 /** Before a FRESH serve binds, drop a stale `stop: true` still sitting in
@@ -234,6 +332,10 @@ export function takeControl(c: Case): SituationControl | undefined {
  *  set-before-start config is preserved (deleting the file only if nothing else
  *  remains). */
 export function clearStaleStop(c: Case): void {
+  withControlLock(c, () => clearStaleStopLocked(c));
+}
+
+function clearStaleStopLocked(c: Case): void {
   const cur = readControl(c);
   if (!cur || cur.stop !== true) return;
   const { stop: _stop, ...rest } = cur;

--- a/src/verbs/case.ts
+++ b/src/verbs/case.ts
@@ -5,7 +5,7 @@
 import { spawn } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { findingStatusMap, makeRecord, errRecord, recordTimeMs, PRIMARY_TEXT_FIELDS, type OvercastRecord } from "../record.js";
+import { findingStatusMap, makeRecord, errRecord, recordTimeMs, stripUrlTail, PRIMARY_TEXT_FIELDS, type OvercastRecord } from "../record.js";
 import { openCase, recordFiles } from "../case.js";
 import { humanSize } from "../render.js";
 import { collectVisualRefs, isHtmlExportPath, mdToPlainHtml, normalizeHtmlTheme, recordToTimelineRecord, renderCsiStatusReport, renderCsiTimelineReport } from "../report/html.js";
@@ -387,7 +387,7 @@ function setupFromExistingRegistries(ctx: VerbContext, caseName: string): CaseSe
 }
 
 function isImageTargetRef(ref: string): boolean {
-  return /\.(avif|bmp|gif|jpe?g|png|tiff?|webp)(?:[?#].*)?$/i.test(ref);
+  return /\.(avif|bmp|gif|jpe?g|png|tiff?|webp)$/i.test(stripUrlTail(ref));
 }
 
 function buildSetupChange(ctx: VerbContext, base: CaseSetup, op: "startup_setup" | "startup_setup_update", apply: boolean): SetupChange {

--- a/src/verbs/crop.ts
+++ b/src/verbs/crop.ts
@@ -273,7 +273,10 @@ function extFromMime(mime: string): string {
 }
 
 function materializeDataUrl(url: string, outDir: string, id: string): string {
-  const match = /^data:([^;,]+)?((?:;[^,]*)*),(.*)$/is.exec(url);
+  // `[^;,]` inside the parameter repetition (NOT `[^,]`, which can also match the
+  // `;` the outer group consumes): the ambiguous form backtracks exponentially on
+  // a crafted `data:;;;;…` URL from an untrusted provider (CodeQL js/redos).
+  const match = /^data:([^;,]+)?((?:;[^;,]*)*),(.*)$/is.exec(url);
   if (!match) throw new Error("invalid data URL");
   const mime = match[1] || "image/jpeg";
   const params = match[2] || "";
@@ -281,7 +284,6 @@ function materializeDataUrl(url: string, outDir: string, id: string): string {
   const frameDir = join(outDir, ".frames");
   mkdirSync(frameDir, { recursive: true });
   const out = join(frameDir, `${safePart(id)}${extFromMime(mime)}`);
-  if (existsSync(out)) return out;
   // Cap the decode too (http thumbnails go through the capped fetchMediaToCase):
   // a huge inline data URL from an untrusted provider must not OOM the process.
   const isBase64 = params.toLowerCase().includes(";base64");
@@ -293,7 +295,14 @@ function materializeDataUrl(url: string, outDir: string, id: string): string {
     throw new Error(`inline data URL too large (~${estBytes} bytes, cap ${THUMBNAIL_MAX_BYTES})`);
   }
   const buf = isBase64 ? Buffer.from(data, "base64") : Buffer.from(decodeURIComponent(data));
-  writeFileSync(out, buf);
+  // `wx` instead of an existsSync cache check + plain write: the check-then-write
+  // pair is a TOCTOU race (CodeQL js/file-system-race). The name is id-addressed,
+  // so an existing file already holds this exact content — EEXIST IS the cache hit.
+  try {
+    writeFileSync(out, buf, { flag: "wx" });
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+  }
   return out;
 }
 

--- a/src/verbs/crop.ts
+++ b/src/verbs/crop.ts
@@ -4,13 +4,14 @@
 // the source detection record remains the full audit trail.
 
 import { createHash } from "node:crypto";
-import { closeSync, existsSync, mkdirSync, openSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { basename, extname, join } from "node:path";
 import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { cropStill, modalityFromExt, probe, type CropBox } from "../media/ffmpeg.js";
 import { fetchMediaToCase } from "../media/fetch.js";
 import { badNumber } from "./validate.js";
 import { stampArchive } from "../archive.js";
+import { writeFileAtomic } from "../fs-atomic.js";
 import type { VerbSpec } from "../registry/types.js";
 
 type CropKind = "face" | "object";
@@ -284,39 +285,33 @@ function materializeDataUrl(url: string, outDir: string, id: string): string {
   const frameDir = join(outDir, ".frames");
   mkdirSync(frameDir, { recursive: true });
   const out = join(frameDir, `${safePart(id)}${extFromMime(mime)}`);
-  // ONE atomic `wx` open does both jobs: it claims the slot and answers "is this
-  // already materialized?". EEXIST is the cache hit — return before decoding, so
-  // a repeat crop never re-runs up to 64MB of base64. Everything after writes to
-  // the DESCRIPTOR, never the path, so there is no second resolution to race
-  // (an existsSync/open probe followed by a path write is exactly the
-  // check-then-use pair CodeQL js/file-system-race flags).
-  let fd: number;
+  // Cache hit = the file is simply THERE. That inference is only sound because
+  // frames are published by an atomic rename below: a file at `out` is always
+  // whole. The previous `wx`-claim approach created an EMPTY file up front, so a
+  // crash (or a concurrent claimer) between claim and write cached a zero-byte
+  // frame permanently — complete-or-absent removes the partial state entirely.
+  // Returning here also skips decoding up to 64MB of base64 on a repeat crop.
   try {
-    fd = openSync(out, "wx");
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === "EEXIST") return out; // id-addressed: same content
-    throw e;
+    closeSync(openSync(out, "r"));
+    return out;
+  } catch {
+    /* not materialized yet — decode and publish below */
   }
-  try {
-    // Cap the decode too (http thumbnails go through the capped fetchMediaToCase):
-    // a huge inline data URL from an untrusted provider must not OOM the process.
-    const isBase64 = params.toLowerCase().includes(";base64");
-    // For base64, decoded ≈ 3/4 of the ASCII char count. For percent/plain, use the
-    // UTF-8 BYTE length (data.length is UTF-16 units and underestimates multibyte) —
-    // an upper bound on the decoded buffer, so a Unicode-crafted URL can't slip past.
-    const estBytes = isBase64 ? Math.floor((data.length * 3) / 4) : Buffer.byteLength(data, "utf8");
-    if (estBytes > THUMBNAIL_MAX_BYTES) {
-      throw new Error(`inline data URL too large (~${estBytes} bytes, cap ${THUMBNAIL_MAX_BYTES})`);
-    }
-    writeFileSync(fd, isBase64 ? Buffer.from(data, "base64") : Buffer.from(decodeURIComponent(data)));
-  } catch (e) {
-    // never leave the empty file we just claimed behind — the next call would
-    // read it as a cache hit and crop a zero-byte frame
-    closeSync(fd);
-    rmSync(out, { force: true });
-    throw e;
+  // Cap the decode too (http thumbnails go through the capped fetchMediaToCase):
+  // a huge inline data URL from an untrusted provider must not OOM the process.
+  const isBase64 = params.toLowerCase().includes(";base64");
+  // For base64, decoded ≈ 3/4 of the ASCII char count. For percent/plain, use the
+  // UTF-8 BYTE length (data.length is UTF-16 units and underestimates multibyte) —
+  // an upper bound on the decoded buffer, so a Unicode-crafted URL can't slip past.
+  const estBytes = isBase64 ? Math.floor((data.length * 3) / 4) : Buffer.byteLength(data, "utf8");
+  if (estBytes > THUMBNAIL_MAX_BYTES) {
+    throw new Error(`inline data URL too large (~${estBytes} bytes, cap ${THUMBNAIL_MAX_BYTES})`);
   }
-  closeSync(fd);
+  // temp-then-rename (the shared state-store helper): a reader never sees a
+  // partial frame, and a crash leaves only a .tmp behind — never a poisoned cache
+  // entry. Two crops racing the same id both publish identical bytes, so
+  // last-writer-wins is harmless.
+  writeFileAtomic(out, isBase64 ? Buffer.from(data, "base64") : Buffer.from(decodeURIComponent(data)));
   return out;
 }
 

--- a/src/verbs/crop.ts
+++ b/src/verbs/crop.ts
@@ -4,7 +4,7 @@
 // the source detection record remains the full audit trail.
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, writeFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
 import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { cropStill, modalityFromExt, probe, type CropBox } from "../media/ffmpeg.js";
@@ -284,6 +284,16 @@ function materializeDataUrl(url: string, outDir: string, id: string): string {
   const frameDir = join(outDir, ".frames");
   mkdirSync(frameDir, { recursive: true });
   const out = join(frameDir, `${safePart(id)}${extFromMime(mime)}`);
+  // Cache probe BEFORE the decode: the name is id-addressed, so an openable file
+  // already holds this exact content and a repeat crop must not re-decode up to
+  // the 64MB cap. Opening (rather than existsSync-ing) keeps this off the
+  // check-then-use path — the write below is `wx` and races safely regardless.
+  try {
+    closeSync(openSync(out, "r"));
+    return out;
+  } catch {
+    /* not materialized yet — decode below */
+  }
   // Cap the decode too (http thumbnails go through the capped fetchMediaToCase):
   // a huge inline data URL from an untrusted provider must not OOM the process.
   const isBase64 = params.toLowerCase().includes(";base64");

--- a/src/verbs/crop.ts
+++ b/src/verbs/crop.ts
@@ -4,7 +4,7 @@
 // the source detection record remains the full audit trail.
 
 import { createHash } from "node:crypto";
-import { closeSync, existsSync, mkdirSync, openSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, rmSync, writeFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
 import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
 import { cropStill, modalityFromExt, probe, type CropBox } from "../media/ffmpeg.js";
@@ -284,35 +284,39 @@ function materializeDataUrl(url: string, outDir: string, id: string): string {
   const frameDir = join(outDir, ".frames");
   mkdirSync(frameDir, { recursive: true });
   const out = join(frameDir, `${safePart(id)}${extFromMime(mime)}`);
-  // Cache probe BEFORE the decode: the name is id-addressed, so an openable file
-  // already holds this exact content and a repeat crop must not re-decode up to
-  // the 64MB cap. Opening (rather than existsSync-ing) keeps this off the
-  // check-then-use path — the write below is `wx` and races safely regardless.
+  // ONE atomic `wx` open does both jobs: it claims the slot and answers "is this
+  // already materialized?". EEXIST is the cache hit — return before decoding, so
+  // a repeat crop never re-runs up to 64MB of base64. Everything after writes to
+  // the DESCRIPTOR, never the path, so there is no second resolution to race
+  // (an existsSync/open probe followed by a path write is exactly the
+  // check-then-use pair CodeQL js/file-system-race flags).
+  let fd: number;
   try {
-    closeSync(openSync(out, "r"));
-    return out;
-  } catch {
-    /* not materialized yet — decode below */
-  }
-  // Cap the decode too (http thumbnails go through the capped fetchMediaToCase):
-  // a huge inline data URL from an untrusted provider must not OOM the process.
-  const isBase64 = params.toLowerCase().includes(";base64");
-  // For base64, decoded ≈ 3/4 of the ASCII char count. For percent/plain, use the
-  // UTF-8 BYTE length (data.length is UTF-16 units and underestimates multibyte) —
-  // an upper bound on the decoded buffer, so a Unicode-crafted URL can't slip past.
-  const estBytes = isBase64 ? Math.floor((data.length * 3) / 4) : Buffer.byteLength(data, "utf8");
-  if (estBytes > THUMBNAIL_MAX_BYTES) {
-    throw new Error(`inline data URL too large (~${estBytes} bytes, cap ${THUMBNAIL_MAX_BYTES})`);
-  }
-  const buf = isBase64 ? Buffer.from(data, "base64") : Buffer.from(decodeURIComponent(data));
-  // `wx` instead of an existsSync cache check + plain write: the check-then-write
-  // pair is a TOCTOU race (CodeQL js/file-system-race). The name is id-addressed,
-  // so an existing file already holds this exact content — EEXIST IS the cache hit.
-  try {
-    writeFileSync(out, buf, { flag: "wx" });
+    fd = openSync(out, "wx");
   } catch (e) {
-    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    if ((e as NodeJS.ErrnoException).code === "EEXIST") return out; // id-addressed: same content
+    throw e;
   }
+  try {
+    // Cap the decode too (http thumbnails go through the capped fetchMediaToCase):
+    // a huge inline data URL from an untrusted provider must not OOM the process.
+    const isBase64 = params.toLowerCase().includes(";base64");
+    // For base64, decoded ≈ 3/4 of the ASCII char count. For percent/plain, use the
+    // UTF-8 BYTE length (data.length is UTF-16 units and underestimates multibyte) —
+    // an upper bound on the decoded buffer, so a Unicode-crafted URL can't slip past.
+    const estBytes = isBase64 ? Math.floor((data.length * 3) / 4) : Buffer.byteLength(data, "utf8");
+    if (estBytes > THUMBNAIL_MAX_BYTES) {
+      throw new Error(`inline data URL too large (~${estBytes} bytes, cap ${THUMBNAIL_MAX_BYTES})`);
+    }
+    writeFileSync(fd, isBase64 ? Buffer.from(data, "base64") : Buffer.from(decodeURIComponent(data)));
+  } catch (e) {
+    // never leave the empty file we just claimed behind — the next call would
+    // read it as a cache hit and crop a zero-byte frame
+    closeSync(fd);
+    rmSync(out, { force: true });
+    throw e;
+  }
+  closeSync(fd);
   return out;
 }
 

--- a/src/verbs/face.ts
+++ b/src/verbs/face.ts
@@ -9,7 +9,7 @@
 //   face <video> --index <id>         → list     (stored detections for that video)
 
 import { existsSync } from "node:fs";
-import { isReady, makeRecord, errRecord, type OvercastRecord } from "../record.js";
+import { isReady, makeRecord, errRecord, stripUrlTail, type OvercastRecord } from "../record.js";
 import { runFace, type FaceOp, type FaceParams } from "../providers/tinycloud/face.js";
 import { tinycloudBaseFromRun, TC_SUBCOMMANDS, TINYCLOUD_TIMEOUT_MS } from "../providers/tinycloud/envelope.js";
 import { isCustomBinding, runBoundProvider } from "../providers/run.js";
@@ -31,7 +31,7 @@ const err = (message: string): OvercastRecord => errRecord("face", message);
 const FACE_QUERY_IMAGE_RE = /\.(jpe?g|png)$/i;
 
 function faceQueryImageError(ref: string): string | undefined {
-  const clean = ref.replace(/[?#].*$/, "");
+  const clean = stripUrlTail(ref);
   return FACE_QUERY_IMAGE_RE.test(clean)
     ? undefined
     : `--match image must be a JPEG or PNG: ${ref} (tinycloud face preflight rejects webp/heic/gif/bmp/tiff/avif; webp support in 0.3.7 is see/extract-only)`;

--- a/src/verbs/media-ref.ts
+++ b/src/verbs/media-ref.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { basename, resolve, sep, isAbsolute } from "node:path";
 import { realpathContained } from "../fs-path.js";
-import { isReady, type OvercastRecord } from "../record.js";
+import { isReady, stripUrlTail, type OvercastRecord } from "../record.js";
 import type { Case } from "../case.js";
 import { ARCHIVE_REF_PREFIX, bucketPathStatus, bucketRecordForPath, listBucketItems, openBucket, parseArchiveRef, resolveBucketPath } from "../archive.js";
 
@@ -53,7 +53,7 @@ const IMAGE_RE = /\.(jpe?g|png|webp|bmp|tiff?|gif|avif|heic)$/i;
 
 /** Whether a ref looks like audio/video the senses/indexes can use. */
 export const isAv = (ref: string): boolean => /^https?:\/\//i.test(ref) || AV_RE.test(ref);
-export const isImage = (ref: string): boolean => /^https?:\/\//i.test(ref) || IMAGE_RE.test(ref.replace(/[?#].*$/, ""));
+export const isImage = (ref: string): boolean => /^https?:\/\//i.test(ref) || IMAGE_RE.test(stripUrlTail(ref));
 
 /** Whether a case RECORD is registerable case media: a captured/sensed verb, an
  *  AV `media.ref`, and NOT a face SEARCH (whose media is the query image, not a

--- a/src/verbs/osint.ts
+++ b/src/verbs/osint.ts
@@ -5,7 +5,7 @@
 import { join, basename, dirname } from "node:path";
 import { copyFileSync, existsSync, appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
+import { makeRecord, errRecord, stripUrlTail, type OvercastRecord } from "../record.js";
 import { sniffExt } from "../media/fetch.js";
 import {
   builtinDescriptor,
@@ -65,7 +65,7 @@ function scanFlagError(ctx: VerbContext, verb = "scan"): OvercastRecord | undefi
 }
 
 const VIDEO_RE = /\.(mp4|m4v|mov|webm|mkv|avi|mpe?g|m2ts|mts|ts|wmv|flv|3gp|3g2|ogv|mxf)$/i;
-const isVideoRef = (ref: string): boolean => !/^https?:\/\//i.test(ref) && VIDEO_RE.test(ref.replace(/[?#].*$/, ""));
+const isVideoRef = (ref: string): boolean => !/^https?:\/\//i.test(ref) && VIDEO_RE.test(stripUrlTail(ref));
 const isLocalVisualRef = (ref: string): boolean => isVideoRef(ref) || isImage(ref);
 
 function localMediaRefs(ctx: VerbContext): string[] {

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -35,6 +35,7 @@ import {
   parsePanels,
   readControl,
   blockedControlPath,
+  controlSnapshot,
   readRuntime,
   runtimeAlive,
   runtimeServing,
@@ -192,7 +193,8 @@ export const situationVerb: VerbSpec = {
       }
       const merged = writeControl(cc, { ...parsed.config, ...(clear ? { clear } : {}) });
       // an unreadable patch earlier in the log holds everything behind it, this
-      // write included — say so instead of reporting a clean apply
+      // write included — say so instead of reporting a clean apply. ONE call:
+      // the value is used twice below and two folds could disagree.
       const blockedBy = blockedControlPath(cc);
       const rt = readRuntime(cc);
       // "running" must reflect a server actually SERVING (pid alive AND the port
@@ -255,6 +257,9 @@ export const situationVerb: VerbSpec = {
       }
       writeControl(cc, { stop: true } satisfies SituationControl);
       let delivered = "control";
+      // ONE snapshot for the payload below: calling blockedControlPath twice
+      // lets a concurrent drain report blocked:true beside a path that is gone
+      const stopBlockedBy = blockedControlPath(cc);
       // whether a SIGTERM actually went out. Tracked as a fact rather than sniffed
       // out of `delivered`: that string says "not signal" in one of its
       // force-ignored variants, so any substring test on it is a trap.
@@ -293,10 +298,10 @@ export const situationVerb: VerbSpec = {
             // A stop that rides the QUEUE ALONE is subject to a blocked log; one
             // that was also signalled has already killed the process, so
             // reporting it as stuck would contradict what just happened.
-            ...(!signalled && blockedControlPath(cc)
+            ...(!signalled && stopBlockedBy
               ? {
                   blocked: true,
-                  blocked_path: blockedControlPath(cc),
+                  blocked_path: stopBlockedBy,
                   blocked_note:
                     "an earlier control patch cannot be read — this stop will NOT be honored until that patch is removed or repaired",
                 }
@@ -534,11 +539,12 @@ async function statusRecord(ctx: VerbContext, cc: Case = ctx.case): Promise<Over
   // running = pid alive AND the recorded port is actually served (Bugbot #98/med:
   // a read-only surface must not report "live" off a reused pid alone).
   const running = runtimeAlive(rt) && (await runtimeServing(rt));
-  const pending = readControl(cc) ?? null;
+  const snap = controlSnapshot(cc);
+  const pending = snap.control ?? null;
   // an unreadable patch holds everything behind it, so `pending` here is the
   // APPLYABLE prefix, not the whole queue — say so rather than showing a clean
   // (and possibly empty) view of a stuck control log
-  const blockedBy = blockedControlPath(cc);
+  const blockedBy = snap.blockedBy;
   return makeRecord({
     verb: "situation",
     format: "json",

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -34,7 +34,7 @@ import {
   inProcessSituationCaseDir,
   parsePanels,
   readControl,
-  controlBlocked,
+  blockedControlPath,
   readRuntime,
   runtimeAlive,
   runtimeServing,
@@ -193,7 +193,7 @@ export const situationVerb: VerbSpec = {
       const merged = writeControl(cc, { ...parsed.config, ...(clear ? { clear } : {}) });
       // an unreadable patch earlier in the log holds everything behind it, this
       // write included — say so instead of reporting a clean apply
-      const blocked = controlBlocked(cc);
+      const blockedBy = blockedControlPath(cc);
       const rt = readRuntime(cc);
       // "running" must reflect a server actually SERVING (pid alive AND the port
       // is up), not just a live/reused pid (Bugbot #98/med) — else `set` tells
@@ -207,9 +207,9 @@ export const situationVerb: VerbSpec = {
             op: "set",
             control: merged,
             running,
-            ...(blocked ? { blocked: true } : {}),
-            note: blocked
-              ? "queued, but an earlier control patch cannot be read — THIS command sits behind it and will not apply until that patch is removed or repaired (earlier readable ones still apply; see .overcast/situation/control.d)"
+            ...(blockedBy ? { blocked: true, blocked_path: blockedBy } : {}),
+            note: blockedBy
+              ? `queued, but an earlier control patch cannot be read (${blockedBy}) — THIS command sits behind it and will not apply until that patch is removed or repaired (earlier readable ones still apply)`
               : running
                 ? `applied by the live page within ~2s (${rt!.displayUrl})`
                 : "no situation is running — the control applies when one starts",
@@ -234,7 +234,7 @@ export const situationVerb: VerbSpec = {
         // control is honored by the rebound server's first tick. A genuinely
         // fresh serve is unaffected: every serve clears a stale stop at start.
         writeControl(cc, { stop: true } satisfies SituationControl);
-        const stopBlocked = controlBlocked(cc);
+        const stopBlockedBy = blockedControlPath(cc);
         return [
           makeRecord({
             verb: "situation",
@@ -242,9 +242,9 @@ export const situationVerb: VerbSpec = {
             payload: {
               op: "stop",
               running: false,
-              ...(stopBlocked ? { blocked: true } : {}),
-              note: stopBlocked
-                ? "stop queued, but an earlier control patch cannot be read — it will NOT be honored until that is removed or repaired (see .overcast/situation/control.d)"
+              ...(stopBlockedBy ? { blocked: true, blocked_path: stopBlockedBy } : {}),
+              note: stopBlockedBy
+                ? `stop queued, but an earlier control patch cannot be read (${stopBlockedBy}) — it will NOT be honored until that patch is removed or repaired`
                 : "no situation is running — stop queued (honored by a server starting on this case; a fresh serve clears it)",
               ...(cc.dir !== ctx.case.dir ? { steered_case: cc.dir } : {}),
             },
@@ -293,11 +293,12 @@ export const situationVerb: VerbSpec = {
             // A stop that rides the QUEUE ALONE is subject to a blocked log; one
             // that was also signalled has already killed the process, so
             // reporting it as stuck would contradict what just happened.
-            ...(!signalled && controlBlocked(cc)
+            ...(!signalled && blockedControlPath(cc)
               ? {
                   blocked: true,
+                  blocked_path: blockedControlPath(cc),
                   blocked_note:
-                    "an earlier control patch cannot be read — this stop will NOT be honored until it is removed or repaired (see .overcast/situation/control.d)",
+                    "an earlier control patch cannot be read — this stop will NOT be honored until that patch is removed or repaired",
                 }
               : {}),
             ...(cc.dir !== ctx.case.dir ? { steered_case: cc.dir } : {}),
@@ -537,18 +538,19 @@ async function statusRecord(ctx: VerbContext, cc: Case = ctx.case): Promise<Over
   // an unreadable patch holds everything behind it, so `pending` here is the
   // APPLYABLE prefix, not the whole queue — say so rather than showing a clean
   // (and possibly empty) view of a stuck control log
-  const blocked = controlBlocked(cc);
+  const blockedBy = blockedControlPath(cc);
   return makeRecord({
     verb: "situation",
     format: "json",
     payload: {
       op: "status",
       running,
-      ...(blocked
+      ...(blockedBy
         ? {
             blocked: true,
+            blocked_path: blockedBy,
             blocked_note:
-              "a control patch cannot be read — the pending control shown is the APPLYABLE PREFIX; anything queued behind that patch is not applying (see .overcast/situation/control.d)",
+              "a control patch cannot be read — the pending control shown is the APPLYABLE PREFIX; anything queued behind that patch is not applying",
           }
         : {}),
       ...(rt && running

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -34,6 +34,7 @@ import {
   inProcessSituationCaseDir,
   parsePanels,
   readControl,
+  controlBlocked,
   readRuntime,
   runtimeAlive,
   runtimeServing,
@@ -190,6 +191,9 @@ export const situationVerb: VerbSpec = {
         return [err("situation set: nothing to set (pass --panels/--source/--since/--limit/--theme/--query, or --clear <keys>)")];
       }
       const merged = writeControl(cc, { ...parsed.config, ...(clear ? { clear } : {}) });
+      // an unreadable patch earlier in the log holds everything behind it, this
+      // write included — say so instead of reporting a clean apply
+      const blocked = controlBlocked(cc);
       const rt = readRuntime(cc);
       // "running" must reflect a server actually SERVING (pid alive AND the port
       // is up), not just a live/reused pid (Bugbot #98/med) — else `set` tells
@@ -203,9 +207,12 @@ export const situationVerb: VerbSpec = {
             op: "set",
             control: merged,
             running,
-            note: running
-              ? `applied by the live page within ~2s (${rt!.displayUrl})`
-              : "no situation is running — the control applies when one starts",
+            ...(blocked ? { blocked: true } : {}),
+            note: blocked
+              ? "queued, but an earlier control patch cannot be read — nothing applies until it is removed or repaired (see .overcast/situation/control.d)"
+              : running
+                ? `applied by the live page within ~2s (${rt!.displayUrl})`
+                : "no situation is running — the control applies when one starts",
             ...(cc.dir !== ctx.case.dir ? { steered_case: cc.dir } : {}),
           },
           meta: { provider: "situation", case: ctx.case.dir },

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -507,7 +507,7 @@ async function statusRecord(ctx: VerbContext, cc: Case = ctx.case): Promise<Over
   // running = pid alive AND the recorded port is actually served (Bugbot #98/med:
   // a read-only surface must not report "live" off a reused pid alone).
   const running = runtimeAlive(rt) && (await runtimeServing(rt));
-  const pending = readControl(cc)?.control ?? null;
+  const pending = readControl(cc) ?? null;
   return makeRecord({
     verb: "situation",
     format: "json",

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -209,7 +209,7 @@ export const situationVerb: VerbSpec = {
             running,
             ...(blocked ? { blocked: true } : {}),
             note: blocked
-              ? "queued, but an earlier control patch cannot be read — nothing applies until it is removed or repaired (see .overcast/situation/control.d)"
+              ? "queued, but an earlier control patch cannot be read — THIS command sits behind it and will not apply until that patch is removed or repaired (earlier readable ones still apply; see .overcast/situation/control.d)"
               : running
                 ? `applied by the live page within ~2s (${rt!.displayUrl})`
                 : "no situation is running — the control applies when one starts",
@@ -543,7 +543,7 @@ async function statusRecord(ctx: VerbContext, cc: Case = ctx.case): Promise<Over
         ? {
             blocked: true,
             blocked_note:
-              "a control patch cannot be read — pending commands behind it are NOT applying (see .overcast/situation/control.d)",
+              "a control patch cannot be read — the pending control shown is the APPLYABLE PREFIX; anything queued behind that patch is not applying (see .overcast/situation/control.d)",
           }
         : {}),
       ...(rt && running

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -234,6 +234,7 @@ export const situationVerb: VerbSpec = {
         // control is honored by the rebound server's first tick. A genuinely
         // fresh serve is unaffected: every serve clears a stale stop at start.
         writeControl(cc, { stop: true } satisfies SituationControl);
+        const stopBlocked = controlBlocked(cc);
         return [
           makeRecord({
             verb: "situation",
@@ -241,7 +242,10 @@ export const situationVerb: VerbSpec = {
             payload: {
               op: "stop",
               running: false,
-              note: "no situation is running — stop queued (honored by a server starting on this case; a fresh serve clears it)",
+              ...(stopBlocked ? { blocked: true } : {}),
+              note: stopBlocked
+                ? "stop queued, but an earlier control patch cannot be read — it will NOT be honored until that is removed or repaired (see .overcast/situation/control.d)"
+                : "no situation is running — stop queued (honored by a server starting on this case; a fresh serve clears it)",
               ...(cc.dir !== ctx.case.dir ? { steered_case: cc.dir } : {}),
             },
             meta: { provider: "situation", case: ctx.case.dir },
@@ -281,6 +285,16 @@ export const situationVerb: VerbSpec = {
             pid: rt!.pid,
             url: rt!.displayUrl,
             delivered,
+            // a control-delivered stop rides the same queue as everything else,
+            // so a blocked log means the server will NOT see it (a --force
+            // signal still lands, which `delivered` already distinguishes)
+            ...(delivered.startsWith("control") && controlBlocked(cc)
+              ? {
+                  blocked: true,
+                  blocked_note:
+                    "an earlier control patch cannot be read — this stop will NOT be honored until it is removed or repaired (see .overcast/situation/control.d)",
+                }
+              : {}),
             ...(cc.dir !== ctx.case.dir ? { steered_case: cc.dir } : {}),
           },
           meta: { provider: "situation", case: ctx.case.dir },
@@ -515,12 +529,23 @@ async function statusRecord(ctx: VerbContext, cc: Case = ctx.case): Promise<Over
   // a read-only surface must not report "live" off a reused pid alone).
   const running = runtimeAlive(rt) && (await runtimeServing(rt));
   const pending = readControl(cc) ?? null;
+  // an unreadable patch holds everything behind it, so `pending` here is the
+  // APPLYABLE prefix, not the whole queue — say so rather than showing a clean
+  // (and possibly empty) view of a stuck control log
+  const blocked = controlBlocked(cc);
   return makeRecord({
     verb: "situation",
     format: "json",
     payload: {
       op: "status",
       running,
+      ...(blocked
+        ? {
+            blocked: true,
+            blocked_note:
+              "a control patch cannot be read — pending commands behind it are NOT applying (see .overcast/situation/control.d)",
+          }
+        : {}),
       ...(rt && running
         ? {
             url: rt.url,

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -12,7 +12,7 @@
 //          action (the chair rule) — the agent tool and TUI slash are refused
 //          here (use /situation on in the TUI; it runs in-process).
 //   status / set / stop — the control plane, agent-safe: they only read
-//          .overcast/situation/runtime.json or write control.json, which the
+//          .overcast/situation/runtime.json or append a control patch, which the
 //          serving process applies on its next poll tick (~2s).
 
 import { makeRecord, errRecord, type OvercastRecord } from "../record.js";
@@ -382,7 +382,7 @@ export const situationVerb: VerbSpec = {
     } catch (e) {
       const code = (e as NodeJS.ErrnoException).code;
       // the loser of a bind race lands here and returns WITHOUT touching
-      // runtime.json/control.json, so it can't clobber the winner's state.
+      // runtime.json or the control patches, so it can't clobber the winner's state.
       return [
         err(
           code === "EADDRINUSE"

--- a/src/verbs/situation.ts
+++ b/src/verbs/situation.ts
@@ -255,6 +255,10 @@ export const situationVerb: VerbSpec = {
       }
       writeControl(cc, { stop: true } satisfies SituationControl);
       let delivered = "control";
+      // whether a SIGTERM actually went out. Tracked as a fact rather than sniffed
+      // out of `delivered`: that string says "not signal" in one of its
+      // force-ignored variants, so any substring test on it is a trap.
+      let signalled = false;
       // --force SIGTERM is ONLY for a dedicated CLI serve pane. For a `/situation
       // on` (mode "tui") the runtime pid IS the whole TUI session, so signalling
       // it would kill the operator's editor (Bugbot #98/high) — the in-process
@@ -268,6 +272,7 @@ export const situationVerb: VerbSpec = {
           try {
             process.kill(rt.pid, "SIGTERM");
             delivered = "control+signal";
+            signalled = true;
           } catch {
             /* already exiting */
           }
@@ -285,10 +290,10 @@ export const situationVerb: VerbSpec = {
             pid: rt!.pid,
             url: rt!.displayUrl,
             delivered,
-            // a control-delivered stop rides the same queue as everything else,
-            // so a blocked log means the server will NOT see it (a --force
-            // signal still lands, which `delivered` already distinguishes)
-            ...(delivered.startsWith("control") && controlBlocked(cc)
+            // A stop that rides the QUEUE ALONE is subject to a blocked log; one
+            // that was also signalled has already killed the process, so
+            // reporting it as stuck would contradict what just happened.
+            ...(!signalled && controlBlocked(cc)
               ? {
                   blocked: true,
                   blocked_note:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -212,7 +212,7 @@ external assets — plus the live monitoring page (`phase6_situation`):
 token-authed `serve` on an ephemeral port (discovered via `runtime.json`), the
 `/api/state` auth boundary (401 without the token, 200 + JSON snapshot with it) +
 the static console shell, a cross-process `situation set` the running server
-consumes (`control.json` swept on its ~2s tick), and a graceful `situation stop`
+consumes (patches under `control.d/` drained on its ~2s tick), and a graceful `situation stop`
 that exits the serving process + sweeps `runtime.json` — plus the
 global archive (`phase9_archive`): bucket init/add/dedup/show under an isolated
 `OVERCAST_HOME`, `capture archive:…` pulls, `ask --archive`, the setup wizard

--- a/test/e2e/cases/phase6_situation.sh
+++ b/test/e2e/cases/phase6_situation.sh
@@ -6,7 +6,7 @@
 #       (OVERCAST_SITUATION_PORT=0), discovered via .overcast/situation/runtime.json.
 #   (c) the auth boundary on /api/state — 401 without the token, 200 (+ JSON
 #       snapshot) with it — plus the static console shell at / (served, secret-free).
-#   (d) a cross-process `situation set` the running server consumes (control.json
+#   (d) a cross-process `situation set` the running server consumes (patches under
 #       written, then swept on the ~2s control tick).
 #   (e) a graceful `situation stop` that exits the serving process + sweeps
 #       runtime.json.
@@ -19,7 +19,7 @@ source "$DIR/lib.sh"
 casedir="$SMOKE_DIR/case_situation"; mkdir -p "$casedir"
 sitdir="$casedir/.overcast/situation"
 rtfile="$sitdir/runtime.json"
-ctlfile="$sitdir/control.json"
+ctldir="$sitdir/control.d"
 TOKEN="sit_tok_phase6"
 
 serve_pid=""
@@ -115,13 +115,27 @@ save_json "phase6_situation_set" "$setout" >/dev/null
 assert_eq "situation.set_op" "set" "$(jq -r '.payload.op' <<<"$setout")" "set emits a set op"
 assert_eq "situation.set_running" "true" "$(jq -r '.payload.running' <<<"$setout")" "set sees the live server"
 assert_eq "situation.set_control" "8" "$(jq -r '.payload.control.limit' <<<"$setout")" "set records the new limit"
-# the serving process consumes (deletes) control.json once it applies the patch
+# The serving process drains the patch directory once it applies the set. Assert
+# the APPLIED EFFECT, not just the drain: this previously waited on control.json
+# disappearing, and when the control plane became a patch directory that file
+# stopped existing at all — so the check passed without verifying anything.
 i=0
-while [ -f "$ctlfile" ] && [ "$i" -lt 30 ]; do sleep 0.5; i=$((i + 1)); done
-if [ ! -f "$ctlfile" ]; then
-  ok "situation.set_consumed" "the live server consumed control.json (applied the set)"
+while [ "$(find "$ctldir" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')" != "0" ] && [ "$i" -lt 30 ]; do
+  sleep 0.5; i=$((i + 1))
+done
+pending_left="$(find "$ctldir" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$pending_left" != "0" ]; then
+  fail "situation.set_consumed" "control patches not drained within ~15s ($pending_left left)"
+elif command -v curl >/dev/null 2>&1 && [ -n "${base:-}" ]; then
+  # the drain is only meaningful if the server actually took the value on
+  applied="$(curl -s --max-time 10 "$base/api/state?token=$TOKEN" 2>/dev/null | jq -r '.config.limit' 2>/dev/null)"
+  if [ "$applied" = "8" ]; then
+    ok "situation.set_consumed" "the live server drained the patch AND applied limit=8"
+  else
+    fail "situation.set_consumed" "patch drained but server config.limit is '$applied', expected 8"
+  fi
 else
-  fail "situation.set_consumed" "control.json not consumed within ~15s"
+  ok "situation.set_consumed" "the live server drained the pending control patch (no curl to confirm the value)"
 fi
 
 # (e) a graceful stop exits the serving process + sweeps runtime.json

--- a/test/unit/case.test.ts
+++ b/test/unit/case.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, statSync, utimesSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, openSync, fstatSync, closeSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openCase, recordFiles } from "../../src/case.ts";
@@ -208,8 +208,18 @@ test("records() cache: a same-size in-place edit is detected even if mtime is fo
     assert.equal((c.recordById("rec_ss")?.payload as { content: string }).content, "AAAA");
 
     const f = join(c.recordsDir, "watch.jsonl");
-    const beforeMtime = statSync(f).mtime;
-    const raw = readFileSync(f, "utf8");
+    // stat + read the SAME descriptor rather than the path twice — the mtime we
+    // forge back has to belong to the bytes we edited for the assertion to mean
+    // anything (and path-check-then-path-read is CodeQL js/file-system-race).
+    const fd = openSync(f, "r");
+    let beforeMtime: Date;
+    let raw: string;
+    try {
+      beforeMtime = fstatSync(fd).mtime;
+      raw = readFileSync(fd, "utf8");
+    } finally {
+      closeSync(fd);
+    }
     const edited = raw.replace('"AAAA"', '"BBBB"'); // same byte length
     assert.equal(edited.length, raw.length, "edit must be the exact same size");
     writeFileSync(f, edited, "utf8");

--- a/test/unit/case.test.ts
+++ b/test/unit/case.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, openSync, fstatSync, closeSync, utimesSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, statSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openCase, recordFiles } from "../../src/case.ts";
@@ -208,18 +208,8 @@ test("records() cache: a same-size in-place edit is detected even if mtime is fo
     assert.equal((c.recordById("rec_ss")?.payload as { content: string }).content, "AAAA");
 
     const f = join(c.recordsDir, "watch.jsonl");
-    // stat + read the SAME descriptor rather than the path twice — the mtime we
-    // forge back has to belong to the bytes we edited for the assertion to mean
-    // anything (and path-check-then-path-read is CodeQL js/file-system-race).
-    const fd = openSync(f, "r");
-    let beforeMtime: Date;
-    let raw: string;
-    try {
-      beforeMtime = fstatSync(fd).mtime;
-      raw = readFileSync(fd, "utf8");
-    } finally {
-      closeSync(fd);
-    }
+    const beforeMtime = statSync(f).mtime;
+    const raw = readFileSync(f, "utf8");
     const edited = raw.replace('"AAAA"', '"BBBB"'); // same byte length
     assert.equal(edited.length, raw.length, "edit must be the exact same size");
     writeFileSync(f, edited, "utf8");

--- a/test/unit/fs-path.test.ts
+++ b/test/unit/fs-path.test.ts
@@ -1,0 +1,92 @@
+// Containment guarantees for the file-serving helpers (src/fs-path.ts). Both
+// the chair static-asset route and the situation /media route hand these a
+// caller-influenced path, so the boundary they draw is worth pinning.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { closeSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openContainedFile, realpathContained } from "../../src/fs-path.ts";
+
+function fixture() {
+  const base = mkdtempSync(join(tmpdir(), "oc-fspath-"));
+  const root = join(base, "assets");
+  mkdirSync(root);
+  const outside = join(base, "SECRET.txt");
+  writeFileSync(outside, "outside-secret", "utf8");
+  const inside = join(root, "ok.txt");
+  writeFileSync(inside, "inside-ok", "utf8");
+  return { base, root, outside, inside };
+}
+
+/** Read and close, or null when the helper refused to open. */
+function served(fd: number | undefined): string | null {
+  if (fd === undefined) return null;
+  try {
+    return readFileSync(fd).toString();
+  } finally {
+    closeSync(fd);
+  }
+}
+
+test("openContainedFile: serves a regular file inside the root", () => {
+  const { base, root, inside } = fixture();
+  try {
+    assert.equal(served(openContainedFile(root, inside)), "inside-ok");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("openContainedFile: follows a symlink that stays inside the root", () => {
+  // resolving first is what makes legitimate symlinked assets keep working —
+  // the containment check runs on the RESOLVED path, not the link
+  const { base, root, inside } = fixture();
+  try {
+    const link = join(root, "link-inside");
+    symlinkSync(inside, link);
+    assert.equal(served(openContainedFile(root, link)), "inside-ok");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("openContainedFile: refuses a symlink escaping the root", () => {
+  // the whole point: a link INSIDE the served dir pointing out of it must not
+  // turn into a file read, however the caller spells the path
+  const { base, root, outside } = fixture();
+  try {
+    const link = join(root, "link-outside");
+    symlinkSync(outside, link);
+    assert.equal(served(openContainedFile(root, link)), null);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("openContainedFile: refuses directories, missing paths, and traversal", () => {
+  const { base, root, outside } = fixture();
+  try {
+    assert.equal(openContainedFile(root, root), undefined, "a directory is not servable");
+    assert.equal(openContainedFile(root, join(root, "nope.txt")), undefined, "missing path");
+    assert.equal(openContainedFile(root, outside), undefined, "plain path outside the root");
+    assert.equal(openContainedFile(root, join(root, "..", "SECRET.txt")), undefined, "..-traversal");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("realpathContained: agrees with openContainedFile on the symlink cases", () => {
+  const { base, root, inside, outside } = fixture();
+  try {
+    const linkIn = join(root, "l-in");
+    const linkOut = join(root, "l-out");
+    symlinkSync(inside, linkIn);
+    symlinkSync(outside, linkOut);
+    assert.equal(realpathContained(root, linkIn), true);
+    assert.equal(realpathContained(root, linkOut), false);
+    assert.equal(realpathContained(root, join(root, "missing")), false, "unresolvable is not contained");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/test/unit/map.test.ts
+++ b/test/unit/map.test.ts
@@ -171,10 +171,7 @@ test("renderMapHtml online: self-contained, OSM tile template, per-point markers
   const m = buildMapModel([geo({ lat: 37.7, lng: -122.4, place: "San Francisco" })], OPTS);
   const html = renderMapHtml(m, "plain", { offline: false });
   assert.match(html, /^<!doctype html>/i);
-  // match the tile URL WITH its path, not the bare host — a bare-host pattern
-  // reads as a host check that arbitrary hosts can straddle (CodeQL
-  // js/regex/missing-regexp-anchor)
-  assert.match(html, /\.tile\.openstreetmap\.org\/'\+zoom/);
+  assert.match(html, /tile\.openstreetmap\.org/);
   assert.match(html, /img-src data: file: https:\/\/\*\.tile\.openstreetmap\.org/);
   assert.match(html, /const POINTS=/);
   assert.match(html, /San Francisco/);
@@ -186,7 +183,7 @@ test("renderMapHtml online: self-contained, OSM tile template, per-point markers
 test("renderMapHtml offline: no tiles, openstreetmap.org deep links, default-src none CSP", () => {
   const m = buildMapModel([geo({ lat: 37.7, lng: -122.4 })], OPTS);
   const html = renderMapHtml(m, "plain", { offline: true });
-  assert.doesNotMatch(html, /\.tile\.openstreetmap\.org\//);
+  assert.doesNotMatch(html, /tile\.openstreetmap\.org/);
   assert.match(html, /openstreetmap\.org\/\?mlat=37\.7&amp;mlon=-122\.4/); // & escaped in href
   assert.match(html, /default-src 'none'/);
 });

--- a/test/unit/map.test.ts
+++ b/test/unit/map.test.ts
@@ -171,7 +171,10 @@ test("renderMapHtml online: self-contained, OSM tile template, per-point markers
   const m = buildMapModel([geo({ lat: 37.7, lng: -122.4, place: "San Francisco" })], OPTS);
   const html = renderMapHtml(m, "plain", { offline: false });
   assert.match(html, /^<!doctype html>/i);
-  assert.match(html, /tile\.openstreetmap\.org/);
+  // match the tile URL WITH its path, not the bare host — a bare-host pattern
+  // reads as a host check that arbitrary hosts can straddle (CodeQL
+  // js/regex/missing-regexp-anchor)
+  assert.match(html, /\.tile\.openstreetmap\.org\/'\+zoom/);
   assert.match(html, /img-src data: file: https:\/\/\*\.tile\.openstreetmap\.org/);
   assert.match(html, /const POINTS=/);
   assert.match(html, /San Francisco/);
@@ -183,7 +186,7 @@ test("renderMapHtml online: self-contained, OSM tile template, per-point markers
 test("renderMapHtml offline: no tiles, openstreetmap.org deep links, default-src none CSP", () => {
   const m = buildMapModel([geo({ lat: 37.7, lng: -122.4 })], OPTS);
   const html = renderMapHtml(m, "plain", { offline: true });
-  assert.doesNotMatch(html, /tile\.openstreetmap\.org/);
+  assert.doesNotMatch(html, /\.tile\.openstreetmap\.org\//);
   assert.match(html, /openstreetmap\.org\/\?mlat=37\.7&amp;mlon=-122\.4/); // & escaped in href
   assert.match(html, /default-src 'none'/);
 });

--- a/test/unit/see-url.test.ts
+++ b/test/unit/see-url.test.ts
@@ -22,17 +22,20 @@ const MP4 = Buffer.concat([Buffer.alloc(4), Buffer.from("ftypisom", "latin1"), B
 let dir: string;
 let server: Server;
 let base: string;
-let hits: Record<string, number>;
+// a Map, not a plain object: the key comes straight off `req.url`, and a request
+// for `/__proto__` would write through an object's prototype (CodeQL
+// js/remote-property-injection) rather than record a hit.
+let hits: Map<string, number>;
 
 before(async () => {
   // the fixture server binds 127.0.0.1, which the media-fetch SSRF guard blocks
   // by default — opt out for this offline test of the fetch/sniff pipeline.
   process.env.OVERCAST_ALLOW_PRIVATE_FETCH = "1";
   dir = mkdtempSync(join(tmpdir(), "oc-seeurl-"));
-  hits = {};
+  hits = new Map();
   server = createServer((req, res) => {
     const path = (req.url ?? "/").split("?")[0];
-    hits[path] = (hits[path] ?? 0) + 1;
+    hits.set(path, (hits.get(path) ?? 0) + 1);
     if (path === "/img.png") {
       res.writeHead(200, { "content-type": "image/png" });
       res.end(PNG);
@@ -111,10 +114,10 @@ test("fetchMediaToCase: URL ext survives query noise; repeat call reuses the art
   const url = `${base}/photo.jpg?Expires=123&Signature=abc~def`;
   const a = await fetchMediaToCase(url, media);
   assert.equal(a.ext, ".jpg");
-  const before = hits["/photo.jpg"];
+  const before = hits.get("/photo.jpg");
   const b = await fetchMediaToCase(url, media);
   assert.equal(b.path, a.path);
-  assert.equal(hits["/photo.jpg"], before); // cache hit — no second download
+  assert.equal(hits.get("/photo.jpg"), before); // cache hit — no second download
 });
 
 test("fetchMediaToCase: no ext + no content-type → magic-byte sniff", async () => {
@@ -129,7 +132,7 @@ test("fetchMediaToCase: HTTP error status throws with the status line", async ()
 test("fetchMediaToCase: follows a redirect (manual loop) to the final media", async () => {
   const got = await fetchMediaToCase(`${base}/redir`, join(dir, "media"));
   assert.equal(got.ext, ".png"); // followed 302 → /img.png
-  assert.ok((hits["/img.png"] ?? 0) > 0, "the redirect target was fetched");
+  assert.ok((hits.get("/img.png") ?? 0) > 0, "the redirect target was fetched");
 });
 
 test("fetchMediaToCase: refuses a redirect to a non-http(s) scheme (file://)", async () => {

--- a/test/unit/situation-extension.test.ts
+++ b/test/unit/situation-extension.test.ts
@@ -5,14 +5,14 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerSituation } from "../../src/extension/situation.ts";
 import { openCase } from "../../src/case.ts";
 import { defaultProfile } from "../../src/profile.ts";
 import { situationVerb } from "../../src/verbs/situation.ts";
-import { readControl, readRuntime, writeControl } from "../../src/situation/state.ts";
+import { readControl, readRuntime, writeControl, situationDir } from "../../src/situation/state.ts";
 import type { VerbContext } from "../../src/registry/types.ts";
 
 type CommandHandler = (args: string, ctx: unknown) => Promise<void>;
@@ -80,6 +80,29 @@ function verbCtx(dir: string, over: Partial<VerbContext> = {}): VerbContext {
     ...over,
   };
 }
+
+test("situation rebind honors a stop it can SEE, even with a blocked patch behind it", () => {
+  // readControl returns the applyable prefix; a stop inside it is one the
+  // server's tick can also see. Gating on "is anything further down unreadable"
+  // makes the page start and get stopped a moment later — a flash-start.
+  const dir = mkdtempSync(join(tmpdir(), "oc-sitrebind-"));
+  let blocker: string | undefined;
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    writeControl(c, { stop: true }); // visible in the prefix
+    const cdir = join(situationDir(c), "control.d");
+    const firstMs = Number(readdirSync(cdir)[0].split("-")[0]);
+    blocker = join(cdir, `${String(firstMs + 1).padStart(15, "0")}-000001-0-blocked.json`);
+    writeFileSync(blocker, JSON.stringify({ limit: 9 }), "utf8");
+    chmodSync(blocker, 0o000); // unreadable, but AFTER the stop
+
+    assert.equal(readControl(c)?.stop, true, "the stop is still visible in the applyable prefix");
+  } finally {
+    if (blocker) { try { chmodSync(blocker, 0o600); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("case-switch rebind honors a stop queued on the new case (no restart over it)", async () => {
   const dirA = tmpCase("oc-situation-ext-a-");

--- a/test/unit/situation-extension.test.ts
+++ b/test/unit/situation-extension.test.ts
@@ -101,7 +101,7 @@ test("case-switch rebind honors a stop queued on the new case (no restart over i
     // wait for that — the last step of the stop — not just server() clearing.
     await until(() => handle.server() === undefined && readRuntime(openCase(dirA)) === undefined);
 
-    assert.equal(readControl(openCase(dirB))?.control.stop, undefined, "pending stop consumed");
+    assert.equal(readControl(openCase(dirB))?.stop, undefined, "pending stop consumed");
     assert.equal(readRuntime(openCase(dirB)), undefined, "no server restarted on case B");
   } finally {
     await emit("session_shutdown", {}, fakeCtx(dirB));
@@ -127,7 +127,7 @@ test("agent-tool set/stop steer the in-process page's BOUND case, not the sessio
     const [setRec] = await situationVerb.run(verbCtx(dirB, { input: "set", opts: { source: "webcam" } }));
     assert.equal(setRec.state, "ready");
     assert.equal((setRec.payload as Record<string, unknown>).steered_case, openCase(dirA).dir, "set reports the steered case");
-    assert.equal(readControl(openCase(dirA))?.control.source, "webcam", "control written to the bound case");
+    assert.equal(readControl(openCase(dirA))?.source, "webcam", "control written to the bound case");
     assert.equal(readControl(openCase(dirB)), undefined, "nothing written to the session case");
     assert.equal((setRec.payload as Record<string, unknown>).running, true, "set sees the live page");
 

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -274,7 +274,10 @@ writeControl(openCase(dir), { clear: [key] });
   const KEYS = ["panels", "source", "since", "limit", "theme", "query"];
   try {
     for (let round = 0; round < 2; round++) {
+      // reset BOTH the legacy file and the patch directory — leftovers from a
+      // previous round would satisfy the assertion and mask a real loss
       rmSync(controlFile(c), { force: true });
+      rmSync(join(situationDir(c), "control.d"), { recursive: true, force: true });
       const startAt = Date.now() + 700; // all contenders write at the same instant
       await Promise.all(KEYS.map((k) => new Promise<void>((res) => {
         spawn(process.execPath, ["--import", "tsx", child, dir, k, String(startAt)], { stdio: "ignore" })
@@ -419,6 +422,38 @@ test("situation state: clearStaleStop keeps a patch it could not read", () => {
       chmodSync(unread, 0o600);
     }
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation state: clearStaleStop keeps surviving config APPLYABLE (position, not just content)", () => {
+  // dropping the stop must not push the set-before-start config behind a later
+  // unreadable patch — it was applyable a moment ago and must stay so
+  const { dir, c } = tmpCase();
+  const cdir = join(situationDir(c), "control.d");
+  let blocker: string | undefined;
+  try {
+    writeControl(c, { stop: true, panels: ["map"], theme: "plain" });
+    // The blocker must sort strictly AFTER the config patch and strictly BEFORE
+    // anything republished later, or the test passes against the very bug it
+    // targets: a far-future name sorts last, and a same-millisecond name can be
+    // beaten by the republish's sequence number. Pin it one ms after the config
+    // patch, then let the clock move past it.
+    const firstName = readdirSync(cdir)[0];
+    const firstMs = Number(firstName.split("-")[0]);
+    blocker = join(cdir, `${String(firstMs + 1).padStart(15, "0")}-000001-0-blocked.json`);
+    writeFileSync(blocker, JSON.stringify({ limit: 9 }), "utf8");
+    chmodSync(blocker, 0o000); // an unreadable patch sitting AFTER the config
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5); // clock > blocker
+
+    clearStaleStop(c);
+
+    const applied = takeControl(c);
+    assert.equal(applied?.stop, undefined, "stale stop dropped");
+    assert.deepEqual(applied?.panels, ["map"], "config still applies despite the later blocker");
+    assert.equal(applied?.theme, "plain");
+  } finally {
+    if (blocker) { try { chmodSync(blocker, 0o600); } catch { /* gone */ } }
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -458,6 +458,37 @@ test("situation state: clearStaleStop keeps surviving config APPLYABLE (position
   }
 });
 
+test("situation state: clearStaleStop neutralizes a stop queued BEHIND a blocker", () => {
+  // folding only the applyable prefix missed this: the fresh serve starts fine,
+  // then dies the moment the blocker is repaired and the take reaches the stale
+  // stop — the exact failure clearStaleStop exists to prevent, just deferred.
+  const { dir, c } = tmpCase();
+  const cdir = join(situationDir(c), "control.d");
+  let blocker: string | undefined;
+  try {
+    writeControl(c, { panels: ["map"] });          // readable prefix
+    const firstMs = Number(readdirSync(cdir)[0].split("-")[0]);
+    blocker = join(cdir, `${String(firstMs + 1).padStart(15, "0")}-000001-0-blocked.json`);
+    writeFileSync(blocker, JSON.stringify({ theme: "plain" }), "utf8");
+    chmodSync(blocker, 0o000);
+    // let the clock pass the blocker's stamp, or the stop lands in the PREFIX
+    // and the test passes against the very implementation it targets
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+    writeControl(c, { stop: true });               // the stale stop, BEHIND it
+
+    clearStaleStop(c);
+    chmodSync(blocker, 0o600);                     // the blocker is repaired
+
+    const applied = takeControl(c);
+    assert.equal(applied?.stop, undefined, "the stale stop cannot come back and kill the server");
+    assert.deepEqual(applied?.panels, ["map"], "everything else still applies");
+    assert.equal(applied?.theme, "plain", "the once-blocked patch applies too");
+  } finally {
+    if (blocker) { try { chmodSync(blocker, 0o600); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("parseRange: standard, open-ended, suffix, and unsatisfiable", () => {
   assert.deepEqual(parseRange("bytes=2-5", 16), { start: 2, end: 5 });
   assert.deepEqual(parseRange("bytes=10-", 16), { start: 10, end: 15 });

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -136,7 +136,7 @@ test("situation control: takeControl claims atomically — a set racing the take
     // never applied it — the operator's command vanishing with no error.
     takeControl(c);
     writeControl(c, { theme: "plain" });
-    assert.deepEqual(readControl(c)?.control, { theme: "plain" }, "post-take write still pending");
+    assert.deepEqual(readControl(c), { theme: "plain" }, "post-take write still pending");
     assert.deepEqual(takeControl(c), { theme: "plain" }, "and is delivered whole on the next take");
 
     // a corrupt/truncated control is dropped rather than wedging the tick loop
@@ -235,23 +235,23 @@ test("situation state: clearStaleStop drops a leftover stop:true (keeps config)"
     // a stop alongside a set-before-start config → stop dropped, config kept
     writeControl(c, { stop: true, panels: ["map"], theme: "plain" });
     clearStaleStop(c);
-    const left = readControl(c)?.control;
+    const left = readControl(c);
     assert.equal(left?.stop, undefined, "stale stop removed");
     assert.deepEqual(left?.panels, ["map"], "set-before-start config preserved");
     // a config-only control is untouched
     clearStaleStop(c);
-    assert.deepEqual(readControl(c)?.control.panels, ["map"]);
+    assert.deepEqual(readControl(c)?.panels, ["map"]);
     // clear-vs-set composition in PENDING control: a clear drops a pending
     // assignment (clear wins over an older set) …
     writeControl(c, { source: "web", limit: 4 });
     writeControl(c, { clear: ["source"] });
-    let pending = readControl(c)?.control;
+    let pending = readControl(c);
     assert.equal(pending?.source, undefined, "pending assignment dropped by a later clear");
     assert.deepEqual(pending?.clear, ["source"]);
     assert.equal(pending?.limit, 4, "unrelated pending key kept");
     // … and a later re-set drops the pending clear (the newest intent wins)
     writeControl(c, { source: "youtube" });
-    pending = readControl(c)?.control;
+    pending = readControl(c);
     assert.equal(pending?.source, "youtube");
     assert.equal(pending?.clear, undefined, "pending clear cancelled by a re-set");
   } finally {

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -2,7 +2,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawn } from "node:child_process";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
 import { openCase } from "../../src/case.ts";
 import { SituationServer, parseRange } from "../../src/situation/server.ts";
 import { writeControl, readControl, takeControl, controlFile, situationDir, clearStaleStop, readRuntime, writeRuntime, clearRuntime, runtimeAlive } from "../../src/situation/state.ts";
@@ -144,6 +148,44 @@ test("situation control: takeControl claims atomically — a set racing the take
     writeFileSync(controlFile(c), "{not json", "utf8");
     assert.equal(takeControl(c), undefined, "corrupt control ignored");
     assert.equal(readControl(c), undefined, "and cleared, so it can't loop forever");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation control: concurrent writeControl across PROCESSES loses no update", async () => {
+  // writeControl is a read-modify-write, so two `situation set`s racing from
+  // different processes (the agent and a CLI in another terminal) could both
+  // read the same pending state and the slower publish would clobber the
+  // faster — an operator command lost with no error. Verified against the
+  // unlocked implementation: it keeps 1 of 6 updates per round.
+  //
+  // Every contender adds a DIFFERENT clear key; writeControl unions clear[], so
+  // a lost fold shows up precisely as a missing key.
+  const { dir, c } = tmpCase();
+  const child = join(dir, "contend.ts");
+  const stateMod = pathToFileURL(join(HERE, "..", "..", "src", "situation", "state.ts")).href;
+  const caseMod = pathToFileURL(join(HERE, "..", "..", "src", "case.ts")).href;
+  writeFileSync(child, `
+import { openCase } from ${JSON.stringify(caseMod)};
+import { writeControl } from ${JSON.stringify(stateMod)};
+const [dir, key, startAt] = process.argv.slice(2);
+while (Date.now() < Number(startAt)) { /* spin to the barrier so we truly contend */ }
+writeControl(openCase(dir), { clear: [key] });
+`, "utf8");
+
+  const KEYS = ["panels", "source", "since", "limit", "theme", "query"];
+  try {
+    for (let round = 0; round < 2; round++) {
+      rmSync(controlFile(c), { force: true });
+      const startAt = Date.now() + 700; // all contenders write at the same instant
+      await Promise.all(KEYS.map((k) => new Promise<void>((res) => {
+        spawn(process.execPath, ["--import", "tsx", child, dir, k, String(startAt)], { stdio: "ignore" })
+          .on("exit", () => res());
+      })));
+      const kept = (readControl(c)?.clear ?? []) as string[];
+      assert.deepEqual([...kept].sort(), [...KEYS].sort(), `round ${round}: a concurrent update was lost`);
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, openSync, closeSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -153,29 +153,59 @@ test("situation control: takeControl claims atomically — a set racing the take
   }
 });
 
-test("situation control: a contended take never blocks the server's event loop", () => {
-  // withControlLock waits via Atomics.wait, which parks the whole thread — on
-  // the situation server that would stall /media and SSE. The server's take must
-  // therefore never wait: it skips and retries on the next poll tick.
+test("situation control: no shared mutable file — writes and takes never block", () => {
+  // the patch directory exists so there is nothing to lock: no .lock is created,
+  // no writer waits, and a take is a directory drain. Earlier designs parked the
+  // event loop here (Atomics.wait), which stalled /media and SSE on the TUI's
+  // in-process server.
   const { dir, c } = tmpCase();
   try {
-    writeControl(c, { limit: 7 });
-    const lock = `${controlFile(c)}.lock`;
-    closeSync(openSync(lock, "wx")); // stand in for another process holding it
-
     const t0 = Date.now();
+    writeControl(c, { limit: 7 });
+    writeControl(c, { theme: "plain" });
     const taken = takeControl(c);
     const elapsed = Date.now() - t0;
-    assert.equal(taken, undefined, "a contended take yields rather than waiting");
-    assert.ok(elapsed < 50, `take blocked for ${elapsed}ms`);
-    assert.deepEqual(readControl(c), { limit: 7 }, "control stays pending for the next tick — not lost");
 
-    // a WRITER, by contrast, must not come away having dropped the command
-    const wrote = writeControl(c, { theme: "plain" });
-    assert.deepEqual(wrote, { limit: 7, theme: "plain" }, "writer still lands its patch");
+    assert.deepEqual(taken, { limit: 7, theme: "plain" }, "both patches folded in order");
+    assert.ok(elapsed < 100, `control ops should not wait; took ${elapsed}ms`);
+    assert.equal(takeControl(c), undefined, "drained");
+    const litter = readdirSync(situationDir(c)).filter((f) => f.includes(".lock"));
+    assert.deepEqual(litter, [], "no lock file exists to be abandoned or aged out");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
-    rmSync(lock, { force: true });
-    assert.deepEqual(takeControl(c), { limit: 7, theme: "plain" }, "take works once the lock frees");
+test("situation control: patch order survives same-millisecond writes", () => {
+  // ordering is filename order, and two sets land in the same millisecond
+  // routinely — a later clear must still beat an earlier assignment
+  const { dir, c } = tmpCase();
+  try {
+    for (let i = 0; i < 25; i++) {
+      writeControl(c, { source: `s${i}` });
+      writeControl(c, { clear: ["source"] });
+    }
+    const pending = readControl(c);
+    assert.equal(pending?.source, undefined, "the last clear wins over the assignment before it");
+    assert.deepEqual(pending?.clear, ["source"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation control: an unreadable patch waits; a corrupt one is dropped", () => {
+  // a transient read failure must not destroy the operator's command, but a
+  // genuinely corrupt patch must not wedge every future tick either
+  const { dir, c } = tmpCase();
+  try {
+    writeControl(c, { limit: 3 });
+    const cdir = join(situationDir(c), "control.d");
+    writeFileSync(join(cdir, "999999999999999-000001-0-corrupt.json"), "{not json", "utf8");
+
+    const taken = takeControl(c);
+    assert.deepEqual(taken, { limit: 3 }, "the readable patch still applies");
+    assert.equal(readdirSync(cdir).length, 0, "the corrupt patch is removed, not retried forever");
+    assert.equal(takeControl(c), undefined);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -354,6 +354,27 @@ test("situation state: clearStaleStop drops a leftover stop:true (keeps config)"
     pending = readControl(c);
     assert.equal(pending?.source, "youtube");
     assert.equal(pending?.clear, undefined, "pending clear cancelled by a re-set");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation state: clearStaleStop keeps a patch it could not read", () => {
+  // it deletes what it CONSUMED, not everything it listed — an unreadable patch
+  // is an operator command nobody has looked at yet, so sweeping it up would
+  // discard it silently. Same rule takeControl follows.
+  const { dir, c } = tmpCase();
+  try {
+    writeControl(c, { stop: true });
+    const cdir = join(situationDir(c), "control.d");
+    // a patch that cannot be parsed stands in for one that cannot be read
+    const unread = join(cdir, "999999999999999-000001-0-unreadable.json");
+    writeFileSync(unread, "{not json", "utf8");
+
+    clearStaleStop(c);
+
+    assert.ok(existsSync(unread), "the unread patch survived the stale-stop sweep");
+    assert.equal(readdirSync(cdir).length, 1, "only the consumed stop patch was removed");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openCase } from "../../src/case.ts";
 import { SituationServer, parseRange } from "../../src/situation/server.ts";
-import { writeControl, readControl, clearStaleStop, readRuntime, writeRuntime, clearRuntime, runtimeAlive } from "../../src/situation/state.ts";
+import { writeControl, readControl, takeControl, controlFile, situationDir, clearStaleStop, readRuntime, writeRuntime, clearRuntime, runtimeAlive } from "../../src/situation/state.ts";
 
 function tmpCase() {
   const dir = mkdtempSync(join(tmpdir(), "oc-situation-"));
@@ -118,6 +118,33 @@ test("situation server: tick() applies control.json and fires onStopRequested on
     assert.equal(stopReason, "control");
   } finally {
     await s.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation control: takeControl claims atomically — a set racing the take is never consumed unseen", () => {
+  const { dir, c } = tmpCase();
+  try {
+    writeControl(c, { limit: 4, source: "web" });
+    // the take returns the pending control AND leaves nothing behind
+    assert.deepEqual(takeControl(c), { limit: 4, source: "web" });
+    assert.equal(readControl(c), undefined, "control consumed by the take");
+    assert.equal(takeControl(c), undefined, "nothing pending is not an error");
+
+    // THE RACE: a `situation set` landing after a take must survive for the next
+    // tick. The old stat-mtime-then-unlink consume could delete this one having
+    // never applied it — the operator's command vanishing with no error.
+    takeControl(c);
+    writeControl(c, { theme: "plain" });
+    assert.deepEqual(readControl(c)?.control, { theme: "plain" }, "post-take write still pending");
+    assert.deepEqual(takeControl(c), { theme: "plain" }, "and is delivered whole on the next take");
+
+    // a corrupt/truncated control is dropped rather than wedging the tick loop
+    mkdirSync(situationDir(c), { recursive: true });
+    writeFileSync(controlFile(c), "{not json", "utf8");
+    assert.equal(takeControl(c), undefined, "corrupt control ignored");
+    assert.equal(readControl(c), undefined, "and cleared, so it can't loop forever");
+  } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -96,7 +96,7 @@ test("situation server: /media serves only allowlisted case media (Range 206), 4
   }
 });
 
-test("situation server: tick() applies control.json and fires onStopRequested on stop", async () => {
+test("situation server: tick() applies a control patch and fires onStopRequested on stop", async () => {
   const { dir, c } = tmpCase();
   let stopReason: string | undefined;
   const s = server(dir, { onStopRequested: (r) => (stopReason = r) });

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, openSync, closeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -148,6 +148,34 @@ test("situation control: takeControl claims atomically — a set racing the take
     writeFileSync(controlFile(c), "{not json", "utf8");
     assert.equal(takeControl(c), undefined, "corrupt control ignored");
     assert.equal(readControl(c), undefined, "and cleared, so it can't loop forever");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation control: a contended take never blocks the server's event loop", () => {
+  // withControlLock waits via Atomics.wait, which parks the whole thread — on
+  // the situation server that would stall /media and SSE. The server's take must
+  // therefore never wait: it skips and retries on the next poll tick.
+  const { dir, c } = tmpCase();
+  try {
+    writeControl(c, { limit: 7 });
+    const lock = `${controlFile(c)}.lock`;
+    closeSync(openSync(lock, "wx")); // stand in for another process holding it
+
+    const t0 = Date.now();
+    const taken = takeControl(c);
+    const elapsed = Date.now() - t0;
+    assert.equal(taken, undefined, "a contended take yields rather than waiting");
+    assert.ok(elapsed < 50, `take blocked for ${elapsed}ms`);
+    assert.deepEqual(readControl(c), { limit: 7 }, "control stays pending for the next tick — not lost");
+
+    // a WRITER, by contrast, must not come away having dropped the command
+    const wrote = writeControl(c, { theme: "plain" });
+    assert.deepEqual(wrote, { limit: 7, theme: "plain" }, "writer still lands its patch");
+
+    rmSync(lock, { force: true });
+    assert.deepEqual(takeControl(c), { limit: 7, theme: "plain" }, "take works once the lock frees");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -9,7 +9,7 @@ import { spawn } from "node:child_process";
 const HERE = dirname(fileURLToPath(import.meta.url));
 import { openCase } from "../../src/case.ts";
 import { SituationServer, parseRange } from "../../src/situation/server.ts";
-import { writeControl, readControl, takeControl, controlFile, situationDir, clearStaleStop, readRuntime, writeRuntime, clearRuntime, runtimeAlive } from "../../src/situation/state.ts";
+import { writeControl, readControl, takeControl, controlSnapshot, controlFile, situationDir, clearStaleStop, readRuntime, writeRuntime, clearRuntime, runtimeAlive } from "../../src/situation/state.ts";
 
 function tmpCase() {
   const dir = mkdtempSync(join(tmpdir(), "oc-situation-"));
@@ -483,6 +483,69 @@ test("situation state: clearStaleStop neutralizes a stop queued BEHIND a blocker
     assert.equal(applied?.stop, undefined, "the stale stop cannot come back and kill the server");
     assert.deepEqual(applied?.panels, ["map"], "everything else still applies");
     assert.equal(applied?.theme, "plain", "the once-blocked patch applies too");
+  } finally {
+    if (blocker) { try { chmodSync(blocker, 0o600); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation control: a patch drained mid-fold is not a blocker", async () => {
+  // pendingPatchFiles LISTS, then foldPending reads. A concurrent take can
+  // delete a listed file in between — that is ENOENT, meaning "already applied
+  // by someone else", NOT "unreadable". Treating it as a blocker would hold
+  // every later patch and report a blocked_path that no longer exists.
+  //
+  // The window is between two calls inside foldPending, so it cannot be staged
+  // from outside: this races a real drainer process against live snapshots and
+  // asserts no phantom blocker is ever reported.
+  const { dir, c } = tmpCase();
+  const drainer = join(dir, "drain.ts");
+  const stateMod = pathToFileURL(join(HERE, "..", "..", "src", "situation", "state.ts")).href;
+  const caseMod = pathToFileURL(join(HERE, "..", "..", "src", "case.ts")).href;
+  writeFileSync(drainer, `
+import { openCase } from ${JSON.stringify(caseMod)};
+import { takeControl } from ${JSON.stringify(stateMod)};
+const c = openCase(process.argv[2]);
+const until = Number(process.argv[3]);
+while (Date.now() < until) takeControl(c);
+`, "utf8");
+
+  const until = Date.now() + 2500;
+  const child = spawn(process.execPath, ["--import", "tsx", drainer, dir, String(until)], { stdio: "ignore" });
+  try {
+    let phantom = 0;
+    let snapshots = 0;
+    while (Date.now() < until) {
+      writeControl(c, { limit: snapshots % 7 });
+      const snap = controlSnapshot(c);
+      snapshots++;
+      // a reported blocker must be a file that actually exists and is unreadable
+      if (snap.blockedBy && !existsSync(snap.blockedBy)) phantom++;
+    }
+    assert.ok(snapshots > 50, `expected real contention, only ${snapshots} snapshots`);
+    assert.equal(phantom, 0, "a vanished patch was reported as a blocker");
+  } finally {
+    child.kill("SIGKILL");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation control: pending and blocked come from ONE fold", () => {
+  // status reports both; two separate folds can be split by a concurrent drain
+  // and disagree — blocked:true beside a path already consumed, say
+  const { dir, c } = tmpCase();
+  const cdir = join(situationDir(c), "control.d");
+  let blocker: string | undefined;
+  try {
+    writeControl(c, { source: "web" });
+    const firstMs = Number(readdirSync(cdir)[0].split("-")[0]);
+    blocker = join(cdir, `${String(firstMs + 1).padStart(15, "0")}-000001-0-blocked.json`);
+    writeFileSync(blocker, JSON.stringify({ limit: 9 }), "utf8");
+    chmodSync(blocker, 0o000);
+
+    const snap = controlSnapshot(c);
+    assert.deepEqual(snap.control, { source: "web" }, "the applyable prefix");
+    assert.equal(snap.blockedBy, blocker, "and the blocker, from the same fold");
   } finally {
     if (blocker) { try { chmodSync(blocker, 0o600); } catch { /* gone */ } }
     rmSync(dir, { recursive: true, force: true });

--- a/test/unit/situation-server.test.ts
+++ b/test/unit/situation-server.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, existsSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -211,6 +211,45 @@ test("situation control: an unreadable patch waits; a corrupt one is dropped", (
   }
 });
 
+test("situation control: an unreadable patch HOLDS the ones behind it (order)", () => {
+  // patches are an ordered log. Skipping an unreadable one and applying a later
+  // one would replay the skipped patch on the NEXT tick, after the later one
+  // already landed — an old assignment silently undoing a newer clear.
+  const { dir, c } = tmpCase();
+  const cdir = join(situationDir(c), "control.d");
+  let blocked: string | undefined;
+  try {
+    writeControl(c, { source: "web" });
+    blocked = readdirSync(cdir)[0] && join(cdir, readdirSync(cdir)[0]);
+    chmodSync(blocked as string, 0o000); // stand in for a transient read failure
+    writeControl(c, { clear: ["source"] }); // the NEWER intent, behind the block
+
+    assert.equal(takeControl(c), undefined, "nothing is applied past the blocked patch");
+    assert.equal(readdirSync(cdir).length, 2, "both patches still pending, in order");
+
+    chmodSync(blocked as string, 0o600); // the transient failure clears
+    assert.deepEqual(takeControl(c), { clear: ["source"] }, "now both apply, in the right order");
+    assert.equal(readdirSync(cdir).length, 0, "drained");
+  } finally {
+    if (blocked) { try { chmodSync(blocked, 0o600); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("situation control: writeControl's return always includes the caller's own patch", () => {
+  // the return is what `situation set` shows the operator; a concurrent drain
+  // must not make it report a control that omits the update just made
+  const { dir, c } = tmpCase();
+  try {
+    assert.deepEqual(writeControl(c, { limit: 4 }), { limit: 4 });
+    assert.deepEqual(writeControl(c, { theme: "plain" }), { limit: 4, theme: "plain" }, "folded onto pending");
+    takeControl(c); // the server drains everything
+    assert.deepEqual(writeControl(c, { source: "web" }), { source: "web" }, "still reports the caller's patch");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("situation control: concurrent writeControl across PROCESSES loses no update", async () => {
   // writeControl is a read-modify-write, so two `situation set`s racing from
   // different processes (the agent and a CLI in another terminal) could both
@@ -367,14 +406,18 @@ test("situation state: clearStaleStop keeps a patch it could not read", () => {
   try {
     writeControl(c, { stop: true });
     const cdir = join(situationDir(c), "control.d");
-    // a patch that cannot be parsed stands in for one that cannot be read
+    // genuinely UNREADABLE, not merely corrupt — a corrupt patch carries no
+    // content and is consumed, while an unreadable one may be a real command
     const unread = join(cdir, "999999999999999-000001-0-unreadable.json");
-    writeFileSync(unread, "{not json", "utf8");
-
-    clearStaleStop(c);
-
-    assert.ok(existsSync(unread), "the unread patch survived the stale-stop sweep");
-    assert.equal(readdirSync(cdir).length, 1, "only the consumed stop patch was removed");
+    writeFileSync(unread, JSON.stringify({ theme: "plain" }), "utf8");
+    chmodSync(unread, 0o000);
+    try {
+      clearStaleStop(c);
+      assert.ok(existsSync(unread), "the unread patch survived the stale-stop sweep");
+      assert.equal(readdirSync(cdir).length, 1, "only the consumed stop patch was removed");
+    } finally {
+      chmodSync(unread, 0o600);
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/situation-verb.test.ts
+++ b/test/unit/situation-verb.test.ts
@@ -227,7 +227,7 @@ test("situation status reports offline / stale runtime; stop writes a stop contr
     assert.equal(stopped.state, "ready");
     assert.equal((stopped.payload as Record<string, unknown>).running, false);
     assert.equal(readRuntime(openCase(dir)), undefined);
-    assert.equal(readControl(c)?.stop, true, "stop queued in control.json");
+    assert.equal(readControl(c)?.stop, true, "stop queued as a control patch");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/situation-verb.test.ts
+++ b/test/unit/situation-verb.test.ts
@@ -92,6 +92,30 @@ test("situation stop: a --force SIGTERM is not reported as blocked", async () =>
   }
 });
 
+test("situation: a LEGACY control.json blocker is named, not hidden behind control.d", async () => {
+  // the legacy file is folded as the OLDEST patch, so an unreadable one blocks
+  // everything after it. A note pointing only at control.d/ sends the operator
+  // looking in the wrong place during exactly the upgrade that produced it.
+  const dir = mkdtempSync(join(tmpdir(), "oc-sitlegacy-"));
+  let legacy: string | undefined;
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    writeControl(c, { limit: 3 }); // a normal patch under control.d/
+    legacy = join(situationDir(c), "control.json");
+    writeFileSync(legacy, JSON.stringify({ theme: "plain" }), "utf8");
+    chmodSync(legacy, 0o000);
+
+    const [status] = await situationVerb.run(ctx(dir, { input: "status", surface: "agent" }));
+    const sp = status.payload as Record<string, unknown>;
+    assert.equal(sp.blocked, true);
+    assert.equal(sp.blocked_path, legacy, "points at control.json, not the control.d directory");
+  } finally {
+    if (legacy) { try { chmodSync(legacy, 0o600); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("situation status and stop BOTH surface a blocked control log", async () => {
   // surfacing this only on `set` (as the first pass did) leaves the two surfaces
   // an operator actually checks reporting a clean, possibly empty view of a
@@ -102,6 +126,7 @@ test("situation status and stop BOTH surface a blocked control log", async () =>
     const sp = status.payload as Record<string, unknown>;
     assert.equal(sp.blocked, true, "status reports the blocked queue");
     assert.match(String(sp.blocked_note), /cannot be read/i);
+    assert.equal(sp.blocked_path, blocker, "names the file that is actually blocking");
 
     const [stop] = await situationVerb.run(ctx(dir, { input: "stop", surface: "agent" }));
     const tp = stop.payload as Record<string, unknown>;

--- a/test/unit/situation-verb.test.ts
+++ b/test/unit/situation-verb.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, readdirSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
+import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openCase } from "../../src/case.ts";
@@ -48,6 +49,48 @@ function blockedCase(): { dir: string; blocker: string } {
   chmodSync(blocker, 0o000);
   return { dir, blocker };
 }
+
+test("situation stop: a --force SIGTERM is not reported as blocked", async () => {
+  // `delivered` reads "control+signal" when the SIGTERM lands, and one of the
+  // force-IGNORED variants literally contains the word "signal" — so gating the
+  // blocked flag on any substring of it is a trap. A stop that already killed
+  // the process must never be reported as stuck behind the queue.
+  const dir = mkdtempSync(join(tmpdir(), "oc-sitforce-"));
+  let blocker: string | undefined;
+  const srv = createServer(() => {});
+  // a DISPOSABLE process to receive the SIGTERM — using our own pid here makes
+  // the verb kill the test runner, which is a silent, detail-free failure
+  const victim = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60000)"], { stdio: "ignore" });
+  try {
+    await new Promise<void>((res) => srv.listen(0, "127.0.0.1", () => res()));
+    const port = (srv.address() as AddressInfo).port;
+    const c = openCase(dir);
+    c.ensure();
+    writeRuntime(c, {
+      pid: victim.pid as number, port, bind: "127.0.0.1", url: `http://127.0.0.1:${port}/`,
+      displayUrl: `http://127.0.0.1:${port}/`, startedAt: new Date(0).toISOString(),
+      caseDir: dir, every: null, mode: "cli",
+    });
+    writeControl(c, { limit: 2 });
+    const cdir = join(situationDir(c), "control.d");
+    const firstMs = Number(readdirSync(cdir)[0].split("-")[0]);
+    blocker = join(cdir, `${String(firstMs + 1).padStart(15, "0")}-000001-0-blocked.json`);
+    writeFileSync(blocker, JSON.stringify({ limit: 9 }), "utf8");
+    chmodSync(blocker, 0o000);
+
+    const [rec] = await situationVerb.run(ctx(dir, { input: "stop", surface: "cli", opts: { force: true } }));
+    const p = rec.payload as Record<string, unknown>;
+    const delivered = String(p.delivered);
+    assert.match(delivered, /signal/, "the force path was exercised (a live pid on a served port)");
+    assert.ok(!delivered.includes("ignored"), `expected a delivered signal, got: ${delivered}`);
+    assert.equal(p.blocked, undefined, "a delivered SIGTERM must not be reported as stuck behind the queue");
+  } finally {
+    try { victim.kill("SIGKILL"); } catch { /* already gone */ }
+    srv.close();
+    if (blocker) { try { chmodSync(blocker, 0o600); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("situation status and stop BOTH surface a blocked control log", async () => {
   // surfacing this only on `set` (as the first pass did) leaves the two surfaces

--- a/test/unit/situation-verb.test.ts
+++ b/test/unit/situation-verb.test.ts
@@ -81,7 +81,7 @@ test("situation set writes a validated control patch (agent-safe)", async () => 
   try {
     const [rec] = await situationVerb.run(ctx(dir, { input: "set", surface: "agent", opts: { panels: "wall,map", theme: "plain" } }));
     assert.equal(rec.state, "ready");
-    const ctl = readControl(c)?.control;
+    const ctl = readControl(c);
     assert.deepEqual(ctl?.panels, ["wall", "map"]);
     assert.equal(ctl?.theme, "plain");
     // an invalid panel is rejected with an error record, no control written
@@ -124,7 +124,7 @@ test("situation status reports offline / stale runtime; stop writes a stop contr
     assert.equal(stopped.state, "ready");
     assert.equal((stopped.payload as Record<string, unknown>).running, false);
     assert.equal(readRuntime(openCase(dir)), undefined);
-    assert.equal(readControl(c)?.control.stop, true, "stop queued in control.json");
+    assert.equal(readControl(c)?.stop, true, "stop queued in control.json");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/situation-verb.test.ts
+++ b/test/unit/situation-verb.test.ts
@@ -35,6 +35,41 @@ function ctx(dir: string, over: Partial<VerbContext> = {}): VerbContext {
   };
 }
 
+/** seed a case whose control log is held by an unreadable patch */
+function blockedCase(): { dir: string; blocker: string } {
+  const dir = mkdtempSync(join(tmpdir(), "oc-sitblocked-"));
+  const c = openCase(dir);
+  c.ensure();
+  writeControl(c, { limit: 2 });
+  const cdir = join(situationDir(c), "control.d");
+  const firstMs = Number(readdirSync(cdir)[0].split("-")[0]);
+  const blocker = join(cdir, `${String(firstMs + 1).padStart(15, "0")}-000001-0-blocked.json`);
+  writeFileSync(blocker, JSON.stringify({ limit: 9 }), "utf8");
+  chmodSync(blocker, 0o000);
+  return { dir, blocker };
+}
+
+test("situation status and stop BOTH surface a blocked control log", async () => {
+  // surfacing this only on `set` (as the first pass did) leaves the two surfaces
+  // an operator actually checks reporting a clean, possibly empty view of a
+  // queue that is going nowhere
+  const { dir, blocker } = blockedCase();
+  try {
+    const [status] = await situationVerb.run(ctx(dir, { input: "status", surface: "agent" }));
+    const sp = status.payload as Record<string, unknown>;
+    assert.equal(sp.blocked, true, "status reports the blocked queue");
+    assert.match(String(sp.blocked_note), /cannot be read/i);
+
+    const [stop] = await situationVerb.run(ctx(dir, { input: "stop", surface: "agent" }));
+    const tp = stop.payload as Record<string, unknown>;
+    assert.equal(tp.blocked, true, "a queued stop reports that it will not be honored yet");
+    assert.match(String(tp.note), /NOT be honored/i);
+  } finally {
+    try { chmodSync(blocker, 0o600); } catch { /* gone */ }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("situation set reports a BLOCKED control log instead of a clean apply", async () => {
   // an unreadable patch earlier in the log holds everything behind it. Telling
   // the operator "applied within ~2s" there is a lie — the server cannot take it.

--- a/test/unit/situation-verb.test.ts
+++ b/test/unit/situation-verb.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, readdirSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,7 +9,7 @@ import { defaultProfile } from "../../src/profile.ts";
 import { situationVerb } from "../../src/verbs/situation.ts";
 import { findVerb } from "../../src/registry/verbs.ts";
 import { OPERATIONAL_VERBS } from "../../src/record.ts";
-import { readControl, readRuntime, writeRuntime } from "../../src/situation/state.ts";
+import { readControl, readRuntime, writeRuntime, writeControl, situationDir } from "../../src/situation/state.ts";
 import type { VerbContext } from "../../src/registry/types.ts";
 
 function tmpCase() {
@@ -34,6 +34,31 @@ function ctx(dir: string, over: Partial<VerbContext> = {}): VerbContext {
     ...over,
   };
 }
+
+test("situation set reports a BLOCKED control log instead of a clean apply", async () => {
+  // an unreadable patch earlier in the log holds everything behind it. Telling
+  // the operator "applied within ~2s" there is a lie — the server cannot take it.
+  const dir = mkdtempSync(join(tmpdir(), "oc-sitblocked-"));
+  let blocker: string | undefined;
+  try {
+    const c = openCase(dir);
+    c.ensure();
+    writeControl(c, { limit: 2 });
+    const cdir = join(situationDir(c), "control.d");
+    const firstMs = Number(readdirSync(cdir)[0].split("-")[0]);
+    blocker = join(cdir, `${String(firstMs + 1).padStart(15, "0")}-000001-0-blocked.json`);
+    writeFileSync(blocker, JSON.stringify({ limit: 9 }), "utf8");
+    chmodSync(blocker, 0o000);
+
+    const recs = await situationVerb.run(ctx(dir, { input: "set", surface: "agent", opts: { limit: 5 } }));
+    const p = recs[0].payload as Record<string, unknown>;
+    assert.equal(p.blocked, true, "the blocked queue is surfaced");
+    assert.match(String(p.note), /cannot be read/i, "the note explains why nothing applies");
+  } finally {
+    if (blocker) { try { chmodSync(blocker, 0o600); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("situation is registered + operational (out of ask/brief evidence)", () => {
   assert.equal(findVerb("situation")?.name, "situation");

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -139,6 +139,40 @@ test("runWatch fills transcript from tinycloud's speech.vtt sidecar", async () =
   }
 });
 
+test("runWatch strips cue tags inside a <v> voice cue, to a fixed point", async () => {
+  // tinycloud VTTs lean on `<v Name>`, and that branch used to return the body
+  // verbatim — so nested <b>/<i>/timestamp tags rode straight into the
+  // transcript. Interleaved brackets also need the fixed-point loop: a single
+  // pass over `<<b>b>` matches `<` to the FIRST `>` and leaves a stray `b>`.
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchvoice-"));
+  try {
+    const vtt = join(dir, "speech.vtt");
+    writeFileSync(vtt, `WEBVTT
+
+1
+00:00:00.000 --> 00:00:01.000
+<v Ada Lovelace><b>bold</b> and <i>italic</i></v>
+
+2
+00:00:01.000 --> 00:00:02.000
+<v Alan Turing><00:00:01.500>timed <<b>b>nested</v>
+`);
+    const json = JSON.stringify({ status: "ready", data: { title: "clip", summary: "s", transcript: "", describe: { vtt_path: vtt }, segments: [] } });
+    const script = join(dir, "watch.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    const transcript = String((rec.payload as Record<string, unknown>).transcript);
+
+    assert.match(transcript, /Ada Lovelace: bold and italic/);
+    assert.match(transcript, /Alan Turing: timed nested/);
+    // no markup of any kind survives — neither whole tags nor bracket residue
+    assert.doesNotMatch(transcript, /[<>]/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("watch resolves capture_id handles before dispatching to a provider", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-watchcap-"));
   const media = join(dir, "clip.mp4");

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -200,17 +200,19 @@ test("runWatch cue stripping stays linear on deeply nested provider text", async
   }
 });
 
-test("runWatch: a `>` with no open tag is spoken text, not markup", async () => {
+test("runWatch: an UNPAIRED bracket is spoken text, not markup", async () => {
   const dir = mkdtempSync(join(tmpdir(), "oc-watchgt-"));
   try {
     const vtt = join(dir, "speech.vtt");
-    writeFileSync(vtt, `WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nif 2 > 1 then <b>ship</b> it\n`);
+    // a lone `<` must NOT swallow the rest of the cue — a plain depth counter
+    // does exactly that, silently truncating real spoken content
+    writeFileSync(vtt, `WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nif 2 > 1 and x < y then <b>ship</b> it\n`);
     const json = JSON.stringify({ status: "ready", data: { title: "clip", summary: "s", transcript: "", describe: { vtt_path: vtt }, segments: [] } });
     const script = join(dir, "watch.sh");
     writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
     chmodSync(script, 0o755);
     const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
-    assert.equal(String((rec.payload as Record<string, unknown>).transcript), "if 2 > 1 then ship it");
+    assert.equal(String((rec.payload as Record<string, unknown>).transcript), "if 2 > 1 and x < y then ship it");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -139,11 +139,11 @@ test("runWatch fills transcript from tinycloud's speech.vtt sidecar", async () =
   }
 });
 
-test("runWatch strips cue tags inside a <v> voice cue, to a fixed point", async () => {
+test("runWatch strips cue tags inside a <v> voice cue, at any nesting", async () => {
   // tinycloud VTTs lean on `<v Name>`, and that branch used to return the body
   // verbatim — so nested <b>/<i>/timestamp tags rode straight into the
-  // transcript. Interleaved brackets also need the fixed-point loop: a single
-  // pass over `<<b>b>` matches `<` to the FIRST `>` and leaves a stray `b>`.
+  // transcript. Interleaved brackets need the depth-aware strip too: a single
+  // regex pass over `<<b>b>` matches `<` to the FIRST `>` and leaves `b>`.
   const dir = mkdtempSync(join(tmpdir(), "oc-watchvoice-"));
   try {
     const vtt = join(dir, "speech.vtt");
@@ -168,6 +168,49 @@ test("runWatch strips cue tags inside a <v> voice cue, to a fixed point", async 
     assert.match(transcript, /Alan Turing: timed nested/);
     // no markup of any kind survives — neither whole tags nor bracket residue
     assert.doesNotMatch(transcript, /[<>]/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runWatch cue stripping stays linear on deeply nested provider text", async () => {
+  // the fixed-point loop this replaced peeled ONE nesting layer per pass, so a
+  // crafted sidecar cost O(n^2) and could stall the mapper. 200k nested opens is
+  // ~seconds-to-minutes quadratic; linear it is instant.
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchdeep-"));
+  try {
+    const vtt = join(dir, "speech.vtt");
+    // text OUTSIDE the nested wrapper must survive; text inside it is markup
+    const nested = "keep" + "<".repeat(200_000) + "inner" + ">".repeat(200_000) + "tail";
+    writeFileSync(vtt, `WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\n${nested}\n`);
+    const json = JSON.stringify({ status: "ready", data: { title: "clip", summary: "s", transcript: "", describe: { vtt_path: vtt }, segments: [] } });
+    const script = join(dir, "watch.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+
+    const started = Date.now();
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    const elapsed = Date.now() - started;
+
+    const transcript = String((rec.payload as Record<string, unknown>).transcript);
+    assert.equal(transcript, "keeptail", "nested wrapper stripped, surrounding text kept");
+    assert.ok(elapsed < 10_000, `cue strip should be linear, took ${elapsed}ms`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runWatch: a `>` with no open tag is spoken text, not markup", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchgt-"));
+  try {
+    const vtt = join(dir, "speech.vtt");
+    writeFileSync(vtt, `WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nif 2 > 1 then <b>ship</b> it\n`);
+    const json = JSON.stringify({ status: "ready", data: { title: "clip", summary: "s", transcript: "", describe: { vtt_path: vtt }, segments: [] } });
+    const script = join(dir, "watch.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    assert.equal(String((rec.payload as Record<string, unknown>).transcript), "if 2 > 1 then ship it");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/youtube-source.test.ts
+++ b/test/unit/youtube-source.test.ts
@@ -53,7 +53,7 @@ case "$FAKE_MODE" in
       # numeric cue IDENTIFIERS (1, 2 — the 2 with a CRLF ending) precede their
       # timing lines and must drop; "12:30 lunch launch" (spoken time) and
       # "2026" (digit-only caption) are caption text and must survive
-      printf 'WEBVTT\\nKind: captions\\nLanguage: en\\n\\n1\\n00:00:00.000 --> 00:00:01.000\\nhello world\\n\\n2\\r\\n00:00:01.000 --> 00:00:02.000\\nhello world\\n\\n00:00:02.000 --> 00:00:03.000\\n<c>second</c> line\\n\\n00:00:03.000 --> 00:00:04.000\\n12:30 lunch launch\\n\\n00:00:04.000 --> 00:00:05.000\\n2026\\n' > "$out.en.vtt"
+      printf 'WEBVTT\\nKind: captions\\nLanguage: en\\n\\n1\\n00:00:00.000 --> 00:00:01.000\\nhello world\\n\\n2\\r\\n00:00:01.000 --> 00:00:02.000\\nhello world\\n\\n00:00:02.000 --> 00:00:03.000\\n<c>second</c> line\\n\\n00:00:02.500 --> 00:00:02.900\\n<<b>b>interleaved<</i>i> tags\\n\\n00:00:03.000 --> 00:00:04.000\\n12:30 lunch launch\\n\\n00:00:04.000 --> 00:00:05.000\\n2026\\n' > "$out.en.vtt"
       printf 'WEBVTT\\n\\n00:00:00.000 --> 00:00:01.000\\norig variant\\n' > "$out.en-orig.vtt"
     fi
     if [ "$FAKE_MODE" = "subs_orig_only" ]; then
@@ -183,7 +183,7 @@ test("fetch --kind transcript: captions + metadata land in the capture payload, 
     assert.equal(p.duration, 65);
     // VTT compaction: cue timings/headers/karaoke tags stripped, consecutive
     // rolling duplicates collapsed
-    assert.equal(p.transcript, "hello world\nsecond line\n12:30 lunch launch\n2026");
+    assert.equal(p.transcript, "hello world\nsecond line\ninterleaved tags\n12:30 lunch launch\n2026");
     assert.equal(p.transcript_lang, "en");
     assert.equal(p.transcript_source, "manual"); // info.json lists manual en subs
     // the exact-lang variant wins; the -orig variant is cleaned up
@@ -220,7 +220,7 @@ test("fetch --kind transcript tolerates a nonzero yt-dlp exit when the track + m
     assert.equal(rec.state, "ready", rec.error);
     const p = rec.payload as Record<string, unknown>;
     assert.equal(p.kind, "transcript");
-    assert.equal(p.transcript, "hello world\nsecond line\n12:30 lunch launch\n2026");
+    assert.equal(p.transcript, "hello world\nsecond line\ninterleaved tags\n12:30 lunch launch\n2026");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/unit/youtube-source.test.ts
+++ b/test/unit/youtube-source.test.ts
@@ -53,7 +53,7 @@ case "$FAKE_MODE" in
       # numeric cue IDENTIFIERS (1, 2 — the 2 with a CRLF ending) precede their
       # timing lines and must drop; "12:30 lunch launch" (spoken time) and
       # "2026" (digit-only caption) are caption text and must survive
-      printf 'WEBVTT\\nKind: captions\\nLanguage: en\\n\\n1\\n00:00:00.000 --> 00:00:01.000\\nhello world\\n\\n2\\r\\n00:00:01.000 --> 00:00:02.000\\nhello world\\n\\n00:00:02.000 --> 00:00:03.000\\n<c>second</c> line\\n\\n00:00:02.500 --> 00:00:02.900\\n<<b>b>interleaved<</i>i> tags\\n\\n00:00:03.000 --> 00:00:04.000\\n12:30 lunch launch\\n\\n00:00:04.000 --> 00:00:05.000\\n2026\\n' > "$out.en.vtt"
+      printf 'WEBVTT\\nKind: captions\\nLanguage: en\\n\\n1\\n00:00:00.000 --> 00:00:01.000\\nhello world\\n\\n2\\r\\n00:00:01.000 --> 00:00:02.000\\nhello world\\n\\n00:00:02.000 --> 00:00:03.000\\n<c>second</c> line\\n\\n00:00:02.500 --> 00:00:02.900\\n<<b>b>interleaved<</i>i> tags\\n\\n00:00:02.900 --> 00:00:02.950\\nx < y stays\\n\\n00:00:03.000 --> 00:00:04.000\\n12:30 lunch launch\\n\\n00:00:04.000 --> 00:00:05.000\\n2026\\n' > "$out.en.vtt"
       printf 'WEBVTT\\n\\n00:00:00.000 --> 00:00:01.000\\norig variant\\n' > "$out.en-orig.vtt"
     fi
     if [ "$FAKE_MODE" = "subs_orig_only" ]; then
@@ -183,7 +183,7 @@ test("fetch --kind transcript: captions + metadata land in the capture payload, 
     assert.equal(p.duration, 65);
     // VTT compaction: cue timings/headers/karaoke tags stripped, consecutive
     // rolling duplicates collapsed
-    assert.equal(p.transcript, "hello world\nsecond line\ninterleaved tags\n12:30 lunch launch\n2026");
+    assert.equal(p.transcript, "hello world\nsecond line\ninterleaved tags\nx < y stays\n12:30 lunch launch\n2026");
     assert.equal(p.transcript_lang, "en");
     assert.equal(p.transcript_source, "manual"); // info.json lists manual en subs
     // the exact-lang variant wins; the -orig variant is cleaned up
@@ -220,7 +220,7 @@ test("fetch --kind transcript tolerates a nonzero yt-dlp exit when the track + m
     assert.equal(rec.state, "ready", rec.error);
     const p = rec.payload as Record<string, unknown>;
     assert.equal(p.kind, "transcript");
-    assert.equal(p.transcript, "hello world\nsecond line\ninterleaved tags\n12:30 lunch launch\n2026");
+    assert.equal(p.transcript, "hello world\nsecond line\ninterleaved tags\nx < y stays\n12:30 lunch launch\n2026");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/vscode/test/hostMessage.test.ts
+++ b/vscode/test/hostMessage.test.ts
@@ -1,0 +1,46 @@
+// Admission rules for host→webview messages (webview/src/hostMessage.ts).
+// A security boundary with no test is a decorative one, so the stray-sender
+// cases are pinned here rather than left to a code review to re-derive.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { acceptHostMessage, isHostMsg, originAllowed } from "../webview/src/hostMessage.ts";
+
+const SELF = "vscode-webview://0deadbeef-1111-2222-3333-444455556666";
+
+test("originAllowed: only the panel's own origin", () => {
+  assert.ok(originAllowed(SELF, SELF));
+  // a DIFFERENT vscode-webview panel must not reach this handler
+  assert.ok(!originAllowed("vscode-webview://ffffffff-9999-8888-7777-666655554444", SELF));
+  // opaque / sandboxed frames
+  assert.ok(!originAllowed("", SELF));
+  assert.ok(!originAllowed("null", SELF));
+  // plain remote pages
+  assert.ok(!originAllowed("https://example.com", SELF));
+  // prefix games around the real origin
+  assert.ok(!originAllowed(SELF + ".evil.test", SELF));
+  assert.ok(!originAllowed("https://evil.test/" + SELF, SELF));
+});
+
+test("originAllowed: an empty self origin rejects rather than matching everything", () => {
+  assert.ok(!originAllowed("", ""));
+  assert.ok(!originAllowed("null", ""));
+  assert.ok(!originAllowed("https://example.com", ""));
+});
+
+test("isHostMsg: requires the discriminant the host contract is built on", () => {
+  assert.ok(isHostMsg({ type: "init" }));
+  assert.ok(!isHostMsg({ noType: true }));
+  assert.ok(!isHostMsg(null));
+  assert.ok(!isHostMsg("init"));
+  assert.ok(!isHostMsg(42));
+  assert.ok(!isHostMsg({ type: 7 })); // non-string discriminant
+});
+
+test("acceptHostMessage: both gates must pass", () => {
+  const msg = { type: "init", view: "record", state: {} };
+  assert.deepEqual(acceptHostMessage({ origin: SELF, data: msg }, SELF), msg);
+  // right shape, wrong sender
+  assert.equal(acceptHostMessage({ origin: "https://evil.test", data: msg }, SELF), undefined);
+  // right sender, junk payload
+  assert.equal(acceptHostMessage({ origin: SELF, data: { nope: 1 } }, SELF), undefined);
+});

--- a/vscode/test/hostMessage.test.ts
+++ b/vscode/test/hostMessage.test.ts
@@ -21,10 +21,15 @@ test("originAllowed: only the panel's own origin", () => {
   assert.ok(!originAllowed("https://evil.test/" + SELF, SELF));
 });
 
-test("originAllowed: an empty self origin rejects rather than matching everything", () => {
+test("originAllowed: an OPAQUE self origin rejects rather than matching its twin", () => {
+  // both `""` and `"null"` are opaque — a sandboxed frame reports `"null"` too,
+  // so equality alone would admit exactly the sender this is meant to reject
   assert.ok(!originAllowed("", ""));
+  assert.ok(!originAllowed("null", "null"));
   assert.ok(!originAllowed("null", ""));
+  assert.ok(!originAllowed("", "null"));
   assert.ok(!originAllowed("https://example.com", ""));
+  assert.ok(!originAllowed("https://example.com", "null"));
 });
 
 test("isHostMsg: requires the discriminant the host contract is built on", () => {

--- a/vscode/test/htmlRewrite.test.ts
+++ b/vscode/test/htmlRewrite.test.ts
@@ -75,7 +75,10 @@ test("map online: data: URIs untouched, remote links untouched, OSM toggle gates
   for (const out of [closed.html, open.html]) {
     assert.equal((out.match(/data:image\/[a-z+]+;base64/g) ?? []).length, dataUris.length);
     assert.ok(out.includes("https://www.openstreetmap.org/?mlat"), "remote deep link untouched");
-    assert.ok(out.includes("tile.openstreetmap.org"), "tile template in script untouched");
+    // the tile URL WITH its path, not the bare host — a bare-host substring reads
+    // as a host check arbitrary hosts can straddle (CodeQL
+    // js/incomplete-url-substring-sanitization)
+    assert.ok(out.includes(".tile.openstreetmap.org/"), "tile template in script untouched");
   }
 });
 

--- a/vscode/test/htmlRewrite.test.ts
+++ b/vscode/test/htmlRewrite.test.ts
@@ -75,10 +75,7 @@ test("map online: data: URIs untouched, remote links untouched, OSM toggle gates
   for (const out of [closed.html, open.html]) {
     assert.equal((out.match(/data:image\/[a-z+]+;base64/g) ?? []).length, dataUris.length);
     assert.ok(out.includes("https://www.openstreetmap.org/?mlat"), "remote deep link untouched");
-    // the tile URL WITH its path, not the bare host — a bare-host substring reads
-    // as a host check arbitrary hosts can straddle (CodeQL
-    // js/incomplete-url-substring-sanitization)
-    assert.ok(out.includes(".tile.openstreetmap.org/"), "tile template in script untouched");
+    assert.ok(out.includes("tile.openstreetmap.org"), "tile template in script untouched");
   }
 });
 

--- a/vscode/webview/src/hostMessage.ts
+++ b/vscode/webview/src/hostMessage.ts
@@ -1,0 +1,36 @@
+// Admission rules for host→webview messages, kept in their own module (free of
+// the `acquireVsCodeApi()` top-level call in vscodeApi.ts) so they are directly
+// unit-testable — this is a security boundary, and an untested one is a
+// decorative one.
+
+import type { HostMsg } from "../../src/shared/protocol.ts";
+
+/** Host→webview messages must come from THIS panel's own origin — nothing
+ *  broader. VS Code's webview preload forwards the extension host's message into
+ *  the content frame with `postMessage(data.message, window.origin, …)`, so a
+ *  genuine host message always arrives with `event.origin === window.origin`.
+ *
+ *  Accepting any `vscode-webview://…` origin (or the opaque `""`/`"null"`) would
+ *  widen this to other panels and sandboxed frames, which is exactly the stray
+ *  sender the check exists to reject — an unchecked handler trusts whoever posts
+ *  (CodeQL js/missing-origin-check). */
+export function originAllowed(origin: string, selfOrigin: string): boolean {
+  // an empty selfOrigin (non-browser/opaque context) must never turn into
+  // "everything matches" — reject rather than fail open
+  return selfOrigin !== "" && origin === selfOrigin;
+}
+
+/** The host contract is a discriminated union — anything without a string `type`
+ *  is not one of ours, whatever origin it claims. */
+export function isHostMsg(data: unknown): data is HostMsg {
+  return typeof data === "object" && data !== null && typeof (data as { type?: unknown }).type === "string";
+}
+
+/** The message if it passes BOTH gates, else undefined. */
+export function acceptHostMessage(
+  event: { origin: string; data: unknown },
+  selfOrigin: string,
+): HostMsg | undefined {
+  if (!originAllowed(event.origin, selfOrigin)) return undefined;
+  return isHostMsg(event.data) ? event.data : undefined;
+}

--- a/vscode/webview/src/hostMessage.ts
+++ b/vscode/webview/src/hostMessage.ts
@@ -15,9 +15,12 @@ import type { HostMsg } from "../../src/shared/protocol.ts";
  *  sender the check exists to reject — an unchecked handler trusts whoever posts
  *  (CodeQL js/missing-origin-check). */
 export function originAllowed(origin: string, selfOrigin: string): boolean {
-  // an empty selfOrigin (non-browser/opaque context) must never turn into
-  // "everything matches" — reject rather than fail open
-  return selfOrigin !== "" && origin === selfOrigin;
+  // A concrete self origin is required. `""` and `"null"` are both OPAQUE — a
+  // sandboxed frame reports `"null"` too, so comparing them for equality admits
+  // exactly the stray sender this rejects (equality alone fails open when both
+  // sides are opaque). Demand a real origin rather than trusting the match.
+  if (selfOrigin === "" || selfOrigin === "null") return false;
+  return origin === selfOrigin;
 }
 
 /** The host contract is a discriminated union — anything without a string `type`

--- a/vscode/webview/src/vscodeApi.ts
+++ b/vscode/webview/src/vscodeApi.ts
@@ -15,6 +15,30 @@ export function post(msg: WebviewMsg): void {
   api.postMessage(msg);
 }
 
+/** Origins a host→webview message may legitimately arrive from. VS Code serves
+ *  webview content off a per-panel `vscode-webview://<uuid>` origin and the
+ *  extension host posts into that same frame, so anything else is a stray sender
+ *  (an embedded remote frame, another window) and must be ignored — an unchecked
+ *  handler trusts whoever posts, CodeQL js/missing-origin-check. `""`/`"null"`
+ *  cover the opaque-origin case some webview hosts report. */
+function originAllowed(origin: string): boolean {
+  return (
+    origin === "" ||
+    origin === "null" ||
+    origin === window.origin ||
+    origin.startsWith("vscode-webview://")
+  );
+}
+
+/** The host contract is a discriminated union — anything without a string `type`
+ *  is not one of ours, whatever origin it claims. */
+function isHostMsg(data: unknown): data is HostMsg {
+  return typeof data === "object" && data !== null && typeof (data as { type?: unknown }).type === "string";
+}
+
 export function onMessage(handler: (msg: HostMsg) => void): void {
-  window.addEventListener("message", (e: MessageEvent) => handler(e.data as HostMsg));
+  window.addEventListener("message", (e: MessageEvent) => {
+    if (!originAllowed(e.origin) || !isHostMsg(e.data)) return;
+    handler(e.data);
+  });
 }

--- a/vscode/webview/src/vscodeApi.ts
+++ b/vscode/webview/src/vscodeApi.ts
@@ -1,5 +1,6 @@
 // Thin wrapper over the VS Code webview messaging API.
 import type { HostMsg, WebviewMsg } from "../../src/shared/protocol.ts";
+import { acceptHostMessage } from "./hostMessage.ts";
 
 interface VsCodeApi {
   postMessage(msg: unknown): void;
@@ -15,30 +16,10 @@ export function post(msg: WebviewMsg): void {
   api.postMessage(msg);
 }
 
-/** Origins a host→webview message may legitimately arrive from. VS Code serves
- *  webview content off a per-panel `vscode-webview://<uuid>` origin and the
- *  extension host posts into that same frame, so anything else is a stray sender
- *  (an embedded remote frame, another window) and must be ignored — an unchecked
- *  handler trusts whoever posts, CodeQL js/missing-origin-check. `""`/`"null"`
- *  cover the opaque-origin case some webview hosts report. */
-function originAllowed(origin: string): boolean {
-  return (
-    origin === "" ||
-    origin === "null" ||
-    origin === window.origin ||
-    origin.startsWith("vscode-webview://")
-  );
-}
-
-/** The host contract is a discriminated union — anything without a string `type`
- *  is not one of ours, whatever origin it claims. */
-function isHostMsg(data: unknown): data is HostMsg {
-  return typeof data === "object" && data !== null && typeof (data as { type?: unknown }).type === "string";
-}
-
 export function onMessage(handler: (msg: HostMsg) => void): void {
   window.addEventListener("message", (e: MessageEvent) => {
-    if (!originAllowed(e.origin) || !isHostMsg(e.data)) return;
-    handler(e.data);
+    // origin + shape gates live in hostMessage.ts so they can be unit-tested
+    const msg = acceptHostMessage(e, window.origin);
+    if (msg) handler(msg);
   });
 }

--- a/web/situation/src/views/wall.ts
+++ b/web/situation/src/views/wall.ts
@@ -80,7 +80,7 @@ export function createWall(): WallView {
     cells.delete(ref);
   }
 
-  function wireVideo(v: HTMLVideoElement, tile: SituationTile, fig: HTMLElement, delayMs: number): void {
+  function wireVideo(v: HTMLVideoElement, tile: SituationTile, fig: HTMLElement, delayMs: number, src: string): void {
     let start = tile.anchor.start;
     let end = tile.anchor.end;
     v.addEventListener("loadedmetadata", () => {
@@ -110,8 +110,11 @@ export function createWall(): WallView {
     v.addEventListener("error", () => fig.classList.add("err"));
     // staggered attach avoids a simultaneous decode burst; only a real autoplay
     // block (NotAllowedError) shows the START button.
+    // src rides a closure, NOT a data-src round-trip through the DOM: reading an
+    // attribute back launders the value into untrusted DOM text as far as any
+    // reader (and CodeQL js/xss-through-dom) can tell, and lets anything that
+    // touches the element rewrite what we load.
     setTimeout(() => {
-      const src = v.getAttribute("data-src");
       if (!src) return;
       v.src = src;
       v.play().catch((err: unknown) => {
@@ -133,12 +136,11 @@ export function createWall(): WallView {
       video.playsInline = true;
       video.loop = true;
       video.preload = "metadata";
-      video.setAttribute("data-src", src);
       fig.append(video);
       const cover = el("div", "cover errcover");
       cover.append(el("span", "nosig-label", "NO SIGNAL"));
       fig.append(cover);
-      wireVideo(video, tile, fig, index * 150);
+      wireVideo(video, tile, fig, index * 150, src);
     } else if (tile.mode !== "down" && !src) {
       // present media the desk chose not to serve (remote, embeds off)
       fig.append(el("div", "static"));


### PR DESCRIPTION
Started as "fix the 20 open CodeQL alerts". The review loop then found 24 rounds of follow-on issues — many in my own fixes — so this is now a substantially larger hardening pass. **Bugbot is clean and all 49 review threads are resolved as of `1df0b40`.**

## The original 20 CodeQL alerts

**ReDoS** — the `crop` data-URL parser's parameter repetition (`[^,]*` could also match the `;` the outer group consumes) backtracked exponentially on untrusted provider input; two quadratic `[?#]` URL-tail patterns in `record.ts` became a linear helper. That helper then got swept across **13 more instances** of the same pattern that CodeQL never flagged.

**TOCTOU** (×6) — the reachable one was the situation server's static-asset route: exists → stat → read re-resolved the path at each step, so a symlink swapped in after the containment check could be served from outside the root.

**Untrusted input** — WebVTT cue-tag stripping, a `data-src` DOM round-trip in the situation wall, and an unchecked webview `postMessage` handler.

**Test-file alerts** (×6) — scoped out via `paths-ignore` after I tried rewriting the assertions and found I was making them worse at their real job. One survives on merit: a fixture server's hit counter is now a `Map`, so `/__proto__` records a hit instead of writing through `Object.prototype`.

**Dismissed** — `js/file-access-to-http` in `media/fetch`: downloading case-referenced media *is* the feature, and the path enforces a scheme allowlist, private/loopback blocking, fail-closed DNS, per-redirect-hop re-validation, and size/time caps.

## What the review loop actually found

Most findings were in code I had just written. The recurring lesson was that **each fix exposed the next edge of a bad shape**, and the fix was to change the shape:

- **The situation control plane** absorbed rounds 8, 9, 12, 13, 15, 16, 17, 19, 20, 22, 23, 24. `control.json` was one mutable file that `situation set` read-modify-wrote. That needed a lock → the lock needed a stale-steal → the steal needed a deadline → the server needed a non-blocking acquire (waiting parked the event loop serving `/media` and SSE) → the consume needed a restore path → the restore could clobber a newer write. It is now an **append-only patch directory**: no shared mutable state, so no lock to hold, wait on, steal, or abandon. Net less code. This is the largest behavioral change here and the part most worth reviewing.
- **`openContainedFile`** went through three rounds before it was right: resolve-then-open (so the open can't be redirected), `O_NOFOLLOW` (so a final-component swap fails instead of being followed), and a POSIX-only dev/ino check — because the identity check alone confirms *consistency*, not *containment*, when both sides follow the same new link.
- **Cue stripping** was fixed four times: incomplete → quadratic fixed-point → a depth counter that silently ate everything after a spoken `x < y` → a pair-aware mark stack. The shell twin got the same treatment, including a linear rewrite after measurement showed per-char `substr` was still quadratic.

## Evidence

Where a fix could be demonstrated, it was — and where it couldn't, I said so:

- **Lost updates**: six processes on a shared barrier, measured against the unlocked code — **0/8 rounds kept all six updates**; five of six operator commands lost per round, silently.
- **Infinite lock spin**: the old loop hung past a 20s watchdog on a read-only dir; the new one returns in 0ms.
- **Crash-safety**: SIGKILL at six points through a real crop leaves the frame absent or complete, never partial.
- **fd leaks**: 240 requests across HEAD/200/206/416 grow the fd table by 2.
- **awk portability**: byte-identical output across BWK awk, mawk (CI's) and gawk, all linear; 800KB single line 11.2s → 0.73s.
- **Honest gap**: for the `O_NOFOLLOW` TOCTOU I could *not* reproduce the escape in ~107k hammered attempts, with or without the flag. That fix is reasoned, not measured, and is labeled as such in the code and the thread.

Several tests had to be fixed **twice** before they discriminated — passing against the very bug they targeted because of same-millisecond ordering, a badly chosen fixture name, or a deletion staged before the listing it was meant to race. Each is now verified to fail against the old implementation. Bugbot also caught one test that couldn't fail at all after the redesign made the file it waited on stop existing.

## Verification

`1212 unit + 55 vscode + 336 offline e2e` green; CodeQL / CI / Bugbot green.

Full **live e2e at the branch tip: 744/746**. Both failures are third-party cloud flakes, confirmed rather than assumed:
- `separate.fal.tracks` — the fal audio-separation call returned nothing. Re-ran that phase in isolation: **5/5 pass**. It also passed in the prior full run, and `separate.local` (same media, local path) passed in the same run.
- `skill_provenance.lens_ran` — `curl: (28)` an explicit **240s upstream timeout** from the Apify lens actor; lens passed with 4 hits in the prior run.

Two earlier scares were not regressions: a live run with heavy failures was **contention from my own concurrent builds** (clean on an idle machine at 745/745), and an intermittent offline `330/332` (`agent.timeout` / `archiveagent.timeout`, which the harness labels "cloud hang") reproduces on a report dated **2026-07-17, before the first commit on this branch**.