### PR TITLE
fix(watch,index): surface actual segmentation + true remote file counts (tinycloud ≤0.3.15 envelope hardening)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,9 @@ Run `overcast commands --json` for the authoritative registry, or `overcast <ver
 - **Senses** — `watch` (shot-detect + all-modality describe → `content` /
   `transcript` / `detailed`; `--segment shots|chapters|segments|uniform:<s>`
   picks the provider's segmentation, `--shot-min-seconds`/`--shot-max-seconds`
-  tune shot detection), `listen` (speech transcript; `--describe` for the
+  tune shot detection; `meta.segmentation` = what actually ran — the `detailed`
+  echo doesn't track it (tinycloud ≤ 0.3.15), a request/ran kind mismatch adds
+  `payload.warning`), `listen` (speech transcript; `--describe` for the
   full audio-scene, `--diarize`, `--lang`), `see` (caption / OCR / open-vocab
   `--detect` — **default: the brain LLM** when image-capable, i.e. a direct
   "describe this image" call; falls back to the Hugging Face captioner,

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -12,7 +12,7 @@ see [configuration.md](configuration.md).
 **Senses** — turn media into records
 | verb | does |
 |---|---|
-| `watch` | analyze a video → `content` / `transcript` / `detailed` (default: Cloudglue); `--segment shots\|chapters\|segments\|uniform:<s>` picks the provider's segmentation (`--shot-min-seconds`/`--shot-max-seconds` tune shot detection) |
+| `watch` | analyze a video → `content` / `transcript` / `detailed` (default: Cloudglue); `--segment shots\|chapters\|segments\|uniform:<s>` picks the provider's segmentation (`--shot-min-seconds`/`--shot-max-seconds` tune shot detection); `meta.segmentation` reports what ACTUALLY ran — trust it over the `detailed` echo (tinycloud ≤ 0.3.15 echoes `uniform:20` there even on a shots run), and a request/ran kind mismatch adds `payload.warning` |
 | `listen` | transcribe audio / a video's audio; `--describe` for the full audio-scene |
 | `see` | caption / OCR / detect on an image, image URL, or video frame (default: the brain LLM when image-capable; falls back to HF, or bind a VLM / the opt-in tinycloud `see`+`extract` provider, ≥ 0.3.7) |
 | `face` | detect faces in a video, `--match <img>` to find a person, or search a face-analysis index |
@@ -89,7 +89,15 @@ or `qmd` when you want configured local semantic memory. Local memory defaults
 to `note`, `watch`, `listen`, `see`, and `scan` evidence, including source/search
 metadata from web, YouTube, TikTok, and similar scans. Remote collections are
 additive and optional: `face-analysis` / `media-descriptions` / `entities` are
-tinycloud-backed for scale and portability. When setup applies with local videos
+tinycloud-backed for scale and portability. Note the upstream default:
+`media-descriptions` collections created through tinycloud index **speech +
+summary only** (the Cloudglue-side `describe_config` disables visual scene
+descriptions, scene text, and audio descriptions; the tinycloud CLI has no flag
+to change it, and the config is immutable after create) — `ask --index` over
+such a collection answers from the spoken words, not the visual channel. For
+visual/on-screen-text questions, `watch` a clip directly (its default describe
+IS full multimodal) or create the collection out-of-band with an explicit
+`describe_config`. When setup applies with local videos
 routed to remote collections, overcast starts collection creation/ingestion
 immediately; use `--no-index` to save the setup without starting remote ingest.
 

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -9,7 +9,7 @@ store; cite findings by `record.id` + `media.at`.
 
 ### `overcast watch`
 
-Runs the bound sense provider (default: tinycloud, exec) over a video file or URL and emits a video.analysis record with markdown content, a transcript (when speech is present), and the full structured describe in `detailed`. `--segment` picks the provider's segmentation — shots (shot-detected boundaries; tune with --shot-min-seconds/--shot-max-seconds) | chapters | segments | uniform:<seconds> — instead of the provider default (uniform:20).
+Runs the bound sense provider (default: tinycloud, exec) over a video file or URL and emits a video.analysis record with markdown content, a transcript (when speech is present), and the full structured describe in `detailed`. `--segment` picks the provider's segmentation — shots (shot-detected boundaries; tune with --shot-min-seconds/--shot-max-seconds) | chapters | segments | uniform:<seconds> — instead of the provider default (uniform:20). The record's meta.segmentation reports the segmentation that ACTUALLY ran — trust it over any segmentation echo inside `detailed` (tinycloud ≤ 0.3.15 echoes uniform:20 there even on a shots run); a kind mismatch with the request adds payload.warning. Footage with no hard cuts (a locked-off talk camera) legitimately yields max-duration-capped shots that LOOK uniform.
 
 ```
 overcast watch <input> [options]

