### PR TITLE
docs: document deception/voice-stress as deliberately out of scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,16 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
   local-solar-time window(s) a shadow bearing implies on `--date`; location from
   `--lat`/`--lng` or a linked record's `payload.gps`; carries `payload.gps` (plots on
   `map`) + `payload.caveat` — a lead, not proof).
+- **Deliberately out of scope — no deception detection.** overcast does not and
+  will not ship deception detection, voice-stress analysis, or micro-expression
+  "lie detection". The underlying methods are not scientifically validated; a
+  verb emitting "72% likely lying" would be confident-sounding junk, the exact
+  opposite of the honesty bar the senses already hold (`voice` disclaims
+  liveness + carries `payload.caveat`; `reconstruct` is quarantined out of
+  evidence). This is a permanent, principled exclusion — not a roadmap gap, not
+  "coming soon". For DESCRIPTIVE acoustics (tone, ambience, the audio scene)
+  use `listen --describe`; for WHO is speaking (identity, never truthfulness)
+  use `voice`.
 - **Inspect** — `view` (self-contained HTML media player; `--at`, `--spectrogram`,
   `--no-open`; on an `enhance` split-op parent it renders a GALLERY of the fanned-out
   children — per-track audio + spectrograms for `separate`, cutouts for `segment`,

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -28,6 +28,17 @@ see [configuration.md](configuration.md).
 | `reconstruct` | **speculative** camera reposition from a still — `--rotate`/`--elevate`/`--zoom`, `--ops sweep` (360° turntable), `--ops model` (image→3D GLB), `--ops depth` — via a bound fal provider; a hypothesis renderer, never evidence (`payload.caveat`, quarantined from ask/brief) |
 | `chronolocate` | chronolocation from the sun/shadows — pure offline solar math, no key: verify a claimed capture time (`--at-time`) or solve the time window a shadow bearing implies (`--shadow-azimuth`) |
 
+**Deliberately out of scope — no deception detection.** overcast does not and
+will not ship deception detection, voice-stress analysis, or micro-expression
+"lie detection". This is a principled choice, not an oversight or a roadmap
+gap: the underlying methods have no validated scientific accuracy, and a verb
+that outputs "72% likely lying" would manufacture confident-sounding junk. The
+senses already hold the opposite bar — `voice` scores identity, explicitly NOT
+liveness or truthfulness (clones score high; every record carries
+`payload.caveat`), and `reconstruct`'s synthesized pixels are quarantined out
+of evidence. For **descriptive** acoustics — tone, ambience, what the audio
+scene contains — use `listen --describe`; for WHO is speaking, use `voice`.
+
 **Inspect** — look at the evidence
 | verb | does |
 |---|---|


### PR DESCRIPTION
**Plan 02 (affect-prosody), Option A — maintainer-confirmed.** Docs-only PR: no `listen --prosody` flag, no code, no new verb. The deliverable for this trope is a decision, documented — not a detector.

## Why

Voice-stress analysis and micro-expression "lie detection" have no validated scientific accuracy. A verb that outputs "72% likely lying" would manufacture confident-sounding junk and invite real harm — the opposite of the honesty bar the codebase already holds (`voice` disclaims liveness and carries `payload.caveat`; `reconstruct` quarantines synthesized output from evidence). This PR makes the exclusion explicit and impossible to read as "coming soon".

## The two additions

`CLAUDE.md` — new bullet in the verb-surface list, between Senses and Inspect:

> **Deliberately out of scope — no deception detection.** overcast does not and will not ship deception detection, voice-stress analysis, or micro-expression "lie detection". The underlying methods are not scientifically validated; a verb emitting "72% likely lying" would be confident-sounding junk, the exact opposite of the honesty bar the senses already hold (`voice` disclaims liveness + carries `payload.caveat`; `reconstruct` is quarantined out of evidence). This is a permanent, principled exclusion — not a roadmap gap, not "coming soon". For DESCRIPTIVE acoustics (tone, ambience, the audio scene) use `listen --describe`; for WHO is speaking (identity, never truthfulness) use `voice`.

`docs/verbs.md` — paragraph directly under the Senses table:

> **Deliberately out of scope — no deception detection.** overcast does not and will not ship deception detection, voice-stress analysis, or micro-expression "lie detection". This is a principled choice, not an oversight or a roadmap gap: the underlying methods have no validated scientific accuracy, and a verb that outputs "72% likely lying" would manufacture confident-sounding junk. The senses already hold the opposite bar — `voice` scores identity, explicitly NOT liveness or truthfulness (clones score high; every record carries `payload.caveat`), and `reconstruct`'s synthesized pixels are quarantined out of evidence. For **descriptive** acoustics — tone, ambience, what the audio scene contains — use `listen --describe`; for WHO is speaking, use `voice`.

(`AGENTS.md` is a symlink to `CLAUDE.md`, so it picks the note up automatically.)

## Verification

- `npm run build` + `npm run typecheck` green.
- `node scripts/sync-version.mjs --check` passes (version untouched).
- `node dist/bin/overcast.js skills generate` leaves `skills/` clean (no verb added, so no skills churn).
- Docs-only: no live/e2e legs apply.

Made with [Cursor](https://cursor.com)