### PR TITLE
feat(brain): add tinycloud:general-medium as a pickable Cloudglue brain model

### DIFF
--- a/src/extension/branding.ts
+++ b/src/extension/branding.ts
@@ -145,8 +145,8 @@ export interface HeaderOptions {
   contextFile: string;
   /** Tool/verb count. */
   tools: number;
-  /** Active model id (e.g. "tinycloud:advanced"). */
-  model: string;
+  /** Active model id (e.g. "tinycloud:advanced"), or a getter for the live one. */
+  model: string | (() => string);
   /** First-run setup cue shown when no completed case setup exists. */
   setup?: string | (() => string | undefined);
 }
@@ -168,7 +168,7 @@ export class OvercastHeader implements Component {
   private readonly tagRaw: string;
   private readonly ctxTag: string;
   private readonly tools: number;
-  private readonly model: string;
+  private readonly model: string | (() => string);
   private readonly setup: string | (() => string | undefined) | undefined;
   private lastSetup: string | undefined;
   private readonly version: string;
@@ -287,6 +287,10 @@ export class OvercastHeader implements Component {
     return typeof this.setup === "function" ? this.setup() : this.setup;
   }
 
+  private modelLabel(): string {
+    return typeof this.model === "function" ? this.model() : this.model;
+  }
+
   private pollSetup(): void {
     const next = this.setupLabel();
     if (next === this.lastSetup) return;
@@ -302,7 +306,7 @@ export class OvercastHeader implements Component {
     const setup = this.setupLabel();
     return (
       `${this.ctxTag}  ${GREEN_DIM}[${MAGENTA}${this.tools}${GREEN_DIM}] ${PALE}tools  ` +
-      `${GREEN_DIM}[${CYAN}◆${GREEN_DIM}] ${PALE}${this.model}` +
+      `${GREEN_DIM}[${CYAN}◆${GREEN_DIM}] ${PALE}${this.modelLabel()}` +
       (setup ? `  ${GREEN_DIM}[${AMBER}SETUP${GREEN_DIM}] ${PALE}${setup}` : "") +
       RESET
     );

--- a/src/extension/overcast.ts
+++ b/src/extension/overcast.ts
@@ -17,7 +17,7 @@ import { toAgentTool } from "../registry/to-agent-tool.js";
 import { openCase } from "../case.js";
 import { loadProfile, resolveCloudglue, resolveHome } from "../profile.js";
 import { loadSetup } from "../state/setup.js";
-import { CLOUDGLUE_MODEL_ID } from "../providers/brain/vision.js";
+import { CLOUDGLUE_MODEL_ID, CLOUDGLUE_PROVIDER_ID, cloudglueBrainModel, cloudglueBrainModels } from "../providers/brain/vision.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { OvercastHeader, OvercastFooter, workingIndicator, opLabel, idleLabel } from "./branding.js";
 import { registerSlashCommands } from "./slash.js";
@@ -233,22 +233,13 @@ export default async function overcastExtension(pi: ExtensionAPI): Promise<void>
     });
     // Turnkey: when a Cloudglue key is available AND the user hasn't pinned
     // their own brain (`setup llm`), make Cloudglue the active model so overcast
-    // works out of the box. An explicit profile llm is always respected; this is
+    // works out of the box. An explicit profile llm is always respected, and a
+    // Cloudglue model that's already active (e.g. launched with
+    // `--model cloudglue/tinycloud:general-medium`) is left alone; this is
     // still overridable via /model — never hardcoded over a user's choice.
-    if (cgKey && !activeProfile.llm) {
+    if (cgKey && !activeProfile.llm && ctx.model?.provider !== CLOUDGLUE_PROVIDER_ID) {
       try {
-        await pi.setModel({
-          id: CLOUDGLUE_MODEL_ID,
-          name: "TinyCloud Advanced",
-          api: "anthropic-messages",
-          provider: "cloudglue",
-          baseUrl,
-          reasoning: false,
-          input: ["text", "image"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 1000000,
-          maxTokens: 32000,
-        } as Parameters<typeof pi.setModel>[0]);
+        await pi.setModel(cloudglueBrainModel(baseUrl) as Parameters<typeof pi.setModel>[0]);
       } catch {
         /* best-effort; user can still /model */
       }
@@ -271,17 +262,7 @@ export default async function overcastExtension(pi: ExtensionAPI): Promise<void>
     baseUrl,
     apiKey: cgKey ?? "$CLOUDGLUE_API_KEY",
     api: "anthropic-messages",
-    models: [
-      {
-        id: CLOUDGLUE_MODEL_ID,
-        name: "TinyCloud Advanced",
-        reasoning: false,
-        input: ["text", "image"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 32000,
-      },
-    ],
+    models: cloudglueBrainModels(baseUrl),
   });
 
   // --- System prompt (persona + verb cheatsheet). --------------------------

--- a/src/extension/overcast.ts
+++ b/src/extension/overcast.ts
@@ -191,7 +191,9 @@ export default async function overcastExtension(pi: ExtensionAPI): Promise<void>
     setTimeout(() => { try { ctx.ui.setTitle(desiredTitle()); } catch { /* ignore */ } }, 50);
 
     // Header: the animated recording-deck banner (gradient wordmark + REC HUD +
-    // centered tagline + bracket status). Respect an explicit `setup llm` choice.
+    // centered tagline + bracket status). The live model (ctx.model, like the
+    // footer) wins so a `--model`/`/model` pick shows truthfully; before it
+    // binds, respect an explicit `setup llm` choice, then the turnkey default.
     const llmLabel = activeProfile.llm?.model || activeProfile.llm?.provider;
     const modelId = llmLabel || (cgKey ? CLOUDGLUE_MODEL_ID : "(set via /model)");
     if (bannerRaw) {
@@ -203,7 +205,7 @@ export default async function overcastExtension(pi: ExtensionAPI): Promise<void>
             version: OVERCAST_VERSION,
             contextFile,
             tools: VERBS.length,
-            model: modelId,
+            model: () => ctx.model?.id ?? modelId,
             setup: () => setupHintLabel(cwd),
           }),
       );

--- a/src/providers/brain/vision.ts
+++ b/src/providers/brain/vision.ts
@@ -31,13 +31,21 @@ import { resolveCloudglue, type Profile } from "../../profile.js";
  *  and the TUI brain agree on the id. */
 export const CLOUDGLUE_PROVIDER_ID = "cloudglue";
 export const CLOUDGLUE_MODEL_ID = "tinycloud:advanced";
+export const CLOUDGLUE_GENERAL_MEDIUM_MODEL_ID = "tinycloud:general-medium";
 
-/** The Cloudglue brain model descriptor (image-capable). One source of truth for
- *  both the see-path (here) and the extension's `pi.setModel`. */
-export function cloudglueBrainModel(baseUrl: string): Model<"anthropic-messages"> {
-  return {
-    id: CLOUDGLUE_MODEL_ID,
-    name: "TinyCloud Advanced",
+/** The pickable Cloudglue brain models. The turnkey default (advanced) stays
+ *  first — cloudglueBrainModel() and the extension's setModel rely on that. */
+const CLOUDGLUE_BRAIN_MODELS = [
+  { id: CLOUDGLUE_MODEL_ID, name: "TinyCloud Advanced" },
+  { id: CLOUDGLUE_GENERAL_MEDIUM_MODEL_ID, name: "TinyCloud General Medium" },
+] as const;
+
+/** The Cloudglue brain model descriptors (image-capable). One source of truth
+ *  for the see-path (here) and the extension's provider registration. */
+export function cloudglueBrainModels(baseUrl: string): Model<"anthropic-messages">[] {
+  return CLOUDGLUE_BRAIN_MODELS.map(({ id, name }) => ({
+    id,
+    name,
     api: "anthropic-messages",
     provider: CLOUDGLUE_PROVIDER_ID,
     baseUrl,
@@ -46,7 +54,12 @@ export function cloudglueBrainModel(baseUrl: string): Model<"anthropic-messages"
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 1_000_000,
     maxTokens: 32_000,
-  };
+  }));
+}
+
+/** The default (turnkey) Cloudglue brain model descriptor. */
+export function cloudglueBrainModel(baseUrl: string): Model<"anthropic-messages"> {
+  return cloudglueBrainModels(baseUrl)[0];
 }
 
 /** OVERCAST_SEE_BRAIN=off|0|false|no hard-disables the brain default (falls back
@@ -163,7 +176,7 @@ export async function resolveBrainModel(profile: Profile, opts: { requireImage?:
         name: "Cloudglue",
         baseUrl: cg.baseUrl,
         auth: { apiKey: envApiKeyAuth("Cloudglue API key", ["CLOUDGLUE_API_KEY"]) },
-        models: [cloudglueBrainModel(cg.baseUrl)],
+        models: cloudglueBrainModels(cg.baseUrl),
         api: anthropicMessagesApi(),
       });
       models.setProvider(cgProvider as unknown as Provider);

--- a/test/unit/branding.test.ts
+++ b/test/unit/branding.test.ts
@@ -48,6 +48,16 @@ test("OvercastHeader: settled frame can show first-run setup cue", () => {
   assert.match(out, /\[[^\]]*SETUP[^\]]*\][^\n]*case not set up/, "setup cue appears in startup status row");
 });
 
+test("OvercastHeader: a function-valued model renders the LIVE model id", () => {
+  let active = "tinycloud:advanced";
+  const h = new OvercastHeader(null, { ...headerOpts, model: () => active });
+  setStart(h, 4000);
+  assert.ok(h.render(160).join("\n").includes("tinycloud:advanced"), "initial model in status");
+  active = "tinycloud:general-medium";
+  assert.ok(h.render(160).join("\n").includes("tinycloud:general-medium"), "model switch reflected");
+  h.dispose();
+});
+
 test("OvercastHeader: setup cue can refresh after first render", () => {
   let pending = true;
   const h = new OvercastHeader(null, { ...headerOpts, setup: () => (pending ? "case not set up" : undefined) });

--- a/test/unit/see-brain.test.ts
+++ b/test/unit/see-brain.test.ts
@@ -11,12 +11,31 @@ import {
   buildSeeContext,
   splitDescriptionOcr,
   mimeForImage,
+  cloudglueBrainModel,
+  cloudglueBrainModels,
+  CLOUDGLUE_MODEL_ID,
+  CLOUDGLUE_GENERAL_MEDIUM_MODEL_ID,
 } from "../../src/providers/brain/vision.ts";
 import { parseProviderSpec } from "../../src/verbs/setup.ts";
 import { seeVerb } from "../../src/verbs/senses.ts";
 import { openCase } from "../../src/case.ts";
 import { defaultProfile } from "../../src/profile.ts";
 import type { VerbContext } from "../../src/registry/types.ts";
+
+test("cloudglueBrainModels lists advanced (default, first) + general-medium, both image-capable", () => {
+  const models = cloudglueBrainModels("https://api.example.test");
+  assert.deepEqual(
+    models.map((m) => m.id),
+    [CLOUDGLUE_MODEL_ID, CLOUDGLUE_GENERAL_MEDIUM_MODEL_ID],
+  );
+  assert.equal(CLOUDGLUE_GENERAL_MEDIUM_MODEL_ID, "tinycloud:general-medium");
+  for (const m of models) {
+    assert.equal(m.provider, "cloudglue");
+    assert.equal(m.baseUrl, "https://api.example.test");
+    assert.ok(m.input.includes("image"), `${m.id} should accept image input`);
+  }
+  assert.equal(cloudglueBrainModel("https://api.example.test").id, CLOUDGLUE_MODEL_ID);
+});
 
 test("parseProviderSpec maps builtin:<name> to an inproc selector (prefix kept)", () => {
   assert.deepEqual(parseProviderSpec("builtin:brain"), { type: "inproc", module: "builtin:brain" });


### PR DESCRIPTION
## What

Adds `tinycloud:general-medium` as a second pickable Cloudglue brain model alongside `tinycloud:advanced` (which stays the turnkey default), on all three surfaces:

- **`src/providers/brain/vision.ts`** — the single source of truth is now a model list (`cloudglueBrainModels()`); `cloudglueBrainModel()` keeps returning the advanced-first default. The see-path provider registration consumes the list, so `setup llm cloudglue tinycloud:general-medium` resolves for the CLI `see` brain too.
- **`src/extension/overcast.ts`** — `registerProvider` and the turnkey `setModel` now consume the shared descriptors instead of two duplicated inline literals, so both models appear in `/model`.
- **Launch-time stomp fix** (exposed by having a second model): the turnkey `session_start` block re-set the model to advanced even when the session was launched with an explicit `--model cloudglue/tinycloud:general-medium`. An already-active Cloudglue model is now left alone; a non-Cloudglue ambient default is still claimed as before.

Users pick the new model via `/model`, `--model cloudglue/tinycloud:general-medium` at launch, or `setup llm cloudglue tinycloud:general-medium`.

## Verification

- `npm run typecheck` — clean.
- `npm test` — **1317/1318 pass**. The single failure (`face-index.test.ts` "aborting during add --all backpressure") is a pre-existing timing flake: it fails identically on clean main under full-suite load and passes 131/131 when the file runs alone.
- `SKIP_BUILD=1 npm run test:e2e` (fresh `npm run build`) — **364/367 pass**. The 3 failures (`agent.mentions_watch`, `archiveagent.names_bucket`, `archiveagent.add_verified`) are the agent-mode cases that go live when a Cloudglue key is ambient; every brain completion is currently dying upstream with `403 Your account is currently being verified…` (AWS account-verification on the Cloudglue backend), unrelated to this change.
- Live headless probes against the built dist:
  - `overcast -p … --mode json --model cloudglue/tinycloud:general-medium` → session runs with `"provider":"cloudglue","model":"tinycloud:general-medium"` (previously stomped back to advanced).
  - same command without `--model` → `"provider":"cloudglue","model":"tinycloud:advanced"` (turnkey default preserved).
- New unit test asserts the model list order (advanced first), ids, and image capability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Model registration and default-selection logic changes are localized; behavior is covered by new unit tests and preserves advanced as the default when no explicit choice is set.
> 
> **Overview**
> Adds **`tinycloud:general-medium`** as a second pickable Cloudglue brain alongside **`tinycloud:advanced`** (still the turnkey default). **`cloudglueBrainModels()`** in `vision.ts` is now the single source of truth for descriptors; the pi extension’s provider registration, turnkey **`setModel`**, and CLI **`see`** brain registration all consume that list so `/model`, `--model`, and **`setup llm`** can target the new id.
> 
> **Launch-time fix:** turnkey session init no longer overwrites an already-selected Cloudglue model (e.g. **`--model cloudglue/tinycloud:general-medium`**); it only claims the default when the active provider is not Cloudglue and the profile has no pinned **`setup llm`**.
> 
> The TUI header **`model`** field can be a getter so the status row shows the live **`ctx.model`** id after **`/model`** switches, matching the footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a3a886aba954f8541f4dd0c4027f1be37bfff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->