--- a/src/providers/tinycloud/collection.ts
+++ b/src/providers/tinycloud/collection.ts
@@ -55,7 +55,12 @@ function summarizeCollection(op: string, extra: Record<string, unknown>, state: 
       if (by.processing) parts.push(`${by.processing} processing`);
       if (by.failed) parts.push(`${by.failed} failed`);
       if (by.other) parts.push(`${by.other} other`);
-      return `${files.length} video${files.length === 1 ? "" : "s"}${parts.length ? `: ${parts.join(", ")}` : ""}`;
+      // `files` is ONE provider page (≤50) — the envelope's collection.file_count
+      // is the real total, so lead with it and say when the listing is partial
+      // (upstream `has_more` is unreliable, so the count comparison is the signal).
+      const total = typeof extra.file_count === "number" ? extra.file_count : files.length;
+      const partial = files.length < total ? ` (provider listed first ${files.length})` : "";
+      return `${total} video${total === 1 ? "" : "s"}${partial}${parts.length ? `: ${parts.join(", ")}` : ""}`;
     }
   }
   return undefined;
@@ -141,11 +146,21 @@ export async function tcCollectionAdd(
   return { rec, fileId };
 }
 
-/** `library collections show <id>` — live metadata + files[].status. */
+/** `library collections show <id>` — live metadata + files[].status.
+ *  `files` is one provider page (≤50 entries); `file_count` is the envelope's
+ *  collection.file_count — the authoritative REMOTE total — falling back to the
+ *  page length on older envelopes. The provider's has_more/next_page_token are
+ *  unreliable (has_more:false alongside a 58-file collection's 50-entry page),
+ *  so callers must compare `files.length` against `file_count`, not trust them. */
 export async function tcCollectionShow(collectionId: string, o: CollectionRunOpts = {}): Promise<{ rec: OvercastRecord }> {
   const out = await runTinycloud(["library", "collections", "show", collectionId, "--json"], o);
   const files = Array.isArray(out.data.files) ? (out.data.files as unknown[]) : [];
-  const rec = collectionRecord("show", out, { collection: collectionId, files, file_count: files.length });
+  const collection =
+    out.data.collection && typeof out.data.collection === "object"
+      ? (out.data.collection as Record<string, unknown>)
+      : {};
+  const total = typeof collection.file_count === "number" ? collection.file_count : files.length;
+  const rec = collectionRecord("show", out, { collection: collectionId, files, file_count: total });
   return { rec };
 }
 

