### PR TITLE
docs: add README badges, DEF CON 34 news, and a Credits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ another backend or your own script with no code changes.
 
 **overcast is at [DEF CON 34](https://info.defcon.org/defcon34/content/?id=66515)
 Demo Labs** — *"Overcast: Video OSINT Agent. Point It at 100 Videos, Ask
-Anything"*, presented by Kevin "kdrwins" Dela Rosa. Two sessions, both in
+Anything"*, presented by Kevin Dela Rosa. Two sessions, both in
 LVCC L1, Exhibit Hall West 3 – 902 (Demo Labs Track 6):
 
 | Session | When |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
   <img src="assets/branding/logo.png" alt="overcast" width="420" />
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@kdrrr/overcast"><img src="https://img.shields.io/npm/v/%40kdrrr%2Fovercast?logo=npm&color=cb3837" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/@kdrrr/overcast"><img src="https://img.shields.io/npm/dm/%40kdrrr%2Fovercast?logo=npm&color=cb3837" alt="npm downloads" /></a>
+  <a href="https://github.com/kdr/overcast/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/kdr/overcast/ci.yml?branch=main&logo=githubactions&logoColor=white&label=ci" alt="ci" /></a>
+  <a href="https://github.com/kdr/overcast/actions/workflows/codeql.yml"><img src="https://img.shields.io/github/actions/workflow/status/kdr/overcast/codeql.yml?branch=main&logo=github&label=codeql" alt="codeql" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="license: Apache-2.0" /></a>
+</p>
+
+<p align="center">
+  <a href="https://nodejs.org"><img src="https://img.shields.io/node/v/%40kdrrr%2Fovercast?logo=nodedotjs&logoColor=white&color=5FA04E" alt="node version" /></a>
+  <img src="https://img.shields.io/badge/TypeScript-ESM-3178C6?logo=typescript&logoColor=white" alt="TypeScript ESM" />
+  <a href="https://github.com/earendil-works/pi"><img src="https://img.shields.io/badge/built%20on-pi-8A2BE2" alt="built on pi" /></a>
+  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs welcome" /></a>
+</p>
+
+<p align="center">
+  <em>Created by <a href="https://github.com/kdr/kdr">Kevin Dela Rosa</a> — co-founder &amp; CTO @ <a href="https://cloudglue.dev/">Cloudglue</a></em>
+</p>
+
+<p align="center">
+  <a href="https://github.com/kdr/kdr"><img src="https://img.shields.io/badge/GitHub-kdr-181717?logo=github&logoColor=white" alt="GitHub @kdr" /></a>
+  <a href="https://kevindelarosa.com/"><img src="https://img.shields.io/badge/Portfolio-kevindelarosa.com-0A66C2?logo=googlechrome&logoColor=white" alt="Portfolio" /></a>
+  <a href="https://x.com/kdrwins"><img src="https://img.shields.io/badge/X-@kdrwins-000000?logo=x&logoColor=white" alt="X @kdrwins" /></a>
+  <a href="https://www.linkedin.com/in/kdrwins/"><img src="https://img.shields.io/badge/LinkedIn-kdrwins-0A66C2?logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
+  <a href="https://scholar.google.com/citations?user=8Pc5MiUAAAAJ&hl=en"><img src="https://img.shields.io/badge/Google%20Scholar-publications-4285F4?logo=googlescholar&logoColor=white" alt="Google Scholar" /></a>
+</p>
+
 # overcast
 
 **Video OSINT agent: senses + OSINT reach for any agent.**
@@ -822,6 +849,19 @@ message showing the version or command-registry drift.
 - **[SUPPORT.md](SUPPORT.md)** — where to get help.
 - Questions and ideas → [Discussions](https://github.com/kdr/overcast/discussions);
   bugs and features → [Issues](https://github.com/kdr/overcast/issues/new/choose).
+
+## Creator
+
+overcast is built by **[Kevin Dela Rosa](https://github.com/kdr/kdr)** (`@kdr`),
+co-founder & CTO of [Cloudglue](https://cloudglue.dev/) and creator of
+[Tinycloud](https://www.tinycloud.sh/) — the default perception backend here. He
+presented *Autonomous Video Hunter*, on AI agents for real-time video OSINT, at
+**DEF CON 33**.
+
+Find him at [kevindelarosa.com](https://kevindelarosa.com/) ·
+[GitHub](https://github.com/kdr/kdr) · [X](https://x.com/kdrwins) ·
+[LinkedIn](https://www.linkedin.com/in/kdrwins/) ·
+[Google Scholar](https://scholar.google.com/citations?user=8Pc5MiUAAAAJ&hl=en)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -854,8 +854,8 @@ third-party services you configure — see [RESPONSIBLE_USE.md](RESPONSIBLE_USE.
 
 ## Credits
 
-Created by **[Kevin Dela Rosa](https://github.com/kdr)** (`@kdr`) — co-founder &
-CTO of [Cloudglue](https://cloudglue.dev/) and creator of
+Created by **[Kevin Dela Rosa](https://github.com/kdr)** — co-founder & CTO of
+[Cloudglue](https://cloudglue.dev/) and creator of
 [Tinycloud](https://www.tinycloud.sh/), the default perception backend here.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ another backend or your own script with no code changes.
 
 ---
 
+## 📣 News
+
+**overcast is at [DEF CON 34](https://info.defcon.org/defcon34/content/?id=66515)
+Demo Labs** — *"Overcast: Video OSINT Agent. Point It at 100 Videos, Ask
+Anything"*, presented by Kevin "kdrwins" Dela Rosa. Two sessions, both in
+LVCC L1, Exhibit Hall West 3 – 902 (Demo Labs Track 6):
+
+| Session | When |
+| --- | --- |
+| 1 | Fri, Aug 7, 2026 · 12:00–12:45 PDT |
+| 2 | Sat, Aug 8, 2026 · 16:00–16:45 PDT |
+
+Come see it run live, or [read the abstract](https://info.defcon.org/defcon34/content/?id=66515).
+
+---
+
 > ### ⚠️ Responsible use & security model
 >
 > overcast is a **dual-use** tool. Its OSINT sources can reach personal
@@ -838,27 +854,23 @@ message showing the version or command-registry drift.
 - Questions and ideas → [Discussions](https://github.com/kdr/overcast/discussions);
   bugs and features → [Issues](https://github.com/kdr/overcast/issues/new/choose).
 
+## License
+
+Licensed under the [Apache License 2.0](LICENSE). Built on top of
+[pi](https://github.com/earendil-works/pi). You are responsible for how you use
+this tool and for complying with all applicable laws and the terms of any
+third-party services you configure — see [RESPONSIBLE_USE.md](RESPONSIBLE_USE.md).
+
 ## Credits
 
-Created by **[Kevin Dela Rosa](https://github.com/kdr/kdr)** (`@kdr`) —
-co-founder & CTO of [Cloudglue](https://cloudglue.dev/) and creator of
+Created by **[Kevin Dela Rosa](https://github.com/kdr)** (`@kdr`) — co-founder &
+CTO of [Cloudglue](https://cloudglue.dev/) and creator of
 [Tinycloud](https://www.tinycloud.sh/), the default perception backend here.
-*Autonomous Video Hunter*, on AI agents for real-time video OSINT, was presented
-at **DEF CON 33**.
 
 <p align="center">
-  <a href="https://github.com/kdr/kdr"><img src="https://img.shields.io/badge/GitHub-kdr-181717?logo=github&logoColor=white" alt="GitHub @kdr" /></a>
+  <a href="https://github.com/kdr"><img src="https://img.shields.io/badge/GitHub-kdr-181717?logo=github&logoColor=white" alt="GitHub @kdr" /></a>
   <a href="https://kevindelarosa.com/"><img src="https://img.shields.io/badge/Portfolio-kevindelarosa.com-0A66C2?logo=googlechrome&logoColor=white" alt="Portfolio" /></a>
   <a href="https://x.com/kdrwins"><img src="https://img.shields.io/badge/X-%40kdrwins-000000?logo=x&logoColor=white" alt="X @kdrwins" /></a>
   <a href="https://www.linkedin.com/in/kdrwins/"><img src="https://img.shields.io/badge/LinkedIn-kdrwins-0A66C2?logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
   <a href="https://scholar.google.com/citations?user=8Pc5MiUAAAAJ&hl=en"><img src="https://img.shields.io/badge/Google%20Scholar-publications-4285F4?logo=googlescholar&logoColor=white" alt="Google Scholar" /></a>
 </p>
-
-Built on top of [pi](https://github.com/earendil-works/pi) by
-[earendil-works](https://github.com/earendil-works).
-
-## License
-
-Licensed under the [Apache License 2.0](LICENSE). You are responsible for how you use
-this tool and for complying with all applicable laws and the terms of any
-third-party services you configure — see [RESPONSIBLE_USE.md](RESPONSIBLE_USE.md).

--- a/README.md
+++ b/README.md
@@ -17,18 +17,6 @@
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs welcome" /></a>
 </p>
 
-<p align="center">
-  <em>Created by <a href="https://github.com/kdr/kdr">Kevin Dela Rosa</a> — co-founder &amp; CTO @ <a href="https://cloudglue.dev/">Cloudglue</a></em>
-</p>
-
-<p align="center">
-  <a href="https://github.com/kdr/kdr"><img src="https://img.shields.io/badge/GitHub-kdr-181717?logo=github&logoColor=white" alt="GitHub @kdr" /></a>
-  <a href="https://kevindelarosa.com/"><img src="https://img.shields.io/badge/Portfolio-kevindelarosa.com-0A66C2?logo=googlechrome&logoColor=white" alt="Portfolio" /></a>
-  <a href="https://x.com/kdrwins"><img src="https://img.shields.io/badge/X-@kdrwins-000000?logo=x&logoColor=white" alt="X @kdrwins" /></a>
-  <a href="https://www.linkedin.com/in/kdrwins/"><img src="https://img.shields.io/badge/LinkedIn-kdrwins-0A66C2?logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
-  <a href="https://scholar.google.com/citations?user=8Pc5MiUAAAAJ&hl=en"><img src="https://img.shields.io/badge/Google%20Scholar-publications-4285F4?logo=googlescholar&logoColor=white" alt="Google Scholar" /></a>
-</p>
-
 # overcast
 
 **Video OSINT agent: senses + OSINT reach for any agent.**
@@ -850,22 +838,27 @@ message showing the version or command-registry drift.
 - Questions and ideas → [Discussions](https://github.com/kdr/overcast/discussions);
   bugs and features → [Issues](https://github.com/kdr/overcast/issues/new/choose).
 
-## Creator
+## Credits
 
-overcast is built by **[Kevin Dela Rosa](https://github.com/kdr/kdr)** (`@kdr`),
+Created by **[Kevin Dela Rosa](https://github.com/kdr/kdr)** (`@kdr`) —
 co-founder & CTO of [Cloudglue](https://cloudglue.dev/) and creator of
-[Tinycloud](https://www.tinycloud.sh/) — the default perception backend here. He
-presented *Autonomous Video Hunter*, on AI agents for real-time video OSINT, at
-**DEF CON 33**.
+[Tinycloud](https://www.tinycloud.sh/), the default perception backend here.
+*Autonomous Video Hunter*, on AI agents for real-time video OSINT, was presented
+at **DEF CON 33**.
 
-Find him at [kevindelarosa.com](https://kevindelarosa.com/) ·
-[GitHub](https://github.com/kdr/kdr) · [X](https://x.com/kdrwins) ·
-[LinkedIn](https://www.linkedin.com/in/kdrwins/) ·
-[Google Scholar](https://scholar.google.com/citations?user=8Pc5MiUAAAAJ&hl=en)
+<p align="center">
+  <a href="https://github.com/kdr/kdr"><img src="https://img.shields.io/badge/GitHub-kdr-181717?logo=github&logoColor=white" alt="GitHub @kdr" /></a>
+  <a href="https://kevindelarosa.com/"><img src="https://img.shields.io/badge/Portfolio-kevindelarosa.com-0A66C2?logo=googlechrome&logoColor=white" alt="Portfolio" /></a>
+  <a href="https://x.com/kdrwins"><img src="https://img.shields.io/badge/X-%40kdrwins-000000?logo=x&logoColor=white" alt="X @kdrwins" /></a>
+  <a href="https://www.linkedin.com/in/kdrwins/"><img src="https://img.shields.io/badge/LinkedIn-kdrwins-0A66C2?logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
+  <a href="https://scholar.google.com/citations?user=8Pc5MiUAAAAJ&hl=en"><img src="https://img.shields.io/badge/Google%20Scholar-publications-4285F4?logo=googlescholar&logoColor=white" alt="Google Scholar" /></a>
+</p>
+
+Built on top of [pi](https://github.com/earendil-works/pi) by
+[earendil-works](https://github.com/earendil-works).
 
 ## License
 
-Licensed under the [Apache License 2.0](LICENSE). Built on top of
-[pi](https://github.com/earendil-works/pi). You are responsible for how you use
+Licensed under the [Apache License 2.0](LICENSE). You are responsible for how you use
 this tool and for complying with all applicable laws and the terms of any
 third-party services you configure — see [RESPONSIBLE_USE.md](RESPONSIBLE_USE.md).

--- a/README.md
+++ b/README.md
@@ -4,17 +4,8 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@kdrrr/overcast"><img src="https://img.shields.io/npm/v/%40kdrrr%2Fovercast?logo=npm&color=cb3837" alt="npm version" /></a>
-  <a href="https://www.npmjs.com/package/@kdrrr/overcast"><img src="https://img.shields.io/npm/dm/%40kdrrr%2Fovercast?logo=npm&color=cb3837" alt="npm downloads" /></a>
   <a href="https://github.com/kdr/overcast/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/kdr/overcast/ci.yml?branch=main&logo=githubactions&logoColor=white&label=ci" alt="ci" /></a>
-  <a href="https://github.com/kdr/overcast/actions/workflows/codeql.yml"><img src="https://img.shields.io/github/actions/workflow/status/kdr/overcast/codeql.yml?branch=main&logo=github&label=codeql" alt="codeql" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="license: Apache-2.0" /></a>
-</p>
-
-<p align="center">
-  <a href="https://nodejs.org"><img src="https://img.shields.io/node/v/%40kdrrr%2Fovercast?logo=nodedotjs&logoColor=white&color=5FA04E" alt="node version" /></a>
-  <img src="https://img.shields.io/badge/TypeScript-ESM-3178C6?logo=typescript&logoColor=white" alt="TypeScript ESM" />
-  <a href="https://github.com/earendil-works/pi"><img src="https://img.shields.io/badge/built%20on-pi-8A2BE2" alt="built on pi" /></a>
-  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs welcome" /></a>
 </p>
 
 # overcast


### PR DESCRIPTION
README-only, purely additive: **36 insertions, 0 deletions.** No existing prose was changed or removed.

## What's added

**1. Badge row under the logo** — three badges:

| Badge | Renders as |
|---|---|
| npm version | `v0.0.11` |
| ci | `passing` |
| license | `Apache-2.0` |

**2. A `## News` section** near the top, plugging the DEF CON 34 Demo Labs sessions:

- *Overcast: Video OSINT Agent. Point It at 100 Videos, Ask Anything*
- LVCC L1, Exhibit Hall West 3 – 902 (Demo Labs Track 6)
- Fri, Aug 7, 2026 · 12:00–12:45 PDT
- Sat, Aug 8, 2026 · 16:00–16:45 PDT

**3. A `## Credits` section** below License — a one-line byline (Cloudglue / Tinycloud) plus five link badges: GitHub, portfolio, X, LinkedIn, Google Scholar.

## Sourcing

The `info.defcon.org` content page is a JS app that serves an empty HTML shell, so the talk details were not transcribed by hand. Its bundle was traced to the schedule data at `info.defcon.org/ht/defcon34/details/content.json`, and entry `66515` was read directly — title, room, and both session times come from that official record.

The npm and ci badge endpoints were each fetched live to confirm they resolve rather than render as `invalid`.

## Worth a look before merge

- **Two sessions are listed** for this talk in the DEF CON data. Standard for Demo Labs, but worth confirming both are yours.
- **npm badges need the URL-encoded scope** (`%40kdrrr%2Fovercast`); the unencoded form 404s. Relevant if these get edited later.
- **GitHub proxies shields through Camo** and caches aggressively, so the ci badge can look stale on first load.