### PR TITLE
build(deps-dev): bump vscode postcss + brace-expansion; deterministic add --all abort test

### DIFF
--- a/test/unit/face-index.test.ts
+++ b/test/unit/face-index.test.ts
@@ -2135,7 +2135,19 @@ test("aborting during add --all backpressure stops before the next wave", async 
       input: "add", rest: [], opts: { all: true, to: "col_abort", batch: 1 },
       case: openCase(cdir), profile, signal: controller.signal,
     });
-    setTimeout(() => controller.abort(new Error("test abort")), 100);
+    // Abort only once wave 0's membership is visibly written: the run is then
+    // guaranteed to be inside the 60s between-wave settle sleep, whose abort
+    // path rejects with signal.reason. A wall-clock timer races the wave-0
+    // child processes under suite load — the abort can land mid-spawn, where
+    // node throws its own generic AbortError (reason demoted to `cause`).
+    let runSettled = false;
+    void run.catch(() => {}).finally(() => { runSettled = true; });
+    const deadline = Date.now() + 30_000;
+    while (!runSettled && (findIndex(openCase(cdir), "col_abort")?.members.length ?? 0) < 1) {
+      assert.ok(Date.now() < deadline, "wave 0 never registered its member");
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    controller.abort(new Error("test abort"));
     await assert.rejects(run, /test abort/);
     assert.equal(findIndex(openCase(cdir), "col_abort")!.members.length, 1, "second wave was never submitted");
   } finally {

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -2554,9 +2554,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4958,9 +4958,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4978,7 +4978,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Closes out the current Dependabot security sweep (https://github.com/kdr/overcast/security/dependabot).

## What

- **vscode/package-lock.json (lockfile-only, within existing semver ranges):**
  - `postcss` 8.5.19 → 8.5.25 — attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset (alert #22; via tsup/vite)
  - `brace-expansion` 5.0.8 → 5.0.9 — DoS via unbounded intermediate arrays (flagged by `npm audit`, no open Dependabot PR; via `@vscode/vsce` → minimatch)
  - vscode `npm audit` after: **0 vulnerabilities**
- **test/unit/face-index.test.ts:** deterministic abort point for `aborting during add --all backpressure stops before the next wave`. The 100 ms wall-clock abort raced wave 0's child processes under suite load: landing mid-spawn surfaces node's generic `AbortError` (reason demoted to `cause`) instead of `signal.reason`, and wave-0 membership may not be written yet — intermittently failing both assertions (this reddened #149's CI and one local full run). The test now aborts only once the wave-0 member is visibly written, i.e. provably inside the 60 s between-wave settle sleep whose abort path rejects with the reason; if the run settles first the poll bails so the real error surfaces through `assert.rejects`.

## Triage context (same sweep, handled outside this PR)

- Merged: #150 (root postcss 8.5.25), #151 (vscode fast-uri 3.1.5) — both green; alerts #21/#23 auto-closed.
- Closed: #149 (vscode postcss) as superseded — its only CI failure was the flaky test fixed here; its bump is included here.
- Already on main: #147 (vscode undici 7.29.0).

## Not addressed — upstream-blocked (alerts #19, #11–13)

Root `brace-expansion@5.0.7` (high) and `undici@8.5.0` (3 medium) are pinned inside `@earendil-works/pi-coding-agent`'s published `npm-shrinkwrap.json`. Root `overrides` and `npm audit fix` silently no-op on the shrinkwrapped subtree (audit even prints "fix available", then changes nothing), and pi-coding-agent 0.83.0 still declares `undici@8.5.0` exactly — the only real fix is an upstream pi release with a refreshed shrinkwrap, then a reviewed exact-pin bump. Interim reachability: pi 0.83.0's undici use has no cache/retry interceptors (the CVE surfaces), and its minimatch patterns are config-driven, not attacker input.

## Verification (all on this branch, full unfiltered output)

| suite | result |
| --- | --- |
| `npm test` | **1319/1319 pass**, exit 0 |
| `npm run test:e2e` (offline) | **367/367 passed, 0 failed**, exit 0 |
| `npm run typecheck` | exit 0 |
| vscode `typecheck` / `build` / `test` / `package` | exit 0 / exit 0 / **56/56** / `.vsix` packaged (vsce = the brace-expansion consumer) |
| `npm run test:e2e:live` (compiled **bun binary**) | **767/778 passed, 11 failed** |
| live re-run of the 5 failing cases (same binary) | **187/194 passed, 7 failed** — 4 recovered (transient: Apify `x` no-hits, brain-LLM `see` empty responses) |

The 7 persistent live failures are external-data conditions, not code: Apify lens actor returning no hits today (4 assertions), `chain:btc` head tx currently **unconfirmed** so `payload.created` is null by design (`chain.sh` maps `status.block_time // null`), and one borderline CLIP text×image ranking. The bun binary under test is content-identical to main's (this diff is vscode-lockfile + a unit test only; root lockfile byte-identical after rebase), so those reflect main's current live status, not this PR.

Flake-fix determinism: patched test file green 3×3 isolated runs + full suite green (previously failed the full-suite run).

## Follow-up suggestions (not in this PR)

- Watch pi upstream for a shrinkwrap refresh to clear alerts #19/#11–13 via a reviewed pin bump.
- The live `20b` chain case could tolerate an unconfirmed head tx (assert `created` only on confirmed txs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency patches plus a unit-test timing fix; no production runtime or application logic changes.
> 
> **Overview**
> **Dependency updates (vscode lockfile only):** bumps `postcss` to 8.5.25 and `brace-expansion` to 5.0.9 within existing semver ranges to address Dependabot/npm audit findings (source map path handling and minimatch DoS).
> 
> **Test stability:** the `index add --all` backpressure abort test no longer fires `AbortController` after a fixed 100ms. It waits until wave 0 has written at least one index member (or the run settles), so abort happens during the long between-wave `sleep` where rejection uses `signal.reason`, avoiding flaky `assert.rejects` and wrong member counts under full-suite load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836b3fbd82f3fe4a33e7c5b59604eac0596558ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->