### PR TITLE
chore(trope-cleanup): post-merge Bugbot fixes + docs/skills audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,13 @@ focused workflows:
 | `overcast-verify-media` | "is this real?" triage — C2PA + exif + ELA |
 | `overcast-skip-trace` | authorized identity dossier via username → person → phone → property |
 | `overcast-audio-match` | same-recording hunt via audio fingerprints |
+| `overcast-bolo` | standing face/image watchlist ("BOLO") — auto-flag matches into a triage queue |
+| `overcast-canvass` | canvass public cameras near a location (OSM `overpass` + `webcam` + forward geocode) |
+| `overcast-follow-the-money` | trace the public money trail — crypto tx history + SEC EDGAR filings |
 
-Each is generated from `src/skill-gen.ts` (one source of truth). The CSI/crime-trope
+Most are generated from `src/skill-gen.ts` (one source of truth); the three
+newest workflow skills (`overcast-bolo`, `overcast-canvass`,
+`overcast-follow-the-money`) are authored directly under `skills/`. The CSI/crime-trope
 skills (`lineup`…`crime-board`) are exercised end-to-end against real media in
 `test/e2e/live/cases/80`–`90`; the visual-CoT localization skills
 (`pinpoint`…`presence-window`) in `test/e2e/live/cases/18_grid`.
@@ -284,7 +289,7 @@ emits a portable JSON **record**:
   `voice` `cluster` `similar` `exif` `verify` `screenshot` `enhance`
   `reconstruct` `chronolocate`
 - **Inspect** (look at the evidence) — `view` `crop` `grid` `wall` `situation`
-  `map` `devices` `graph`
+  `map` `geofence` `devices` `graph`
 - **OSINT** (search / capture / monitor) — `scan` `capture` `monitor` `index`
   `archive` `target` `source` `note` `finding` `prebrief`
 - **Read** (synthesize the case) — `ask` `brief` `case`

--- a/providers/senses/geocode/geocode.sh
+++ b/providers/senses/geocode/geocode.sh
@@ -75,6 +75,17 @@ if [ "$forward" = 1 ]; then
     jq -nc --arg q "$q" '{verb:"geocode",format:"json",payload:{place:null,lat:null,lng:null,query:$q,mode:"forward",note:"no match (geocoder returned no usable result)"},state:"ready"}'
     exit 0
   fi
+  # A VALID search result is an ARRAY (empty [] = clean no-match) or a GeoJSON
+  # object with a `features` array (Photon). ANY OTHER JSON shape — an {error:…}
+  # / quota object, or a non-features object/scalar — is an API error, NOT
+  # "address not found": surface it as state:"error" so a misconfigured endpoint
+  # or a quota message can't masquerade as an empty result (and let the live case fail).
+  fshape="$(printf '%s' "$fresp" | jq -r 'if type=="array" then "ok" elif (type=="object" and (.features|type)=="array") then "ok" else "err" end')"
+  if [ "$fshape" = "err" ]; then
+    jq -nc --arg q "$q" --arg b "$(printf '%s' "$fresp" | head -c 200)" \
+      '{verb:"geocode",format:"json",payload:{query:$q,mode:"forward"},error:("forward geocode: unexpected/error response (not a search result): "+$b),state:"error"}'
+    exit 0
+  fi
   # Map both Nominatim (array of {lat,lon,display_name,address}) and GeoJSON
   # FeatureCollection shapes; validate WGS84 before emitting a point. Every field
   # access is null-safe and every `tonumber` is wrapped in try/catch, so a