--- a/src/providers/tinycloud/watch.ts
+++ b/src/providers/tinycloud/watch.ts
@@ -385,14 +385,37 @@ export async function runWatch(
   if (typeof data.title === "string") meta.title = data.title;
   if (typeof data.duration_seconds === "number") meta.duration_seconds = data.duration_seconds;
 
+  // The envelope's top-level `segmentation` does not track the requested/actual
+  // segmentation (a shots run still echoes "uniform:20" there, tinycloud ≤ 0.3.15);
+  // `describe.primary_segmentation` is the authoritative field. Surface it — plus
+  // the modality list, which answers "does this analysis have the visual channel?"
+  // — on meta so readers never have to trust the misleading echo in `detailed`.
+  const describe =
+    data.describe && typeof data.describe === "object" ? (data.describe as Record<string, unknown>) : {};
+  const ranSegmentation =
+    typeof describe.primary_segmentation === "string" && describe.primary_segmentation
+      ? describe.primary_segmentation
+      : undefined;
+  if (ranSegmentation) meta.segmentation = ranSegmentation;
+  if (Array.isArray(describe.primary_modalities)) meta.modalities = describe.primary_modalities;
+  if (opts.segment) meta.segmentation_requested = opts.segment;
+
+  const payload: Record<string, unknown> = { content, transcript };
+  // A requested segmentation KIND that differs from what actually ran is a silent
+  // fallback (the provider reused an existing describe, or predates the segment
+  // flags) — say so instead of shipping a clean "ready" that reads as a shots
+  // pass. Kind-only compare: `uniform:<s>` window drift stays unflagged because
+  // the reported value's param shape isn't contractual.
+  const kindOf = (s: string) => s.trim().toLowerCase().split(":")[0];
+  if (opts.segment && ranSegmentation && kindOf(ranSegmentation) !== kindOf(opts.segment)) {
+    payload.warning = `requested --segment ${opts.segment} but the analysis ran ${ranSegmentation} — the provider likely reused an existing describe for this source; meta.segmentation is authoritative (the detailed.segmentation echo is not).`;
+  }
+  payload.detailed = data;
+
   return makeRecord({
     verb: "watch",
     format: "json",
-    payload: {
-      content,
-      transcript,
-      detailed: data,
-    },
+    payload,
     media: { ref: input },
     meta,
     state,

--- a/src/registry/verbs.ts
+++ b/src/registry/verbs.ts
@@ -57,7 +57,12 @@ export const watchVerb: VerbSpec = {
     "is present), and the full structured describe in `detailed`. `--segment` picks the " +
     "provider's segmentation — shots (shot-detected boundaries; tune with " +
     "--shot-min-seconds/--shot-max-seconds) | chapters | segments | uniform:<seconds> — " +
-    "instead of the provider default (uniform:20).",
+    "instead of the provider default (uniform:20). The record's meta.segmentation " +
+    "reports the segmentation that ACTUALLY ran — trust it over any segmentation echo " +
+    "inside `detailed` (tinycloud ≤ 0.3.15 echoes uniform:20 there even on a shots run); " +
+    "a kind mismatch with the request adds payload.warning. Footage with no hard cuts " +
+    "(a locked-off talk camera) legitimately yields max-duration-capped shots that LOOK " +
+    "uniform.",
   args: [{ name: "input", summary: "Video file path or URL", required: true }],
   flags: [
     { name: "format", summary: "Output surface: json | md | txt", type: "string", choices: ["json", "md", "txt"] },

--- a/src/verbs/index.ts
+++ b/src/verbs/index.ts
@@ -340,6 +340,7 @@ function remoteFileRef(f: Record<string, unknown>): string | undefined {
     nonEmpty(f.path) ??
     nonEmpty(f.url) ??
     nonEmpty(f.file_id) ??
+    nonEmpty(f.cloudglue_file_id) ??
     nonEmpty(f.fileId) ??
     nonEmpty(f.id)
   );
@@ -572,19 +573,27 @@ export const indexVerb: VerbSpec = {
       const files = remoteFiles(shown);
       const members = files.flatMap((f) => {
         const ref = remoteFileRef(f);
-        return ref ? [{ ref, fileId: nonEmpty(f.file_id) ?? nonEmpty(f.fileId) ?? nonEmpty(f.id) }] : [];
+        // 0.3.15 `collections show` entries carry `cloudglue_file_id` — without it
+        // in this chain the mirror stored members with no file id at all.
+        return ref ? [{ ref, fileId: nonEmpty(f.file_id) ?? nonEmpty(f.cloudglue_file_id) ?? nonEmpty(f.fileId) ?? nonEmpty(f.id) }] : [];
       });
       setMembers(c, remoteId, members);
+      // files[] is ONE provider page (≤50); the show payload's file_count carries
+      // the envelope's authoritative remote total. Report the total — a 58-file
+      // collection must not read as "(50 remote files)" — and say when the mirror
+      // only holds the listed first page.
+      const fileCount = typeof shownPayload.file_count === "number" ? shownPayload.file_count : files.length;
+      const partial = files.length < fileCount ? `; provider listed first ${files.length}, mirrored those` : "";
       return [makeRecord({
         verb: "index",
         format: "json",
         payload: {
           op: "attach",
-          summary: `attached ${type} index '${entry.name}' (${files.length} remote file${files.length === 1 ? "" : "s"})`,
+          summary: `attached ${type} index '${entry.name}' (${fileCount} remote file${fileCount === 1 ? "" : "s"}${partial})`,
           index: entry.id,
           name: entry.name,
           type: entry.type,
-          files: files.length,
+          files: fileCount,
           member_count: listIndexes(c).find((x) => x.id === remoteId)?.members.length ?? entry.members.length,
           detailed: shownPayload.detailed,
         },

--- a/test/fixtures/fake-tinycloud.sh
+++ b/test/fixtures/fake-tinycloud.sh
@@ -102,7 +102,13 @@ if [ "$top" = "library" ] && [ "$sub" = "collections" ]; then
   case "$sub2" in
     create)   echo '{"tinycloud":"1","kind":"collection","status":"ready","result_id":"col_fake123","data":{"collection_id":"col_fake123","name":"fixture","type":"media-descriptions"}}' ;;
     add)      echo '{"tinycloud":"1","kind":"collection","status":"pending","data":{"file_id":"file_abc","status":"pending"}}' ;;
-    show)     echo '{"tinycloud":"1","kind":"collection","status":"ready","data":{"id":"col_fake123","files":[{"file_id":"file_abc","status":"completed"},{"file_id":"file_def","status":"pending"}]}}' ;;
+    # real 0.3.15 show shape: nested collection{file_count} + one ≤50-entry files
+    # page whose has_more/next_page_token are BROKEN upstream (has_more:false on a
+    # partially-listed collection; the token is the literal "[redacted]") — the
+    # mapper must trust collection.file_count, not the pagination markers. Entries
+    # carry cloudglue_file_id (not file_id). file_count 3 > 2 listed models the
+    # truncation.
+    show)     echo '{"tinycloud":"1","kind":"collection","status":"ready","data":{"view":"collection","collection":{"id":"col_fake123","name":"fixture","collection_type":"media-descriptions","file_count":3},"files":[{"cloudglue_file_id":"file_abc","filename":"clip-abc.mp4","media_type":"video","status":"completed"},{"cloudglue_file_id":"file_def","filename":"clip-def.mp4","media_type":"video","status":"pending"}],"has_more":false,"next_page_token":"[redacted]"}}' ;;
     list)     echo '{"tinycloud":"1","kind":"collection","status":"ready","data":{"collections":[{"id":"col_fake123","type":"media-descriptions","name":"fixture"}]}}' ;;
     delete)   echo '{"tinycloud":"1","kind":"collection","status":"ready","data":{"deleted":true,"id":"col_fake123"}}' ;;
     remove)   echo '{"tinycloud":"1","kind":"collection","status":"pending","data":{"status":"pending"}}' ;;

--- a/test/unit/face-index.test.ts
+++ b/test/unit/face-index.test.ts
@@ -570,7 +570,10 @@ test("index verb: create → add → list → show → delete, mirroring locally
     assert.equal((lp.indexes as unknown[]).length, 1);
 
     const [shown] = await indexVerb.run(mk("show", ["col_fake123"]));
-    assert.equal((shown.payload as Record<string, unknown>).file_count, 2);
+    // file_count = the envelope's collection.file_count (remote total), which can
+    // exceed the ≤50-entry files page (fixture: 3 remote, 2 listed)
+    assert.equal((shown.payload as Record<string, unknown>).file_count, 3);
+    assert.equal(((shown.payload as Record<string, unknown>).files as unknown[]).length, 2);
 
     const [deleted] = await indexVerb.run(mk("delete", ["col_fake123"]));
     assert.equal(deleted.state, "ready");
@@ -1271,9 +1274,10 @@ test("index ops lead with a synthesized summary headline (show file-status, crea
   try {
     const c = openCase(cdir); c.ensure();
     addIndex(c, { id: "col_fake123", type: "media-descriptions", name: "fixture" });
-    // show: a file-status headline (fixture has 1 completed + 1 pending)
+    // show: a file-status headline — remote total first, partial listing named
+    // (fixture: 3 remote files, 2 listed — 1 completed + 1 pending)
     const [show] = await indexVerb.run({ input: "show", rest: ["col_fake123"], opts: {}, case: openCase(cdir), profile: defaultProfile() });
-    assert.match(String((show.payload as Record<string, unknown>).summary), /2 videos:.*1 ready.*1 processing/);
+    assert.match(String((show.payload as Record<string, unknown>).summary), /3 videos \(provider listed first 2\):.*1 ready.*1 processing/);
     assert.equal(Object.keys(show.payload as Record<string, unknown>)[1], "summary"); // headline near the top (after op)
     // create: "created <type> index '<name>'"
     const [create] = await indexVerb.run({ input: "create", rest: ["acme"], opts: { type: "media-descriptions" }, case: openCase(cdir), profile: defaultProfile() });
@@ -1418,7 +1422,12 @@ test("index attach mirrors an existing remote index by name", async () => {
     assert.equal(p.index, "col_fake123");
     assert.equal(p.name, "fixture");
     assert.equal(p.type, "media-descriptions");
+    // `files` is the envelope's collection.file_count (the remote TOTAL), not the
+    // one listed page — a 58-file collection must not read as "50 remote files".
+    // The fixture models the provider's ≤50-entry page: 3 remote, 2 listed.
+    assert.equal(p.files, 3);
     assert.equal(p.member_count, 2);
+    assert.match(p.summary as string, /3 remote files; provider listed first 2/);
     assert.equal(findIndex(c, "fixture")?.id, "col_fake123");
     assert.equal(listIndexes(c)[0].members.length, 2);
   } finally {
@@ -1437,14 +1446,16 @@ test("index attach syncs mirrored members instead of keeping stale refs", async 
     const [attached] = await indexVerb.run({ input: "attach", rest: ["fixture"], opts: {}, case: c, profile: defaultProfile() });
     assert.equal(attached.state, "ready");
     assert.equal(setMembers(c, "col_fake123", [
-      { ref: "file_abc", fileId: "file_abc" },
+      { ref: "clip-abc.mp4", fileId: "file_abc" },
       { ref: "stale.mp4", fileId: "file_stale" },
     ]), true);
-    assert.deepEqual(listIndexes(c)[0].members.map((m) => m.ref), ["file_abc", "stale.mp4"]);
+    assert.deepEqual(listIndexes(c)[0].members.map((m) => m.ref), ["clip-abc.mp4", "stale.mp4"]);
 
     const [synced] = await indexVerb.run({ input: "attach", rest: ["fixture"], opts: {}, case: c, profile: defaultProfile() });
     assert.equal(synced.state, "ready");
-    assert.deepEqual(listIndexes(c)[0].members.map((m) => m.ref), ["file_abc", "file_def"]);
+    assert.deepEqual(listIndexes(c)[0].members.map((m) => m.ref), ["clip-abc.mp4", "clip-def.mp4"]);
+    // the 0.3.15 show entries carry `cloudglue_file_id` — the mirror must keep it
+    assert.deepEqual(listIndexes(c)[0].members.map((m) => m.fileId), ["file_abc", "file_def"]);
     assert.equal((synced.payload as Record<string, unknown>).member_count, 2);
   } finally {
     if (saved === undefined) delete process.env.OVERCAST_TINYCLOUD_CMD;

--- a/test/unit/watch-mapper.test.ts
+++ b/test/unit/watch-mapper.test.ts
@@ -281,6 +281,76 @@ test("runWatch appends segmentation flags to a custom run template (wrapper cont
   }
 });
 
+test("runWatch surfaces describe.primary_segmentation as the authoritative meta.segmentation", async () => {
+  // tinycloud ≤ 0.3.15's top-level `segmentation` doesn't track what ran (a real
+  // shots run still echoes "uniform:20" there — the field that sent a live case
+  // down a phantom "shots silently fell back" debugging spiral). The record must
+  // lead with describe.primary_segmentation + the modality list instead.
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchprimseg-"));
+  try {
+    const json = JSON.stringify({
+      status: "ready",
+      data: {
+        title: "talk",
+        summary: "a talk",
+        duration_seconds: 1298,
+        segmentation: "uniform:20", // the misleading upstream echo
+        segments: [{ index: 1, start_time: 0, end_time: 60, description: "d", summary: "s" }],
+        describe: {
+          profile: "default",
+          primary_segmentation: "shots",
+          primary_modalities: ["speech", "visual", "scene_text", "audio_description", "summary"],
+        },
+      },
+    });
+    const script = join(dir, "tc.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+
+    // requested kind matches what ran → truthful meta, NO warning
+    const rec = await runWatch("talk.mp4", { run: `bash ${script} {{input}}`, segment: "shots" });
+    assert.equal(rec.state, "ready");
+    assert.equal(rec.meta?.segmentation, "shots");
+    assert.equal(rec.meta?.segmentation_requested, "shots");
+    assert.deepEqual(rec.meta?.modalities, ["speech", "visual", "scene_text", "audio_description", "summary"]);
+    assert.equal((rec.payload as Record<string, unknown>).warning, undefined);
+
+    // requested kind DIFFERS from what ran → a leading warning names both sides
+    const fell = await runWatch("talk.mp4", { run: `bash ${script} {{input}}`, segment: "chapters" });
+    assert.equal(fell.state, "ready");
+    assert.equal(fell.meta?.segmentation, "shots");
+    assert.match((fell.payload as Record<string, unknown>).warning as string, /--segment chapters/);
+    assert.match((fell.payload as Record<string, unknown>).warning as string, /ran shots/);
+
+    // no --segment requested → meta still carries the truth, no requested echo
+    const plain = await runWatch("talk.mp4", { run: `bash ${script} {{input}}` });
+    assert.equal(plain.meta?.segmentation, "shots");
+    assert.equal(plain.meta?.segmentation_requested, undefined);
+    assert.equal((plain.payload as Record<string, unknown>).warning, undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runWatch stays quiet about segmentation when the provider doesn't report it", async () => {
+  // an older tinycloud (or custom wrapper) with no describe.primary_segmentation:
+  // no meta.segmentation, and no mismatch warning to false-positive on.
+  const dir = mkdtempSync(join(tmpdir(), "oc-watchnoseg-"));
+  try {
+    const json = JSON.stringify({ status: "ready", data: { title: "t", summary: "s", segments: [] } });
+    const script = join(dir, "tc.sh");
+    writeFileSync(script, `#!/usr/bin/env bash\nprintf '%s\\n' '${json}'\n`);
+    chmodSync(script, 0o755);
+    const rec = await runWatch("clip.mp4", { run: `bash ${script} {{input}}`, segment: "shots" });
+    assert.equal(rec.state, "ready");
+    assert.equal(rec.meta?.segmentation, undefined);
+    assert.equal(rec.meta?.segmentation_requested, "shots");
+    assert.equal((rec.payload as Record<string, unknown>).warning, undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("runWatch survives an envelope past the 64 KiB pipe buffer (stdoutToFile)", async () => {
   // shot segmentation on long-form video pushes the envelope well past 64 KiB —
   // exactly where the tinycloud bun-flush truncation used to sever the JSON.


### PR DESCRIPTION
## Problem

Two tinycloud ≤ 0.3.15 envelope quirks make overcast records misleading, in ways that send record readers (human or agent) down phantom debugging spirals:

1. **The watch envelope's top-level `segmentation` doesn't track what actually ran.** A real `--segment shots` run still echoes `uniform:20` there — the authoritative field is `describe.primary_segmentation`, buried inside `detailed`. A reader checking the obvious field concludes the shots request silently fell back and re-runs (and re-pays for) analyses that already succeeded. Cut-free footage compounds the illusion: on a locked-off talk camera every shot hits the max-duration cap, so the segment durations *look* uniform too.
2. **`library collections show` lists at most 50 files, with broken pagination markers.** `has_more` is `false` even when `collection.file_count` is larger, and `next_page_token` is the literal string `"[redacted]"` — so `index attach` on a 58-file collection reported "(50 remote files)" and mirrored 50 members as if that were everything. Found while fixing: show entries carry `cloudglue_file_id`, which the member-mirror's fileId chain (`file_id`/`fileId`/`id`) missed entirely — every mirrored member stored `fileId: undefined`.

## Fix

All at the exec boundary (invariants #3/#9) — map the envelope truthfully; no provider behavior assumed fixed:

- **watch** (`src/providers/tinycloud/watch.ts`): `meta.segmentation` = `describe.primary_segmentation` (the field that tells the truth), `meta.modalities` = `describe.primary_modalities` (answers "does this analysis carry the visual channel?"), `meta.segmentation_requested` when `--segment` was passed, and a leading `payload.warning` when the requested segmentation KIND differs from what actually ran. Kind-only compare — `uniform:<s>` window params aren't contractual in the reported value, so window drift can't false-positive.
- **collection show** (`src/providers/tinycloud/collection.ts`): `file_count` = the envelope's `collection.file_count` (the real remote total) instead of the ≤50-entry page length; the summary names a partial listing (`3 videos (provider listed first 2): 1 ready, 1 processing`). Since the provider's `has_more`/`next_page_token` are unreliable, the count comparison is the signal.
- **index attach** (`src/verbs/index.ts`): summary/`payload.files` report the remote total and say when only the first page was mirrored (`attached … (58 remote files; provider listed first 50, mirrored those)`); the member fileId chain and `remoteFileRef` learn `cloudglue_file_id`.
- **fixture** (`test/fixtures/fake-tinycloud.sh`): `collections show` now emits the REAL 0.3.15 nested shape — `collection{file_count}`, `cloudglue_file_id` entries, and the broken pagination markers — so the mappers are tested against what the binary actually sends.
- **docs** (`docs/verbs.md`, `CLAUDE.md`/`AGENTS.md`, regenerated skill reference): trust `meta.segmentation` over the `detailed` echo; cut-free footage legitimately yields max-capped shots that look uniform; and tinycloud-created `media-descriptions` collections index **speech + summary only** (the Cloudglue-side `describe_config` default — no CLI flag reaches it, and it's immutable after create), so `ask --index` answers from spoken words — `watch` a clip directly for visual/on-screen-text questions.

## Verification

- `npm run typecheck` clean; `npm test` 1295/1295; offline e2e 367/367; skills regen no-diff.
- Live e2e (compiled bun binary, real Cloudglue): `10_watch` + `23_index` cases **27/27**.
- Real-data spot checks of the new behaviors: `index attach` on a real 58-file collection → `attached media-descriptions index … (58 remote files; provider listed first 50, mirrored those)`, `payload.files: 58` / `member_count: 50`; a real `watch --segment shots` run → `meta.segmentation: shots` + the full `meta.modalities` list while the envelope's `detailed.segmentation` echo still reads `uniform:20`, and no spurious warning.
- New unit tests: authoritative `meta.segmentation` + modalities surfacing, the request/ran mismatch warning (and silence when the provider doesn't report segmentation at all), attach/show totals with partial-listing annotations against the real envelope shape, and the `cloudglue_file_id` member mirror.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Exec-boundary mapping and documentation only; no auth or data-model changes. Behavior change is more accurate counts and segmentation metadata on watch/index records.
> 
> **Overview**
> Hardens tinycloud ≤0.3.15 envelope mapping so **watch** and **index** records stop lying about segmentation and collection size.
> 
> **`watch`** now sets **`meta.segmentation`** from `describe.primary_segmentation` (not the misleading top-level/`detailed` echo), adds **`meta.modalities`** and **`meta.segmentation_requested`**, and emits **`payload.warning`** when the requested `--segment` *kind* differs from what actually ran.
> 
> **Collection show / index attach** use **`collection.file_count`** as the remote total instead of the ≤50-entry `files` page; summaries and attach payloads note partial listings. Member mirroring picks up **`cloudglue_file_id`** and member refs from the real show shape.
> 
> Docs and the skill reference explain trusting **`meta.segmentation`**, default **`media-descriptions`** indexing being speech+summary only, and the updated fixture/tests for the 0.3.15 envelope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312509b9924757842ed7fa375d52c4fa84df3a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
