### PR TITLE
docs(claude): pre-PR verification, adversarial self-review, and shell-portability discipline in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,6 +534,23 @@ CLI router, bun binary), run the live suite (`npm run test:e2e:live`) and inspec
 the generated `report.md`. Keep pi touch-points isolated in `src/extension/` and
 `src/registry/to-agent-tool.ts` so a pi bump has a small blast radius.
 
+Before opening or merging a PR: run `npm test` + `npm run test:e2e` (and the
+live suite when providers/records/CLI/binary are touched) from the repo root,
+judging pass/fail on FULL output — never through a `| grep`/`| tail` filter.
+Put the real counts in the PR body's verification section; anything not proven
+by a run is "unverified", not a claim. Then re-read your own diff adversarially
+before every push — error paths that fall through to success, unbounded
+loops/spins, new crash surfaces (ENOENT/null), a regression of the exact bug
+class just fixed — review bots keep catching bugs introduced by fix commits;
+catch them first. Fix review findings by CLASS: grep the PR for adjacent
+instances of the same pattern and root-fix once (shared helper at 2+ sites),
+not one finding per review round.
+
+Shell must stay portable both ways: dev boxes are macOS (bash 3.2 — no
+associative arrays; BSD coreutils — no `split -n l/N`, no GNU-only tar/sed
+flags) while CI is GNU/Linux + shellcheck — anything shelling out to
+tar/split/sed/find must pass on both.
+
 ## Cursor Cloud specific instructions
 
 The startup update script runs `npm ci` for the root, `vscode/`, and the sibling


### PR DESCRIPTION
## What

Extends the **Verifying changes** section of `CLAUDE.md` with working discipline distilled from a month of session-history analysis (/insights):

- **Pre-PR contract** — run `npm test` + `npm run test:e2e` (plus the live suite when providers/records/CLI/binary are touched) from the repo root, judging pass/fail on FULL output, never through a `| grep`/`| tail` filter; PR bodies carry real counts, and unproven claims are labeled "unverified".
- **Adversarial self-review before every push** — hunt for error paths that fall through to success, unbounded loops/spins, new crash surfaces (ENOENT/null), and regressions of the exact bug class just fixed. This targets the recurring pattern of fix commits introducing new defects that only Bugbot caught.
- **Fix review findings by class** — grep the PR for adjacent instances of the same pattern and root-fix once (shared helper at 2+ sites) instead of one finding per review round.
- **Shell portability both ways** — dev boxes are macOS (bash 3.2, BSD coreutils) while CI is GNU/Linux + shellcheck; anything shelling out to tar/split/sed/find must pass on both.

## Verification

Doc-only change (`CLAUDE.md`, +17 lines, no code touched) — no test suites run; behavior is unaffected by construction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CLAUDE.md; no code, scripts, or CI behavior modified.
> 
> **Overview**
> Extends **`CLAUDE.md` → Verifying changes** with agent/PR working rules—no runtime or code changes.
> 
> **Pre-merge verification:** Run `npm test` and `npm run test:e2e` (plus `npm run test:e2e:live` when providers, records, CLI, or the binary change) from the repo root; judge pass/fail on full output (no `grep`/`tail`); put real counts in the PR verification section and label anything not run as unverified.
> 
> **Review discipline:** Adversarial self-review before every push (fall-through success paths, unbounded loops, ENOENT/null crashes, regressions of the bug class just fixed); address review findings by pattern class (grep adjacent instances, shared helper at 2+ sites) instead of one-off fixes per round.
> 
> **Shell portability:** Document macOS dev (bash 3.2, BSD coreutils) vs GNU/Linux CI + shellcheck—`tar`/`split`/`sed`/`find` usage must work on both.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc899aa4f009074d1035b04ec136dd15a514bc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->