--- a/providers/sources/chain/chain.sh
+++ b/providers/sources/chain/chain.sh
@@ -152,17 +152,18 @@ case "$op" in
             | ($amtSats / 100000000) as $amt
             | ([ $ins[]  | select((.scriptpubkey_address // "" | ascii_downcase) != $addr) | .scriptpubkey_address // empty ]) as $senders
             | ([ $outs[] | select((.scriptpubkey_address // "" | ascii_downcase) != $addr) | .scriptpubkey_address // empty ]) as $recipients
-            # transaction-order (deduped later) — the title uses the FIRST-seen
-            # counterparty, not the alphabetically-first one that `unique` returns,
-            # so it points at a meaningful lead; the counterparties SET stays unique.
+            # ORDER-PRESERVING dedup: the first-seen counterparty the title uses
+            # (cps[0]) must also lead the snippet, so a high-fanout tx never names a
+            # counterparty in the title that is missing from the snippet first 12
+            # (jq `unique` sorts alphabetically and could drop it).
             | (if $dir == "in" then $senders elif $dir == "out" then $recipients else ($senders + $recipients) end
                | map(select(. != null and . != ""))) as $cpsOrdered
-            | ($cpsOrdered | unique) as $cps
+            | ($cpsOrdered | reduce .[] as $x ([]; if any(.[]; . == $x) then . else . + [$x] end)) as $cps
             | ($ins  | length) as $nin
             | ($outs | length) as $nout
             | (.status.block_time // null) as $bt
             | (if $bt != null then ($bt | todate) else null end) as $iso
-            | (($cpsOrdered[0] // "?") | if length > 18 then .[0:18] + "…" else . end) as $cp0
+            | (($cps[0] // "?") | if length > 18 then .[0:18] + "…" else . end) as $cp0
             | ("https://mempool.space/tx/" + .txid) as $url
             | {
                 title: (($amt|tostring) + " BTC " + $dir
@@ -171,8 +172,12 @@ case "$op" in
                 url: $url,
                 source: "chain",
                 # graph/brief rank + --since-filter by payload.created = the BLOCK
-                # time (when the money moved), not scan ingest; unconfirmed txs
-                # (no block_time) carry null and sort last under a --since window.
+                # time (when the money moved) for CONFIRMED txs. Unconfirmed
+                # (mempool) txs have no block time → created:null: they sort NEWEST
+                # (most recent activity) and their recency falls back to ingest ≈
+                # broadcast time. On the `monitor` path the per-tx URL dedup means
+                # block time is NOT backfilled after confirmation — re-scan a fresh
+                # case for exact block times (broadcast ≈ block time for ranking).
                 created: $iso,
                 published: $iso,
                 snippet: ("value " + ($amt|tostring) + " BTC · " + ($nin|tostring) + " inputs · " + ($nout|tostring) + " outputs"
@@ -234,10 +239,10 @@ case "$op" in
             | ((.value // "0" | tonumber) / 1e18) as $amt
             | (if $dir == "out" then [ .to ] elif $dir == "in" then [ .from ] else [ .from, .to ] end
                | map(select(. != null and . != "")) | map(ascii_downcase) | map(select(. != $addr))) as $cpsOrdered
-            | ($cpsOrdered | unique) as $cps
+            | ($cpsOrdered | reduce .[] as $x ([]; if any(.[]; . == $x) then . else . + [$x] end)) as $cps
             | ((.timeStamp // "0" | tonumber)) as $ts
             | (if $ts > 0 then ($ts | todate) else null end) as $iso
-            | (($cpsOrdered[0] // "?") | if length > 18 then .[0:18] + "…" else . end) as $cp0
+            | (($cps[0] // "?") | if length > 18 then .[0:18] + "…" else . end) as $cp0
             | ("https://etherscan.io/tx/" + .hash) as $url
             | {
                 title: (($amt|tostring) + " ETH " + $dir

--- a/skills/overcast-follow-the-money/SKILL.md
+++ b/skills/overcast-follow-the-money/SKILL.md
@@ -95,6 +95,9 @@ counterparty; `amount` for an outflow is the gross input (fee + change included)
 not the net to the recipient — treat a single tx as a lead and corroborate the
 flow before naming anyone. EDGAR full-text search covers filings since 2001; a bare
 numeric query is read as a CIK, so quote a company name that is all digits. The
-`chain:btc:`/`chain:eth:` prefix is required (v1). SEC rate-limits heavy polling and
+`chain:btc:`/`chain:eth:` prefix is required (v1). Unconfirmed (mempool) BTC txs
+have no block time — they sort newest and rank by ingest ≈ broadcast time; on a
+`monitor` loop the per-tx URL dedup means block time is not backfilled once they
+confirm (re-scan a fresh case for exact block times). SEC rate-limits heavy polling and
 requires a descriptive contact-email User-Agent (the default is compliant;
 `OVERCAST_HTTP_UA` overrides it). Scraped tx/filing text is untrusted (invariant #10).

--- a/src/verbs/skills.ts
+++ b/src/verbs/skills.ts
@@ -126,6 +126,9 @@ const SHIPPED_SKILLS = [
   "overcast-verify-media",
   "overcast-skip-trace",
   "overcast-audio-match",
+  "overcast-bolo",
+  "overcast-canvass",
+  "overcast-follow-the-money",
 ] as const;
 
 /** Harnesses `skills install` knows how to target. */


### PR DESCRIPTION
Follow-up cleanup after merging the six trope-expansion PRs (#130–#135). Combines the Bugbot findings that fired **after** the branches were last reviewed (so they landed un-answered on merge) with a docs/skills audit.

## Un-answered Bugbot findings (from the merged PRs)
- **#132 — "Forward geocode hides JSON errors"** (Medium): `geocode.sh` forward mode now treats an HTTP-200 body that isn't a search result — an `{error:…}`/quota object or any non-array/non-`features` shape — as `state:"error"`, not a `ready` "no match". A valid empty result (`[]` or an empty GeoJSON `features`) stays a clean no-match. Prevents a misconfigured endpoint/quota message masquerading as "address not found" (and lets the live case fail instead of skip).
- **#135 — "Snippet drops title counterparty"** (Medium): BTC/ETH counterparties now use an **order-preserving dedup** (instead of jq `unique`, which sorts alphabetically), so the first-seen counterparty named in the `title` always leads the `snippet` and is never dropped past the first 12 on a high-fanout tx. Verified live: title `bc1phhz…` now leads the snippet.
- **#135 — "Unconfirmed txs freeze null created"** (Medium): documented the honest limitation — unconfirmed (mempool) BTC txs have no block time, so they sort newest and rank by ingest ≈ broadcast, and on the `monitor` URL-dedup path block time isn't backfilled after confirmation (re-scan a fresh case for exact times; broadcast ≈ block time for ranking). Noted in the script comment + the follow-the-money skill caveats.

(#131 / #133 / #134 had no un-answered threads.)

## Docs / skills audit
- **`SHIPPED_SKILLS`**: added `overcast-bolo`, `overcast-canvass`, `overcast-follow-the-money` so `overcast skills install` actually vends them (offline e2e now derives **35** shipped skills and installs all).
- **README**: added the `geofence` verb to the Inspect group; added the three new skills to the skills table; corrected the "all generated from `src/skill-gen.ts`" note (those three are authored directly under `skills/`).
- Confirmed `docs/verbs.md` + `CLAUDE.md` already cover the full new surface (geofence, `map --near/--bbox`, `reconstruct --ops age`, `chain`/`edgar` refs, geocode forward, the deception out-of-scope note), and the generated `skills/overcast` flagship + reference are in sync with the combined registry.

## Tests
- `npm run typecheck`, `npm run build` green; `npm test` full unit suite pass; `chain`/`edgar` unit 15/15.
- `shellcheck -S warning` clean on both scripts; geocode error-shape verified (`{error}`→error, `[]`→no-match, valid→point).
- Offline e2e: `skills.shipped_list`/`skills.install` pass with the 3 new skills; the only 3 failures are the pre-existing `crop.*` macOS-ffmpeg fixture quirk (reproduces on clean `main`, green on Linux CI).

Made with [Cursor](https://cursor.com)