### PR TITLE
fix(watch): --segment shots pass-through + tinycloud 64 KiB stdout truncation workaround (v0.0.14)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.13"
+    "version": "0.0.14"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "author": {
     "name": "kdr"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,9 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
 [`docs/providers.md`](docs/providers.md).
 
 - **Senses** — `watch` (shot-detect + all-modality describe → `content` /
-  `transcript` / `detailed`), `listen` (speech transcript; `--describe` for the
+  `transcript` / `detailed`; `--segment shots|chapters|segments|uniform:<s>`
+  picks the provider's segmentation, `--shot-min-seconds`/`--shot-max-seconds`
+  tune shot detection), `listen` (speech transcript; `--describe` for the
   full audio-scene, `--diarize`, `--lang`), `see` (caption / OCR / open-vocab
   `--detect` — **default: the brain LLM** when image-capable, i.e. a direct
   "describe this image" call; falls back to the Hugging Face captioner,

--- a/docs/field-manual.md
+++ b/docs/field-manual.md
@@ -431,6 +431,7 @@ When you already have a file.
 ```bash
 overcast case init --name "demo"
 overcast watch ./clip.mp4
+overcast watch ./clip.mp4 --segment shots --shot-min-seconds 0.6   # shot-detected segments instead of uniform:20
 overcast note "rear plate is missing" --ref <watch-record-id> --at 12-18 --tag vehicle
 overcast ask "What happened in the clip?"
 overcast view <watch-record-id>

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -12,7 +12,7 @@ see [configuration.md](configuration.md).
 **Senses** — turn media into records
 | verb | does |
 |---|---|
-| `watch` | analyze a video → `content` / `transcript` / `detailed` (default: Cloudglue) |
+| `watch` | analyze a video → `content` / `transcript` / `detailed` (default: Cloudglue); `--segment shots\|chapters\|segments\|uniform:<s>` picks the provider's segmentation (`--shot-min-seconds`/`--shot-max-seconds` tune shot detection) |
 | `listen` | transcribe audio / a video's audio; `--describe` for the full audio-scene |
 | `see` | caption / OCR / detect on an image, image URL, or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM / the opt-in tinycloud `see`+`extract` provider, ≥ 0.3.7) |
 | `face` | detect faces in a video, `--match <img>` to find a person, or search a face-analysis index |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "Apache-2.0",
   "author": "kdr",

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -22,6 +22,9 @@ Arguments:
 Options:
   --format <string>      Output surface: json | md | txt
   --json                 Shorthand for --format json
+  --segment <string>     Segmentation kind passed to the provider: shots | chapters | segments | uniform:<seconds> (default: the provider's own, uniform:20)
+  --shot-min-seconds <number> Min shot duration in seconds with --segment shots (e.g. 0.6 catches flash frames)
+  --shot-max-seconds <number> Max shot duration in seconds with --segment shots
 ```
 
 Emits `video.analysis` records.

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -9,7 +9,7 @@ store; cite findings by `record.id` + `media.at`.
 
 ### `overcast watch`
 
-Runs the bound sense provider (default: tinycloud, exec) over a video file or URL and emits a video.analysis record with markdown content, a transcript (when speech is present), and the full structured describe in `detailed`.
+Runs the bound sense provider (default: tinycloud, exec) over a video file or URL and emits a video.analysis record with markdown content, a transcript (when speech is present), and the full structured describe in `detailed`. `--segment` picks the provider's segmentation — shots (shot-detected boundaries; tune with --shot-min-seconds/--shot-max-seconds) | chapters | segments | uniform:<seconds> — instead of the provider default (uniform:20).
 
 ```
 overcast watch <input> [options]

--- a/src/providers/exec.ts
+++ b/src/providers/exec.ts
@@ -3,7 +3,7 @@
 // to the loose record at THIS boundary — provider envelopes never leak inward.
 
 import { spawn } from "node:child_process";
-import { closeSync, mkdtempSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
+import { closeSync, fstatSync, mkdtempSync, openSync, readSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
@@ -55,16 +55,14 @@ export function execCapture(
     }
 
     // stdoutToFile: hand the child a real file for stdout. The fd is dup'd into
-    // the child at spawn, so the parent copy closes right after; the file is
-    // read back (size-capped) once the child exits, and the temp dir is removed
-    // on EVERY settle path (done() below).
+    // the child at spawn; the PARENT keeps its copy open for the whole run —
+    // every later size check and the final read go through this ONE descriptor
+    // (fstat/read on the fd, never a path re-resolve — the same TOCTOU
+    // discipline as watch.ts's readCappedUtf8; CodeQL js/file-system-race).
     let outDir: string | undefined;
-    let outPath: string | undefined;
-    if (opts.stdoutToFile) {
-      outDir = mkdtempSync(join(tmpdir(), "oc-exec-"));
-      outPath = join(outDir, "stdout");
-    }
-    const outFd = outPath !== undefined ? openSync(outPath, "w") : undefined;
+    if (opts.stdoutToFile) outDir = mkdtempSync(join(tmpdir(), "oc-exec-"));
+    // w+ so the same descriptor the child writes is readable back
+    const outFd = outDir !== undefined ? openSync(join(outDir, "stdout"), "w+") : undefined;
 
     const child = spawn(command, args, {
       cwd: opts.cwd,
@@ -75,7 +73,6 @@ export function execCapture(
       // overcast providers receive input via argv ({{input}}), not stdin.
       stdio: ["ignore", outFd ?? "pipe", "pipe"],
     });
-    if (outFd !== undefined) closeSync(outFd); // child holds its own dup
 
     // Decode through StringDecoder so a multi-byte UTF-8 sequence split across a
     // chunk boundary isn't mangled into U+FFFD — chunk-independent `d.toString()`
@@ -89,13 +86,22 @@ export function execCapture(
     const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
     let settled = false;
     let timer: NodeJS.Timeout | undefined;
+    let sizeTimer: NodeJS.Timeout | undefined;
     const done = (fn: () => void) => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
-      // unlinking while a killed child still holds the fd is fine on unix — the
-      // file goes away when the last descriptor closes
-      if (outDir) rmSync(outDir, { recursive: true, force: true });
+      if (sizeTimer) clearInterval(sizeTimer);
+      // Cleanup must never block the settle — a throwing rm here would leave the
+      // promise hanging forever (Bugbot). fd first, then the dir (Windows can't
+      // unlink an open file; on unix a killed child's dup keeps the data alive
+      // until its descriptor closes and the unlink is still fine).
+      if (outFd !== undefined) {
+        try { closeSync(outFd); } catch { /* already closed */ }
+      }
+      if (outDir) {
+        try { rmSync(outDir, { recursive: true, force: true }); } catch { /* best-effort temp cleanup */ }
+      }
       fn();
     };
     if (opts.timeoutMs) {
@@ -105,31 +111,55 @@ export function execCapture(
       }, opts.timeoutMs);
     }
 
+    const overflow = () => {
+      child.kill("SIGKILL");
+      done(() => rejectP(new Error(`command output exceeded ${maxBuffer} bytes: ${command}`)));
+    };
     const guard = (chunk: Buffer): boolean => {
       bytes += chunk.length;
       if (bytes > maxBuffer) {
-        child.kill("SIGKILL");
-        done(() => rejectP(new Error(`command output exceeded ${maxBuffer} bytes: ${command}`)));
+        overflow();
         return false;
       }
       return true;
     };
+    // file-mode stdout grows on DISK, not in parent memory, so the data-event
+    // guard never sees it — poll the descriptor and kill an over-cap child
+    // MID-RUN, like pipe mode does (Bugbot: deferred maxBuffer). 500ms bounds
+    // the excursion; disk (unlike memory) survives half a second of overshoot.
+    if (outFd !== undefined) {
+      sizeTimer = setInterval(() => {
+        try {
+          if (bytes + fstatSync(outFd).size > maxBuffer) overflow();
+        } catch { /* fd closed by a concurrent settle */ }
+      }, 500);
+      sizeTimer.unref?.();
+    }
     child.stdout?.on("data", (d) => guard(d) && (stdout += outDec.write(d)));
     child.stderr?.on("data", (d) => guard(d) && (stderr += errDec.write(d)));
     child.on("error", (err) => done(() => rejectP(err)));
     child.on("close", (code) => {
-      if (outPath !== undefined) {
-        // file-mode stdout: the maxBuffer guard above only saw stderr, so apply
-        // the same ceiling to the file BEFORE reading it into memory.
+      if (outFd !== undefined) {
+        // file-mode stdout: enforce the ceiling, then read back — both through
+        // the SAME descriptor the child wrote (no path re-resolution, no
+        // check-then-use window). Whole-file decode, so no chunk-boundary
+        // multi-byte concerns.
         try {
-          const size = statSync(outPath).size;
+          const size = fstatSync(outFd).size;
           if (bytes + size > maxBuffer) {
             done(() => rejectP(new Error(`command output exceeded ${maxBuffer} bytes: ${command}`)));
             return;
           }
-          stdout = readFileSync(outPath, "utf8");
+          const buf = Buffer.alloc(size);
+          let read = 0;
+          while (read < size) {
+            const n = readSync(outFd, buf, read, size - read, read);
+            if (n <= 0) break;
+            read += n;
+          }
+          stdout = buf.subarray(0, read).toString("utf8");
         } catch {
-          stdout = ""; // already-settled paths (timeout/abort) may have removed it
+          stdout = ""; // an already-settled path (timeout/abort) closed the fd
         }
       } else {
         stdout += outDec.end();

--- a/src/providers/exec.ts
+++ b/src/providers/exec.ts
@@ -3,6 +3,9 @@
 // to the loose record at THIS boundary — provider envelopes never leak inward.
 
 import { spawn } from "node:child_process";
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 export interface ExecResult {
@@ -26,6 +29,11 @@ export interface ExecOptions {
   extraPath?: string[];
   /** cap on captured stdout+stderr bytes (default 64 MB); over → kill + reject */
   maxBuffer?: number;
+  /** capture stdout via a temp FILE instead of a pipe. Some child runtimes
+   *  (tinycloud's embedded bun) issue a final non-blocking stdout write and
+   *  exit without draining it — a pipe then cuts the output at the 64 KiB pipe
+   *  buffer (invalid JSON); a regular file always takes the whole write. */
+  stdoutToFile?: boolean;
 }
 
 /**
@@ -46,6 +54,18 @@ export function execCapture(
       env[key] = opts.extraPath.join(sep) + sep + (env[key] ?? "");
     }
 
+    // stdoutToFile: hand the child a real file for stdout. The fd is dup'd into
+    // the child at spawn, so the parent copy closes right after; the file is
+    // read back (size-capped) once the child exits, and the temp dir is removed
+    // on EVERY settle path (done() below).
+    let outDir: string | undefined;
+    let outPath: string | undefined;
+    if (opts.stdoutToFile) {
+      outDir = mkdtempSync(join(tmpdir(), "oc-exec-"));
+      outPath = join(outDir, "stdout");
+    }
+    const outFd = outPath !== undefined ? openSync(outPath, "w") : undefined;
+
     const child = spawn(command, args, {
       cwd: opts.cwd,
       env,
@@ -53,8 +73,9 @@ export function execCapture(
       // ignore stdin so a child that reads stdin (e.g. some CLIs probing for
       // piped input) gets EOF immediately instead of blocking until timeout.
       // overcast providers receive input via argv ({{input}}), not stdin.
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", outFd ?? "pipe", "pipe"],
     });
+    if (outFd !== undefined) closeSync(outFd); // child holds its own dup
 
     // Decode through StringDecoder so a multi-byte UTF-8 sequence split across a
     // chunk boundary isn't mangled into U+FFFD — chunk-independent `d.toString()`
@@ -72,6 +93,9 @@ export function execCapture(
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
+      // unlinking while a killed child still holds the fd is fine on unix — the
+      // file goes away when the last descriptor closes
+      if (outDir) rmSync(outDir, { recursive: true, force: true });
       fn();
     };
     if (opts.timeoutMs) {
@@ -90,11 +114,26 @@ export function execCapture(
       }
       return true;
     };
-    child.stdout.on("data", (d) => guard(d) && (stdout += outDec.write(d)));
-    child.stderr.on("data", (d) => guard(d) && (stderr += errDec.write(d)));
+    child.stdout?.on("data", (d) => guard(d) && (stdout += outDec.write(d)));
+    child.stderr?.on("data", (d) => guard(d) && (stderr += errDec.write(d)));
     child.on("error", (err) => done(() => rejectP(err)));
     child.on("close", (code) => {
-      stdout += outDec.end();
+      if (outPath !== undefined) {
+        // file-mode stdout: the maxBuffer guard above only saw stderr, so apply
+        // the same ceiling to the file BEFORE reading it into memory.
+        try {
+          const size = statSync(outPath).size;
+          if (bytes + size > maxBuffer) {
+            done(() => rejectP(new Error(`command output exceeded ${maxBuffer} bytes: ${command}`)));
+            return;
+          }
+          stdout = readFileSync(outPath, "utf8");
+        } catch {
+          stdout = ""; // already-settled paths (timeout/abort) may have removed it
+        }
+      } else {
+        stdout += outDec.end();
+      }
       stderr += errDec.end();
       done(() => resolveP({ code, stdout, stderr }));
     });

--- a/src/providers/tinycloud/envelope.ts
+++ b/src/providers/tinycloud/envelope.ts
@@ -287,6 +287,9 @@ export async function runTinycloud(
     timeoutMs: opts.timeoutMs ?? TINYCLOUD_TIMEOUT_MS,
     env: tinycloudChildEnv(opts.env),
     signal: opts.signal,
+    // tinycloud's embedded bun can exit without draining a >64 KiB pipe write,
+    // severing the JSON mid-envelope — a file stdout takes the whole write.
+    stdoutToFile: true,
   });
 
   const parsed = parseFirstJson(res.stdout);

--- a/src/providers/tinycloud/listen.ts
+++ b/src/providers/tinycloud/listen.ts
@@ -234,6 +234,9 @@ export async function runListen(
     timeoutMs: opts.timeoutMs ?? 15 * 60_000,
     env: tinycloudChildEnv(opts.env),
     signal: opts.signal,
+    // tinycloud's embedded bun can exit without draining a >64 KiB pipe write,
+    // severing the JSON mid-envelope — a file stdout takes the whole write.
+    stdoutToFile: true,
   });
 
   // No parseable JSON at all → surface the exit code (parse JSON first, like
@@ -249,7 +252,9 @@ export async function runListen(
       meta: { provider: "tinycloud", model: "cloudglue" },
       error:
         res.code === 0
-          ? "tinycloud listen produced no JSON output"
+          ? res.stdout.trim()
+            ? `tinycloud listen printed ${res.stdout.length} chars but no parseable JSON (output may be malformed or truncated)`
+            : "tinycloud listen produced no JSON output"
           : res.code === 13
             ? "tinycloud listen needs credentials (exit 13 — set CLOUDGLUE_API_KEY)"
             : withProxyEgressHint(`tinycloud listen exited ${res.code}: ${redactSecrets(res.stderr.trim().slice(0, 500))}`),

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -11,7 +11,7 @@ import {
   renderCommand,
   parseFirstJson,
 } from "../exec.js";
-import { segmentSpeechCues, tinycloudBase, tinycloudChildEnv, withProxyEgressHint } from "./envelope.js";
+import { segmentSpeechCues, tinycloudBase, tinycloudChildEnv, tinycloudError, withProxyEgressHint } from "./envelope.js";
 import type { ProviderDescriptor } from "../../profile.js";
 
 const DEFAULT_RUN = "tinycloud watch {{input}} --json";
@@ -215,7 +215,13 @@ function contentMarkdown(data: Record<string, unknown>): string {
 export interface WatchOptions {
   /** override the run template (from the profile binding) */
   run?: string;
-  /** pass-through CLI opts (e.g. speechOnly) reserved for later phases */
+  /** segmentation kind forwarded to the provider (`--segment`):
+   *  shots | chapters | segments | uniform:<seconds> */
+  segment?: string;
+  /** min shot duration in seconds with segment=shots (`--shot-min-seconds`) */
+  shotMinSeconds?: number;
+  /** max shot duration in seconds with segment=shots (`--shot-max-seconds`) */
+  shotMaxSeconds?: number;
   timeoutMs?: number;
   env?: NodeJS.ProcessEnv;
   signal?: AbortSignal;
@@ -234,9 +240,19 @@ export async function runWatch(
   const configured = opts.run?.trim();
   const defaultPath = !configured || configured === DEFAULT_RUN;
   const template = defaultPath ? DEFAULT_RUN : configured;
+  // Segmentation pass-through (`watch --segment shots`): the default path used
+  // to hardcode ["watch", input, "--json"], silently dropping the flags — every
+  // watch got tinycloud's uniform:20. Append them when set, on BOTH paths: the
+  // default speaks to tinycloud (which owns these flags), and a custom template
+  // receives them as its wrapper contract (like listen's --diarize/--lang) —
+  // unset flags append nothing, so existing bindings see an unchanged argv.
+  const segArgs: string[] = [];
+  if (opts.segment) segArgs.push("--segment", opts.segment);
+  if (opts.shotMinSeconds !== undefined) segArgs.push("--shot-min-seconds", String(opts.shotMinSeconds));
+  if (opts.shotMaxSeconds !== undefined) segArgs.push("--shot-max-seconds", String(opts.shotMaxSeconds));
   const argv = defaultPath
-    ? [...tinycloudBase(), "watch", input, "--json"]
-    : renderCommand(template, { input });
+    ? [...tinycloudBase(), "watch", input, ...segArgs, "--json"]
+    : [...renderCommand(template, { input }), ...segArgs];
   const [cmd, ...args] = argv;
 
   // A template that renders to no command (all tokens dropped) would reject at
@@ -258,6 +274,9 @@ export async function runWatch(
     timeoutMs: opts.timeoutMs ?? 15 * 60_000,
     env: tinycloudChildEnv(opts.env),
     signal: opts.signal,
+    // tinycloud's embedded bun can exit without draining a >64 KiB pipe write,
+    // severing the JSON mid-envelope — a file stdout takes the whole write.
+    stdoutToFile: true,
   });
 
   const parsed = parseFirstJson(res.stdout);
@@ -270,7 +289,9 @@ export async function runWatch(
       meta: { provider: "tinycloud", model: "cloudglue" },
       error:
         res.code === 0
-          ? "tinycloud watch produced no JSON output"
+          ? res.stdout.trim()
+            ? `tinycloud watch printed ${res.stdout.length} chars but no parseable JSON (output may be malformed or truncated)`
+            : "tinycloud watch produced no JSON output"
           : res.code === 13
             ? "tinycloud watch needs credentials (exit 13 — set CLOUDGLUE_API_KEY)"
             : // a MITM-proxied bun fetch dies before any JSON is printed, so the
@@ -288,10 +309,11 @@ export async function runWatch(
   // A non-zero exit OR an error envelope is a failure even if JSON parsed — the
   // record's state/error is authoritative, so surface it instead of a silent
   // empty "ready" record (would otherwise mark the video as successfully watched).
-  const envError =
-    (typeof envObj.error === "string" && envObj.error) ||
-    (typeof (data.error as string) === "string" && (data.error as string)) ||
-    "";
+  // string OR {code,message} object — a real Cloudglue job-timeout ships
+  // `error: {code:"upstream", message:"Describe job did not finish…"}`, which a
+  // string-only check silently dropped (the record then read `exit 1:` with an
+  // empty stderr excerpt). The shared extractor handles both shapes.
+  const envError = tinycloudError(envObj, data) ?? "";
   const errored =
     res.code !== 0 ||
     envObj.status === "error" ||

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -54,7 +54,10 @@ export const watchVerb: VerbSpec = {
   description:
     "Runs the bound sense provider (default: tinycloud, exec) over a video file or URL " +
     "and emits a video.analysis record with markdown content, a transcript (when speech " +
-    "is present), and the full structured describe in `detailed`.",
+    "is present), and the full structured describe in `detailed`. `--segment` picks the " +
+    "provider's segmentation — shots (shot-detected boundaries; tune with " +
+    "--shot-min-seconds/--shot-max-seconds) | chapters | segments | uniform:<seconds> — " +
+    "instead of the provider default (uniform:20).",
   args: [{ name: "input", summary: "Video file path or URL", required: true }],
   flags: [
     { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -59,6 +59,11 @@ export const watchVerb: VerbSpec = {
   flags: [
     { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },
     { name: "json", summary: "Shorthand for --format json", type: "boolean" },
+    // free string (not choices): tinycloud's kinds include parameterized forms
+    // like uniform:<seconds>; the provider validates and errors loudly.
+    { name: "segment", summary: "Segmentation kind passed to the provider: shots | chapters | segments | uniform:<seconds> (default: the provider's own, uniform:20)", type: "string" },
+    { name: "shot-min-seconds", summary: "Min shot duration in seconds with --segment shots (e.g. 0.6 catches flash frames)", type: "number" },
+    { name: "shot-max-seconds", summary: "Max shot duration in seconds with --segment shots", type: "number" },
   ],
   outputKind: "video.analysis",
   providerKey: "watch",
@@ -90,11 +95,21 @@ export const watchVerb: VerbSpec = {
     const input = resolved.ref ?? ctx.input;
     // resolve the run template from the active profile binding (else default).
     const binding = providerBinding(ctx, "watch");
+    // segmentation flags thread through to the provider argv (tinycloud owns
+    // them; a custom provider receives them as extraArgs, the wrapper contract
+    // like listen's --diarize/--lang). Unset flags add nothing.
+    const segment = ctx.opts.segment ? String(ctx.opts.segment) : undefined;
+    const shotMin = ctx.opts["shot-min-seconds"] !== undefined ? Number(ctx.opts["shot-min-seconds"]) : undefined;
+    const shotMax = ctx.opts["shot-max-seconds"] !== undefined ? Number(ctx.opts["shot-max-seconds"]) : undefined;
+    const extraArgs: string[] = [];
+    if (segment) extraArgs.push("--segment", segment);
+    if (shotMin !== undefined) extraArgs.push("--shot-min-seconds", String(shotMin));
+    if (shotMax !== undefined) extraArgs.push("--shot-max-seconds", String(shotMax));
     // A custom provider already emits a record → dispatch by transport. Only the
     // tinycloud default needs envelope→record mapping.
     const rec = isCustomBinding(binding)
-      ? await runBoundProvider("watch", binding!, input, { env: providerEnv(ctx.case.mediaDir), timeoutMs: 15 * 60_000, signal: ctx.signal, home: ctx.home })
-      : await runWatch(input, { run: binding?.run, signal: ctx.signal });
+      ? await runBoundProvider("watch", binding!, input, { env: providerEnv(ctx.case.mediaDir), extraArgs, timeoutMs: 15 * 60_000, signal: ctx.signal, home: ctx.home })
+      : await runWatch(input, { run: binding?.run, segment, shotMinSeconds: shotMin, shotMaxSeconds: shotMax, signal: ctx.signal });
     rec.meta = { ...rec.meta, case: ctx.case.dir };
     // trace back to the originating post (like listen) — for archived media the
     // capture that materialized it lives in the BUCKET, so look there

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.82.1.
 
-export const OVERCAST_VERSION = "0.0.13";
+export const OVERCAST_VERSION = "0.0.14";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.82.1";

--- a/test/unit/audit-hardening.test.ts
+++ b/test/unit/audit-hardening.test.ts
@@ -88,6 +88,21 @@ test("execCapture stdoutToFile still enforces maxBuffer", async () => {
   );
 });
 
+test("execCapture stdoutToFile kills an over-cap child MID-RUN (not at exit)", async () => {
+  // pipe mode SIGKILLs on the data event; file mode must not let a child that
+  // blew the cap keep running (and growing the file) until it exits on its own.
+  const started = Date.now();
+  await assert.rejects(
+    execCapture(
+      process.execPath,
+      ["-e", "process.stdout.write('x'.repeat(64*1024)); setTimeout(() => {}, 30_000)"],
+      { maxBuffer: 1000, stdoutToFile: true },
+    ),
+    /output exceeded 1000 bytes/,
+  );
+  assert.ok(Date.now() - started < 10_000, "killed by the size poll, not the child's own 30s exit");
+});
+
 test("execCapture stdoutToFile keeps stderr on the pipe and utf-8 intact", async () => {
   const s = "café — 日本語 — 🎥";
   const r = await execCapture(

--- a/test/unit/audit-hardening.test.ts
+++ b/test/unit/audit-hardening.test.ts
@@ -62,6 +62,43 @@ test("execCapture decodes multibyte utf-8 without mangling (C7)", async () => {
   assert.equal(r.stdout, s);
 });
 
+// --- stdoutToFile: the tinycloud bun-flush workaround -------------------------
+
+test("execCapture stdoutToFile captures output past the 64 KiB pipe buffer", async () => {
+  // tinycloud's embedded bun exits without draining a >64 KiB pipe write, so
+  // tinycloud call sites capture stdout via a temp FILE instead of a pipe.
+  const n = 200 * 1024;
+  const r = await execCapture(
+    process.execPath,
+    ["-e", `process.stdout.write('y'.repeat(${n}))`],
+    { stdoutToFile: true },
+  );
+  assert.equal(r.code, 0);
+  assert.equal(r.stdout.length, n, "whole write captured, nothing severed at 65536");
+});
+
+test("execCapture stdoutToFile still enforces maxBuffer", async () => {
+  await assert.rejects(
+    execCapture(
+      process.execPath,
+      ["-e", "process.stdout.write('x'.repeat(1024*1024))"],
+      { maxBuffer: 1000, stdoutToFile: true },
+    ),
+    /output exceeded 1000 bytes/,
+  );
+});
+
+test("execCapture stdoutToFile keeps stderr on the pipe and utf-8 intact", async () => {
+  const s = "café — 日本語 — 🎥";
+  const r = await execCapture(
+    process.execPath,
+    ["-e", `process.stderr.write('warn'); process.stdout.write(${JSON.stringify(s)})`],
+    { stdoutToFile: true },
+  );
+  assert.equal(r.stdout, s);
+  assert.equal(r.stderr, "warn");
+});
+
 // --- C5: media-fetch SSRF guard ---------------------------------------------
 
 // a resolver that must never be consulted (literals skip DNS)

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -239,6 +239,66 @@ test("watch resolves capture_id handles before dispatching to a provider", async
   }
 });
 
+test("runWatch passes --segment/--shot-*-seconds through to the default tinycloud argv", async () => {
+  // `watch --segment shots` used to be silently dropped: the default path
+  // hardcoded ["watch", input, "--json"], so every watch got uniform:20.
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchseg-"));
+  const prior = process.env.OVERCAST_TINYCLOUD_CMD;
+  try {
+    // a fake tinycloud that echoes the argv it received back inside the envelope
+    const script = join(dir, "tc.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '{"status":"ready","data":{"title":"argv","summary":"%s"}}\\n' "$*"\n`);
+    chmodSync(script, 0o755);
+    process.env.OVERCAST_TINYCLOUD_CMD = `bash ${script}`;
+
+    const rec = await runWatch("clip.mp4", { segment: "shots", shotMinSeconds: 0.6, shotMaxSeconds: 30 });
+    assert.equal(rec.state, "ready");
+    const argv = String(((rec.payload as Record<string, unknown>).detailed as Record<string, unknown>).summary);
+    assert.equal(argv, "watch clip.mp4 --segment shots --shot-min-seconds 0.6 --shot-max-seconds 30 --json");
+
+    // unset flags leave the default argv untouched
+    const plain = await runWatch("clip.mp4", {});
+    const plainArgv = String(((plain.payload as Record<string, unknown>).detailed as Record<string, unknown>).summary);
+    assert.equal(plainArgv, "watch clip.mp4 --json");
+  } finally {
+    if (prior === undefined) delete process.env.OVERCAST_TINYCLOUD_CMD;
+    else process.env.OVERCAST_TINYCLOUD_CMD = prior;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runWatch appends segmentation flags to a custom run template (wrapper contract)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchsegc-"));
+  try {
+    const script = join(dir, "tc.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '{"status":"ready","data":{"title":"argv","summary":"%s"}}\\n' "$*"\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("clip.mp4", { run: `bash ${script} {{input}}`, segment: "shots" });
+    const argv = String(((rec.payload as Record<string, unknown>).detailed as Record<string, unknown>).summary);
+    assert.equal(argv, "clip.mp4 --segment shots");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runWatch survives an envelope past the 64 KiB pipe buffer (stdoutToFile)", async () => {
+  // shot segmentation on long-form video pushes the envelope well past 64 KiB —
+  // exactly where the tinycloud bun-flush truncation used to sever the JSON.
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchbig-"));
+  try {
+    const summary = "s".repeat(128 * 1024);
+    writeFileSync(join(dir, "big.json"), JSON.stringify({ status: "ready", data: { title: "big", summary, segments: [] } }));
+    const script = join(dir, "tc.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\ncat "${join(dir, "big.json")}"\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    assert.equal(rec.state, "ready");
+    assert.ok(String((rec.payload as Record<string, unknown>).content).includes(summary), "full envelope parsed, not truncated at 65536");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("runWatch returns an error record when the provider emits no JSON", async () => {
   const rec = await runWatch("x.mp4", { run: `bash -c 'echo not-json' {{input}}` });
   assert.equal(rec.state, "error");
@@ -257,6 +317,29 @@ test("runWatch maps an error envelope (status:error) to an error record", async 
   const rec = await runWatch("x.mp4", { run: `bash ${CASES} error {{input}}` });
   assert.equal(rec.state, "error");
   assert.match(rec.error ?? "", /quota exceeded/);
+});
+
+test("runWatch surfaces an OBJECT error envelope ({code,message}), not an empty exit message", async () => {
+  // a real Cloudglue job-timeout envelope: status error, data null, and the
+  // detail under error.message — the string-only check used to drop it.
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchobjerr-"));
+  try {
+    const json = JSON.stringify({
+      tinycloud: "1",
+      kind: "watch",
+      status: "error",
+      data: null,
+      error: { code: "upstream", message: "Describe job did not finish within 600s (still processing — retry).", retryable: true },
+    });
+    const script = join(dir, "watch.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\nexit 1\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("x.mp4", { run: `bash ${script} {{input}}` });
+    assert.equal(rec.state, "error");
+    assert.match(rec.error ?? "", /Describe job did not finish within 600s/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("runWatch tags pending when the marker is nested under data", async () => {

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "overcast",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "overcast",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "Overcast",
   "description": "The situation room in your editor — senses on your media (watch, listen, see, faces, EXIF via right-click), OSINT on your sources, and a wall to monitor the situation: maps, graphs, briefs, live feeds.",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "publisher": "kdrrr",
   "private": true,
   "preview": true,


### PR DESCRIPTION
## Problem

`overcast watch --segment shots` was silently broken (found via a field shim in a live case):

1. **Flag dropped.** The CLI flag parser accepts unknown flags without error, and the default tinycloud path in `src/providers/tinycloud/watch.ts` hardcoded `["watch", input, "--json"]` — so `--segment shots` parsed cleanly and was never passed. Every watch got `uniform:20`.
2. **64 KiB stdout truncation.** tinycloud's embedded bun can exit without draining a >64 KiB non-blocking pipe write, severing the JSON envelope at exactly 65536 bytes → `tinycloud watch produced no JSON output`. Invisible at uniform:20 (~28 KB envelopes); bites exactly when shot segmentation pushes long-form output past 64 KiB.
3. **(found while verifying)** A real Cloudglue job-timeout ships an OBJECT error (`{code, message}`); `runWatch`'s string-only check dropped it, producing an empty `exit 1:` record error.

## Fix

- Declare `--segment` / `--shot-min-seconds` / `--shot-max-seconds` on the `watch` verb spec (one spec → CLI + agent tool + skill docs, invariant #5) and thread them into the tinycloud argv; custom providers receive them as `extraArgs` (the wrapper contract, mirroring `listen --diarize/--lang`).
- `execCapture` gains `stdoutToFile`: stdout goes to a temp file instead of a pipe (maxBuffer still enforced, stderr unchanged); all tinycloud call sites (`runWatch`, `runListen`, `runTinycloud`) opt in. The no-JSON error now distinguishes unparseable/truncated output from no output.
- `runWatch` maps object error envelopes via the shared `tinycloudError` extractor.
- Docs (`docs/verbs.md`, `CLAUDE.md`/`AGENTS.md`) + regenerated `skills/overcast/reference/verbs.md`.

## Verification

- `npm run typecheck` clean; `npm test` 1291/1291; offline e2e 367/367.
- Live `10_watch` case against real Cloudglue with the **compiled bun binary**: 10/10.
- Real `watch --segment shots --shot-min-seconds 0.6` (bun binary, real videos, fresh cache-miss analyses): `state: ready`, `detailed.describe.primary_segmentation == "shots"` on both a 4 MB and a 43 MB clip. (Top-level `segmentation` still echoes `uniform:20` — known upstream cosmetic bug in tinycloud, out of scope.)
- New unit tests: segment flags on default + custom argv paths, >64 KiB envelope survival, `stdoutToFile` maxBuffer/stderr/utf-8 behavior, object-error envelope mapping.

## Release

Patch bump **0.0.13 → 0.0.14** folded into this PR (`npm version patch --no-git-tag-version`, all surfaces synced, `sync-version --check` clean) per the RELEASING.md fold-into-PR flow — tag `v0.0.14` on `main` after merge to trigger the npm publish.

Made with [Cursor](https://cursor.com)