### PR TITLE
release: v0.0.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Video-understanding OSINT for coding agents: watch/listen/see media, scan/capture/monitor sources, ask/brief over a case.",
-    "version": "0.0.14"
+    "version": "0.0.15"
   },
   "plugins": [
     {
       "name": "overcast",
       "source": "./",
       "description": "Give any agent senses (video/audio/image) and OSINT reach (search/capture/monitor), organized around an investigation case. Drives the overcast CLI (pi + tinycloud/Cloudglue).",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "author": {
         "name": "kdr"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "overcast — video-OSINT senses",
   "description": "Give any agent senses (video/audio/image understanding) and OSINT reach (search/capture/monitor), organized around an investigation case. Built on pi with the tinycloud/Cloudglue perception backend.",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "author": {
     "name": "kdr"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kdrrr/overcast",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdrrr/overcast",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "overcast — senses (video/audio/image) + OSINT reach for any agent, built on pi",
   "license": "Apache-2.0",
   "author": "kdr",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 // Version surface for overcast. The pinned pi version is an invariant
 // (CLAUDE.md): @earendil-works/pi-* are pinned at exactly 0.82.1.
 
-export const OVERCAST_VERSION = "0.0.14";
+export const OVERCAST_VERSION = "0.0.15";
 
 /** The exact pi version overcast is built against (pinned, not floated). */
 export const PI_VERSION = "0.82.1";

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "overcast",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "overcast",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "overcast",
   "displayName": "Overcast",
   "description": "The situation room in your editor — senses on your media (watch, listen, see, faces, EXIF via right-click), OSINT on your sources, and a wall to monitor the situation: maps, graphs, briefs, live feeds.",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publisher": "kdrrr",
   "private": true,
   "preview": true,


### PR DESCRIPTION
Patch version bump so the Dependabot lockfile fixes (#147/#150/#151/#152) ship to npm.

`npm version patch --no-git-tag-version` per RELEASING.md — `sync-version.mjs` propagated 0.0.15 to `src/version.ts`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `vscode/package.json`+lock (7 files, verified with `sync-version.mjs --check`).

After merge, cut the tag on main to trigger the npm publish + binary release train:

```bash
git checkout main && git pull && git tag v0.0.15 && git push origin v0.0.15
```

## Verification

| suite | result |
| --- | --- |
| `npm test` | **1319/1319 pass**, exit 0 |
| `npm run test:e2e` (offline) | **367/367 passed, 0 failed**, exit 0 |
| `node scripts/sync-version.mjs --check` | all surfaces match 0.0.15 |
| `node dist/bin/overcast.js --version --json` | `{"overcast":"0.0.15","pi":"0.82.1","node":"24.17.0"}` |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata-only bump with no runtime or security logic changes.
> 
> **Overview**
> **Patch release** that bumps the published version from **0.0.14** to **0.0.15** so recent lockfile/dependency fixes can ship on npm and the release train.
> 
> The change is limited to synchronized version strings: root `package.json` / `package-lock.json`, `OVERCAST_VERSION` in `src/version.ts`, Claude plugin metadata (`plugin.json`, `marketplace.json`), and the VS Code extension `package.json` / lockfile. No application logic or behavior changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25017732255a78317627c27ebed9b767a3793aa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->