### PR TITLE
fix(cli): --json emits compact JSONL + document the multi-record stdout contract

### DIFF
--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -7,6 +7,15 @@ shows the full surface + env vars.) For how the verbs chain into real
 investigations, see the [Field Manual](field-manual.md); for binding backends,
 see [configuration.md](configuration.md).
 
+**Scripting note — `--json` stdout is JSONL.** Every record prints as one
+compact JSON object per line, and a verb can emit more than one record per run:
+a match that clears a findings threshold (face / image / similar / cluster /
+voice / audio, target phrases) appends a `status:"suggested"` finding record
+after the verb's own. Parse line-by-line (or with `jq`, which consumes the
+stream natively) and select the record whose `verb` matches the one you ran —
+a whole-buffer `JSON.parse` / `json.loads` fails with "extra data" exactly on
+the runs that found something.
+
 ## Verbs
 
 **Senses** — turn media into records

--- a/skills/overcast/SKILL.md
+++ b/skills/overcast/SKILL.md
@@ -68,7 +68,12 @@ records). Every verb emits a loose, indexable **record**; cite findings by
 
 ## How to drive it
 
-Run any verb from bash and parse the JSON record:
+Run any verb from bash and parse the JSON records. `--json` stdout is JSONL —
+ONE compact record per line — and a verb can emit MORE than one record per run:
+a match that clears a findings threshold (face/image/similar/cluster/voice/audio,
+target phrases) appends a `finding` record after the verb's own. Parse
+line-by-line and select the record whose `verb` matches the one you ran; a
+whole-buffer `json.loads(stdout)` breaks exactly on the runs that found something.
 
 ```bash
 overcast watch ./clip.mp4 --json          # video.analysis record

--- a/skills/overcast/reference/verbs.md
+++ b/skills/overcast/reference/verbs.md
@@ -1,7 +1,11 @@
 # overcast — verb reference
 
 Generated from the verb registry (`overcast commands --json`). Drive any verb
-from a shell via `overcast <verb> [args] --json` and parse the emitted record.
+from a shell via `overcast <verb> [args] --json` and parse the emitted records:
+stdout is JSONL — one compact JSON record per line — and a verb can emit MORE
+than one record per run (a match that clears a findings threshold appends a
+suggested-finding record after the verb's own), so parse line-by-line and pick
+the record whose `verb` is the one you ran; never whole-buffer `JSON.parse`.
 Every verb emits one or more loose records persisted to the case's `.overcast/`
 store; cite findings by `record.id` + `media.at`.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -265,7 +265,9 @@ export function renderTopHelp(): string {
   lines.push("  --case <dir>     Operate on the case rooted at <dir> (default: cwd)");
   lines.push("  --home <dir>     overcast home for profiles (default: ~/.overcast)");
   lines.push("  --profile <name> Active profile (default: default)");
-  lines.push("  --json           JSON output  ·  --format json|md|txt");
+  lines.push("  --json           JSON output, one compact record per line (JSONL) — a verb can");
+  lines.push("                   emit several records (e.g. an appended suggested-finding lead),");
+  lines.push("                   so parse stdout line-by-line  ·  --format json|md|txt");
   lines.push("");
   lines.push(renderEnvHelp());
   lines.push("");

--- a/src/render.ts
+++ b/src/render.ts
@@ -280,8 +280,14 @@ export function nativeReportFormat(rec: OvercastRecord): string | undefined {
  * Format-aware single-record render, shared by the CLI and the TUI slash handler
  * so both honor `--format`/`--json` identically (a paged `chunk` shows in full
  * under txt/md, not a truncated preview):
- *   json → the whole record · md/txt → the body text field (else the payload
- *   JSON) · default → the magnitude preview.
+ *   json → the whole record, COMPACT on one line · md/txt → the body text field
+ *   (else the payload JSON) · default → the magnitude preview.
+ *
+ * json is compact (no pretty-print) so a multi-record invocation — a verb's own
+ * output plus any appended suggested-finding leads — prints as valid JSONL: one
+ * record per line, parseable line-by-line. Pretty-printing here made stdout a
+ * stream of concatenated multi-line JSON documents that a whole-buffer
+ * JSON.parse/json.loads choked on exactly when a match fired a finding trigger.
  */
 export function renderForFormat(rec: OvercastRecord, format?: string): string {
   // sanitizeTerminalText on EVERY branch: a record's payload inlines scraped
@@ -290,7 +296,7 @@ export function renderForFormat(rec: OvercastRecord, format?: string): string {
   // page can repaint the analyst's screen with fabricated records. json is
   // sanitized too: JSON.stringify escapes control chars inside string
   // VALUES, but one in a key position or a non-string field would survive.
-  if (format === "json") return safeText(JSON.stringify(rec, null, 2));
+  if (format === "json") return safeText(JSON.stringify(rec));
   if (format === "md" || format === "txt") {
     if (typeof rec.payload === "string") return safeText(rec.payload);
     const p = rec.payload as JsonMap;

--- a/src/skill-gen.ts
+++ b/src/skill-gen.ts
@@ -23,7 +23,11 @@ export function generateVerbReference(): string {
   lines.push("");
   lines.push(
     "Generated from the verb registry (`overcast commands --json`). Drive any verb",
-    "from a shell via `overcast <verb> [args] --json` and parse the emitted record.",
+    "from a shell via `overcast <verb> [args] --json` and parse the emitted records:",
+    "stdout is JSONL — one compact JSON record per line — and a verb can emit MORE",
+    "than one record per run (a match that clears a findings threshold appends a",
+    "suggested-finding record after the verb's own), so parse line-by-line and pick",
+    "the record whose `verb` is the one you ran; never whole-buffer `JSON.parse`.",
     "Every verb emits one or more loose records persisted to the case's `.overcast/`",
     "store; cite findings by `record.id` + `media.at`.",
     "",
@@ -86,7 +90,12 @@ ${verbList}
 
 ## How to drive it
 
-Run any verb from bash and parse the JSON record:
+Run any verb from bash and parse the JSON records. \`--json\` stdout is JSONL —
+ONE compact record per line — and a verb can emit MORE than one record per run:
+a match that clears a findings threshold (face/image/similar/cluster/voice/audio,
+target phrases) appends a \`finding\` record after the verb's own. Parse
+line-by-line and select the record whose \`verb\` matches the one you ran; a
+whole-buffer \`json.loads(stdout)\` breaks exactly on the runs that found something.
 
 \`\`\`bash
 overcast watch ./clip.mp4 --json          # video.analysis record

--- a/test/unit/render.test.ts
+++ b/test/unit/render.test.ts
@@ -163,6 +163,13 @@ test("renderForFormat: txt/md surface a paged chunk in full (shared by CLI + sla
   // json → the whole record; default → the magnitude preview
   assert.match(renderForFormat(page, "json"), /"chunk"/);
   assert.match(renderForFormat(page), /\[case\] state=ready payload:/);
+  // json is COMPACT single-line (JSONL contract): the CLI can emit several
+  // records per run (verb output + suggested-finding leads), so each must
+  // round-trip from its own line — a pretty-printed record broke line-by-line
+  // and whole-buffer parsing alike.
+  const jsonOut = renderForFormat(makeRecord({ verb: "audio", payload: { op: "match", matches: [{ score: 340 }], note: "multi\nline\tbody" } }), "json");
+  assert.doesNotMatch(jsonOut, /\n/);
+  assert.equal((JSON.parse(jsonOut) as { verb: string }).verb, "audio");
   // string payload under txt → the body
   assert.equal(renderForFormat(makeRecord({ verb: "note", payload: "hello body" }), "txt"), "hello body");
 });

--- a/vscode/src/lib/cliOutput.ts
+++ b/vscode/src/lib/cliOutput.ts
@@ -2,10 +2,11 @@
 // module is exercised directly by `node --test` (see ../../test).
 //
 // Contract (verified against src/cli.ts): with --json the CLI prints each
-// result record as JSON.stringify(rec, null, 2), one after another — i.e.
-// stdout is a stream of concatenated pretty-printed JSON documents, not a
-// single array. Exit codes: 0 ready/pending, 1 hard error (record
-// state:"error" or thrown handler), 2 CLI usage, 3 needs_credentials.
+// result record as compact single-line JSON, one per line (JSONL) — older
+// builds pretty-printed each record, so this scanner is brace-balanced and
+// handles both, plus stray non-JSON between records. Exit codes: 0
+// ready/pending, 1 hard error (record state:"error" or thrown handler),
+// 2 CLI usage, 3 needs_credentials.
 import type { OvercastRecord } from "../types.ts";
 
 /** Parse a stream of concatenated JSON objects (tolerates stray non-JSON). */


### PR DESCRIPTION
## The bug

`overcast audio match --json` (hit in the field by a batch-matching script) broke `json.loads(stdout)` with **"Extra data" — and only on the queries that found matches**. A hit clears the findings margin threshold, so `persistRecords` appends a `status:"suggested"` finding record after the verb's own — and each record rendered as `JSON.stringify(rec, null, 2)`, making multi-record stdout a stream of **concatenated pretty-printed JSON documents**: not valid JSON (whole-buffer parse dies) and not valid JSONL either (records span multiple lines). The worst failure profile: scripts pass testing on misses and blow up exactly on the interesting results. Same shape for every trigger-bearing verb (`face`/`image`/`similar`/`cluster`/`voice`/`audio` matches, `exif` editing-software flags, `verify`, target phrases) plus multi-hit `scan`.

Printing the lead alongside the verb's output is deliberate (it's how CLI-driven agents learn a lead fired) — the fix keeps the stream and makes it parseable + documented.

## The fix

- **`src/render.ts`** — the `json` branch of `renderForFormat` is now compact `JSON.stringify(rec)`: `--json` stdout is true JSONL, one record per line, parseable with `for line in stdout.splitlines(): json.loads(line)`. Sanitization (`safeText`) unchanged on every branch.
- **Contract documented where a script author would look**: `overcast --help` global flags, a scripting note in `docs/verbs.md`, and the generated flagship skill + verb reference — parse line-by-line and select the record whose `verb` matches the one you ran. `skills/` regenerated (CI no-diff gate clean).
- **`vscode/src/lib/cliOutput.ts`** — comment-only: its brace-balanced `parseRecords` already handles both old and new formats.
- **`test/unit/render.test.ts`** — locks the contract: the json render contains no newlines (even with `\n`/`\t` inside payload strings) and round-trips through `JSON.parse` per line.

## Compatibility

- `jq` consumes concatenated JSON streams natively — every e2e assertion (`jq -r`, `jq -s`) works identically on both formats.
- The VS Code extension's parser is format-agnostic (verified by reading it, comment updated).
- `commands --json` / `--version --json` (single-document surfaces) are unchanged.

## Verification

- `npm run typecheck` clean · **1293/1293** unit · **367/367** offline e2e (the suite parses `--json` stdout with `jq` throughout).
- Live repro of the original failure shape: `overcast exif` on an image tagged with editing software emits 2 records (`exif` + suggested `finding`) as **2 clean JSONL lines**, each `json.loads`-able; whole-buffer parse fails only in the now-documented multi-record case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow output-format change in `renderForFormat` plus docs; VS Code parser already tolerates both formats; single-document surfaces like `commands --json` are unchanged.
> 
> **Overview**
> **`--json` stdout is now valid JSONL.** `renderForFormat` writes each record as one compact `JSON.stringify(rec)` line instead of pretty-printed multi-line JSON, so runs that append a second record (e.g. verb output plus an auto-**suggested** `finding` when a match clears a threshold) no longer break `json.loads(stdout)` with “extra data” on the hits that matter most.
> 
> **Contract is documented** in `overcast --help`, `docs/verbs.md`, and regenerated skill/reference copy: parse line-by-line, pick the record whose `verb` matches what you ran; `jq` still works on the stream.
> 
> A unit test asserts JSON mode has no newlines and round-trips per line; the VS Code `parseRecords` comment notes JSONL vs legacy pretty output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0e56ddb847c774279ba25fb6d2efe3e3cfb42f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->